### PR TITLE
Add DDF validator for json coming back for service plan schemas

### DIFF
--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -5,6 +5,7 @@ class ServicePlan < ApplicationRecord
   belongs_to :portfolio_item
   validates :base, :presence => true
   validate :modified_survey, :on => :update, :if => proc { modified.present? }
+  validate :data_driven_form, :on => :update, :if => proc { modified.present? }
 
   private
 
@@ -12,5 +13,9 @@ class ServicePlan < ApplicationRecord
     if Catalog::SurveyCompare.changed?(self)
       raise Catalog::InvalidSurvey, "Base survey does not match Topology"
     end
+  end
+
+  def data_driven_form
+    Catalog::DataDrivenFormValidator.valid?(modified)
   end
 end

--- a/lib/catalog/data_driven_form_validator.rb
+++ b/lib/catalog/data_driven_form_validator.rb
@@ -1,0 +1,86 @@
+module Catalog
+  class DataDrivenFormValidator
+    COMPONENTS = %i[text-field
+                    textarea-field
+                    field-array
+                    select-field
+                    checkbox
+                    sub-form
+                    radio
+                    tabs
+                    tab-item
+                    date-picker
+                    time-picker
+                    wizard
+                    switch-field
+                    plain-text].freeze
+
+    VALIDATORS = %i[required-validator
+                    min-length-validator
+                    max-length-validator
+                    exact-length-validator
+                    min-items-validator
+                    min-number-value
+                    max-number-value
+                    pattern-validator
+                    url-validator].freeze
+
+    DATA_TYPES = %i[integer
+                    float
+                    number
+                    boolean
+                    string].freeze
+
+    def self.valid?(ddf)
+      ddf = ddf.class == Hash ? ddf.with_indifferent_access : JSON.parse(ddf).with_indifferent_access
+      fields?(ddf[:schema][:fields])
+
+      true
+    end
+
+    class << self
+      def fields?(fields)
+        fields.each do |field|
+          component?(field[:component].to_sym)
+          data_type?(field[:dataType].to_sym) if field.key?(:dataType)
+          validators?(field[:validate]) if field.key?(:validate)
+          options?(fields)
+        end
+      end
+
+      def component?(schema_component)
+        raise Catalog::InvalidSurvey unless COMPONENTS.include?(schema_component)
+      end
+
+      def data_type?(schema_data_type)
+        raise Catalog::InvalidSurvey unless DATA_TYPES.include?(schema_data_type)
+      end
+
+      def validators?(schema_validators)
+        schema_validators.map do |validator|
+          next if validator.nil?
+          raise Catalog::InvalidSurvey unless VALIDATORS.include?(validator[:type].to_sym)
+
+          # validator types that require other fields in the validator
+          case validator[:type]
+          when "min-length-validator", "max-length-validator", "exact-length-validator"
+            raise Catalog::InvalidSurvey if validator[:threshold].nil?
+          when "min-number-value", "max-number-value"
+            raise Catalog::InvalidSurvey if validator[:value].nil?
+          end
+        end
+      end
+
+      def options?(schema_fields)
+        schema_fields.map do |field|
+          next unless field[:component] == "select-field"
+
+          # the options must contain label and value keys
+          field[:options].each do |option|
+            raise Catalog::InvalidSurvey unless option.key?(:label) && option.key?(:value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/catalog/data_driven_form_validator_spec.rb
+++ b/spec/lib/catalog/data_driven_form_validator_spec.rb
@@ -1,0 +1,79 @@
+describe Catalog::DataDrivenFormValidator do
+  let(:subject) { described_class.valid?(ddf) }
+  let(:ddf_file) { File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json")) }
+
+  shared_examples_for "fails validation" do
+    it "blows up" do
+      expect { subject }.to raise_exception(Catalog::InvalidSurvey)
+    end
+  end
+
+  describe "#valid?" do
+    context "when given valid DDF JSON" do
+      let(:ddf) { ddf_file }
+      it "validates successfully" do
+        expect(subject).to eq true
+      end
+    end
+
+    context "when giving a invalid validator" do
+      let(:ddf) do
+        JSON.parse(ddf_file).with_indifferent_access.tap do |invalid|
+          invalid[:schema][:fields].first[:validate].first[:type] = "not-a-real-validator"
+        end.to_json
+      end
+
+      it_behaves_like "fails validation"
+    end
+
+    context "when giving a invalid component" do
+      let(:ddf) do
+        JSON.parse(ddf_file).with_indifferent_access.tap do |invalid|
+          invalid[:schema][:fields].first[:component] = "not-a-real-component"
+        end.to_json
+      end
+
+      it_behaves_like "fails validation"
+    end
+
+    context "when giving a invalid datatype" do
+      let(:ddf) do
+        JSON.parse(ddf_file).with_indifferent_access.tap do |invalid|
+          invalid[:schema][:fields].first[:dataType] = "not-a-real-data-type"
+        end.to_json
+      end
+
+      it_behaves_like "fails validation"
+    end
+
+    context "when giving a bad option" do
+      let(:ddf) do
+        JSON.parse(ddf_file).with_indifferent_access.tap do |invalid|
+          invalid[:schema][:fields].second[:options].first.delete(:label)
+        end.to_json
+      end
+
+      it_behaves_like "fails validation"
+    end
+
+    context "when giving a bad length validator" do
+      let(:ddf) do
+        JSON.parse(ddf_file).with_indifferent_access.tap do |invalid|
+          invalid[:schema][:fields].first[:validate].second.delete(:threshold)
+        end.to_json
+      end
+
+      it_behaves_like "fails validation"
+    end
+
+    context "when giving a bad number validator" do
+      let(:ddf) do
+        JSON.parse(ddf_file).with_indifferent_access.tap do |invalid|
+          invalid[:schema][:fields].third[:validate].first.delete(:value)
+        end.to_json
+      end
+
+      it_behaves_like "fails validation"
+    end
+  end
+end

--- a/spec/models/service_plan_spec.rb
+++ b/spec/models/service_plan_spec.rb
@@ -2,6 +2,7 @@ describe ServicePlan do
   let(:service_plan) { create(:service_plan) }
   let!(:portfolio_item) { service_plan.portfolio_item }
   let!(:service_offering_ref) { portfolio_item.service_offering_ref }
+  let(:valid_ddf) { File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json")) }
 
   around do |example|
     with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost", :BYPASS_RBAC => 'true') do
@@ -14,7 +15,7 @@ describe ServicePlan do
       :name               => "The Plan",
       :id                 => "1",
       :description        => "A Service Plan",
-      :create_json_schema => {"schema" => {}}
+      :create_json_schema => JSON.parse(valid_ddf)
     )
   end
 
@@ -38,15 +39,11 @@ describe ServicePlan do
     end
 
     context "valid" do
-      let(:base) do
-        {
-          "schema" => {}
-        }
-      end
+      let(:base) { JSON.parse(valid_ddf) }
       let(:service_plan) { create(:service_plan, :base => base) }
 
       before do
-        service_plan.update!(:modified => topo_service_plan.to_json)
+        service_plan.update!(:modified => JSON.parse(valid_ddf))
       end
 
       it "does not set an error" do
@@ -55,7 +52,7 @@ describe ServicePlan do
       end
 
       it "shows the modified column is unchanged" do
-        expect(JSON.parse(service_plan.modified)["name"]).to eq "The Plan"
+        expect(service_plan.modified["schema"]).to eq JSON.parse(valid_ddf)["schema"]
       end
     end
   end

--- a/spec/requests/service_plans_spec.rb
+++ b/spec/requests/service_plans_spec.rb
@@ -1,8 +1,10 @@
 describe "ServicePlansRequests", :type => :request do
-  let(:service_plan) { create(:service_plan) }
+  let(:service_plan) { create(:service_plan, :base => JSON.parse(modified_schema)) }
   let(:portfolio_item) { service_plan.portfolio_item }
   let(:service_offering_ref) { portfolio_item.service_offering_ref }
   let!(:portfolio_item_without_service_plan) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
+
+  let(:modified_schema) { File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json")) }
 
   around do |example|
     with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost", :BYPASS_RBAC => 'true') do
@@ -15,7 +17,7 @@ describe "ServicePlansRequests", :type => :request do
       :name               => "The Plan",
       :id                 => "1",
       :description        => "A Service Plan",
-      :create_json_schema => {"schema" => {}}
+      :create_json_schema => JSON.parse(modified_schema)
     )
   end
   let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => [topo_service_plan]) }
