### PR TITLE
[WIP] When using `/portfolios/:id/copy` copy the associated RBAC shares

### DIFF
--- a/app/services/catalog/copy_portfolio.rb
+++ b/app/services/catalog/copy_portfolio.rb
@@ -21,12 +21,31 @@ module Catalog
         new_portfolio.save!
 
         copy_portfolio_items(new_portfolio.id)
+        copy_shares(new_portfolio.id)
       end
     end
 
     def copy_portfolio_items(portfolio_id)
       @portfolio.portfolio_items.each do |item|
         Catalog::CopyPortfolioItem.new(:portfolio_item_id => item.id, :portfolio_id => portfolio_id).process
+      end
+    end
+
+    def copy_shares(portfolio_id)
+      shares = ManageIQ::API::Common::RBAC::QuerySharedResource.new(
+        :app_name      => ENV['APP_NAME'],
+        :resource_name => 'portfolios',
+        :resource_id   => @portfolio.id.to_s
+      ).process.share_info
+
+      shares.each do |share|
+        ManageIQ::API::Common::RBAC::ShareResource.new(
+          :app_name      => ENV['APP_NAME'],
+          :resource_name => 'portfolios',
+          :resource_ids  => [portfolio_id.to_s],
+          :permissions   => share[:permissions],
+          :group_uuids   => [share[:group_uuid]]
+        ).process
       end
     end
   end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-565

When copying or duplicating a portfolio we need to copy the RBAC shares associated with it as well. 

\# TODO:
- [ ] RBAC specs