@@ -124,6 +126,42 @@ describe "ServicePlansRequests", :type => :request do
         get "#{api}/service_plans/#{service_plan.id}/modified", :headers => default_headers
 
         expect(response).to have_http_status :no_content
+      end
+    end
+  end
+
+  describe "#update_modified" do
+    before do
+      patch "#{api}/service_plans/#{service_plan.id}/modified", :headers => default_headers, :params => params
+    end
+
+    context "when patching the modified schema with a valid schema" do
+      let(:params) { {:modified => JSON.parse(modified_schema)} }
+
+      it "returns a 200" do
+        expect(response).to have_http_status :ok
+      end
+
+      it "returns the newly modified schema from the service_plan" do
+        expect(json).to eq params[:modified]
+      end
+    end
+
+    context "when patching in a bad schema" do
+      let(:params) do
+        {
+          :modified => JSON.parse(modified_schema).tap do |schema|
+                         schema["schema"]["fields"].first["dataType"] = "not-a-real-dataType"
+                       end
+        }
+      end
+
+      it "returns a 400" do
+        expect(response).to have_http_status :bad_request
+      end
+
+      it "fails validation" do
+        expect(first_error_detail).to match(/Catalog::InvalidSurvey/)
       end
     end
   end

--- a/spec/support/ddf/valid_service_plan_ddf.json
+++ b/spec/support/ddf/valid_service_plan_ddf.json
@@ -1,0 +1,103 @@
+{
+  "schema": {
+    "title": "",
+    "fields": [
+      {
+        "name": "username",
+        "label": "What is your name",
+        "validate": [
+          {
+            "type": "required-validator"
+          },
+          {
+            "type": "min-length-validator",
+            "threshold": 0
+          },
+          {
+            "type": "max-length-validator",
+            "threshold": 255
+          }
+        ],
+        "component": "text-field",
+        "helperText": "",
+        "isRequired": true,
+        "initialValue": ""
+      },
+      {
+        "name": "quest",
+        "label": "What is your quest?",
+        "options": [
+          {
+            "label": "Test Approval",
+            "value": "Test Approval"
+          },
+          {
+            "label": "Test Catalog",
+            "value": "Test Catalog"
+          },
+          {
+            "label": "Test Topology",
+            "value": "Test Topology"
+          },
+          {
+            "label": "Seek the Holy Grail",
+            "value": "Seek the Holy Grail"
+          }
+        ],
+        "validate": [
+          {
+            "type": "required-validator"
+          }
+        ],
+        "component": "select-field",
+        "helperText": "",
+        "isRequired": true,
+        "initialValue": ""
+      },
+      {
+        "name": "airspeed",
+        "type": "number",
+        "label": "What is the airspeed velocity of an unladen swallow?",
+        "dataType": "float",
+        "validate": [
+          {
+            "type": "min-number-value",
+            "value": 0
+          },
+          {
+            "type": "max-number-value",
+            "value": 10
+          }
+        ],
+        "component": "text-field",
+        "helperText": "Type: Float",
+        "initialValue": ""
+      },
+      {
+        "name": "int_value",
+        "type": "number",
+        "label": "Integer value",
+        "dataType": "integer",
+        "validate": [
+          {
+            "type": "required-validator"
+          },
+          {
+            "type": "min-number-value",
+            "value": 0
+          },
+          {
+            "type": "max-number-value",
+            "value": 10
+          }
+        ],
+        "component": "text-field",
+        "helperText": "",
+        "isRequired": true,
+        "initialValue": 5
+      }
+    ],
+    "description": ""
+  },
+  "schemaType": "default"
+}


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-838

Validate the DDF schema when it comes back to use - went off of this: 

https://github.com/ManageIQ/topological_inventory-ansible_tower/blob/84b2ae44322bbf28bc8bcf6b39ec3546c05c37ee/lib/topological_inventory/ansible_tower/parser/service_plan.rb 

a lot since it maps what will generally be there from a survey and convert it to DDF. 

#456 must go first. 

\# TODO: 
- [x] request specs