### PR TITLE
Add Topology and CurrentForwardable spec helpers

### DIFF
--- a/spec/lib/approval/service_spec.rb
+++ b/spec/lib/approval/service_spec.rb
@@ -1,9 +1,8 @@
-describe Approval::Service do
+describe Approval::Service, :type => :current_forwardable do
   let(:topo_ex) { ApprovalApiClient::ApiError.new("kaboom") }
 
   it "raises ApprovalError" do
     with_modified_env :APPROVAL_URL => 'http://www.example.com' do
-      allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
       expect do
         described_class.call(ApprovalApiClient::RequestApi) do |_api|
           raise topo_ex

--- a/spec/lib/sources_spec.rb
+++ b/spec/lib/sources_spec.rb
@@ -1,9 +1,8 @@
-describe Sources do
+describe Sources, :type => :current_forwardable do
   let(:sources_ex) { SourcesApiClient::ApiError.new("kaboom") }
 
   it "raises SourcesError" do
     with_modified_env :SOURCES_URL => 'http://localhost' do
-      allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
       expect do
         described_class.call do |_klass|
           raise sources_ex

--- a/spec/lib/topological_inventory_spec.rb
+++ b/spec/lib/topological_inventory_spec.rb
@@ -1,14 +1,11 @@
-describe TopologicalInventory do
+describe TopologicalInventory, :type => [:topology, :current_forwardable] do
   let(:topo_ex) { TopologicalInventoryApiClient::ApiError.new("kaboom") }
 
   it "raises TopologyError" do
-    with_modified_env :TOPOLOGICAL_INVENTORY_URL => 'http://www.example.com' do
-      allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
-      expect do
-        described_class.call do |_api|
-          raise topo_ex
-        end
-      end.to raise_exception(Catalog::TopologyError)
-    end
+    expect do
+      described_class.call do |_api|
+        raise topo_ex
+      end
+    end.to raise_exception(Catalog::TopologyError)
   end
 end

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -1,7 +1,7 @@
-describe "v1.0 - PortfolioItemRequests", :type => [:request, :v1] do
+describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
   around do |example|
     bypass_rbac do
-      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology", :APPROVAL_URL => "http://localhost") { example.call }
+      with_modified_env(:APPROVAL_URL => "http://localhost") { example.call }
     end
   end
 

--- a/spec/requests/api/v1.0/service_plans_spec.rb
+++ b/spec/requests/api/v1.0/service_plans_spec.rb
@@ -1,4 +1,4 @@
-describe "v1.0 - ServicePlansRequests", :type => [:request, :v1] do
+describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
   let(:service_plan) { create(:service_plan, :base => JSON.parse(modified_schema)) }
   let(:portfolio_item) { service_plan.portfolio_item }
   let(:service_offering_ref) { portfolio_item.service_offering_ref }
@@ -7,7 +7,7 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1] do
   let(:modified_schema) { File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json")) }
 
   around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology", :BYPASS_RBAC => 'true') do
+    with_modified_env(:BYPASS_RBAC => 'true') do
       Insights::API::Common::Request.with_request(default_request) { example.call }
     end
   end

--- a/spec/services/catalog/cancel_order_spec.rb
+++ b/spec/services/catalog/cancel_order_spec.rb
@@ -1,4 +1,4 @@
-describe Catalog::CancelOrder do
+describe Catalog::CancelOrder, :type => [:service, :current_forwardable] do
   let(:order) { create(:order) }
   let(:portfolio_item) { create(:portfolio_item) }
   let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
@@ -14,7 +14,6 @@ describe Catalog::CancelOrder do
 
     before do
       order.update(:state => state)
-      allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
     end
 
     describe "when the state of the order is Completed" do

--- a/spec/services/catalog/import_service_plans_spec.rb
+++ b/spec/services/catalog/import_service_plans_spec.rb
@@ -1,14 +1,7 @@
-describe Catalog::ImportServicePlans, :type => :service do
+describe Catalog::ImportServicePlans, :type => [:service, :topology, :current_forwardable] do
   let(:service_offering_ref) { "1" }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
   let(:subject) { described_class.new(portfolio_item.id) }
-
-  around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
-      example.call
-    end
-  end
-
   let(:service_plan) do
     TopologicalInventoryApiClient::ServicePlan.new(
       :name               => "The Plan",
@@ -23,8 +16,6 @@ describe Catalog::ImportServicePlans, :type => :service do
   end
 
   before do
-    allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
-
     stub_request(:get, topological_url("service_offerings/1"))
       .to_return(:status => 200, :body => service_offering_response.to_json, :headers => default_headers)
     stub_request(:get, topological_url("service_offerings/1/service_plans"))

--- a/spec/services/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/services/catalog/order_item_sanitized_parameters_spec.rb
@@ -1,16 +1,6 @@
-describe Catalog::OrderItemSanitizedParameters, :type => :service do
+describe Catalog::OrderItemSanitizedParameters, :type => [:service, :topology, :current_forwardable] do
   let(:subject) { described_class.new(params) }
   let(:params) { ActionController::Parameters.new('order_item_id' => order_item.id) }
-
-  before do
-    allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
-  end
-
-  around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
-      example.call
-    end
-  end
 
   describe "#process" do
     let(:order_item) { create(:order_item, :service_plan_ref => service_plan_ref) }
@@ -83,7 +73,7 @@ describe Catalog::OrderItemSanitizedParameters, :type => :service do
 
       it "does not call the api" do
         subject.process
-        expect(a_request(:any, /localhost/)).not_to have_been_made
+        expect(a_request(:any, /topology/)).not_to have_been_made
       end
 
       it "returns an empty hash" do

--- a/spec/services/catalog/provider_control_parameters_spec.rb
+++ b/spec/services/catalog/provider_control_parameters_spec.rb
@@ -1,4 +1,4 @@
-describe Catalog::ProviderControlParameters, :type => :service do
+describe Catalog::ProviderControlParameters, :type => [:service, :topology, :current_forwardable] do
   let(:source_id) { "1" }
   let(:params) { portfolio_item.id }
   let(:provider_control_parameters) { described_class.new(params) }
@@ -12,16 +12,6 @@ describe Catalog::ProviderControlParameters, :type => :service do
   let(:project2) do
     TopologicalInventoryApiClient::ContainerProject.new('name'      => project2_name,
                                                         'source_id' => "2")
-  end
-
-  before do
-    allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
-  end
-
-  around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
-      example.call
-    end
   end
 
   describe "#process" do

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -1,18 +1,8 @@
-describe Catalog::ServicePlans, :type => :service do
+describe Catalog::ServicePlans, :type => [:service, :topology, :current_forwardable] do
   let(:service_offering_ref) { "998" }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
   let(:params) { portfolio_item.id }
   let(:service_plans) { described_class.new(params) }
-
-  before do
-    allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
-  end
-
-  around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
-      example.call
-    end
-  end
 
   describe "#process" do
     let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => data) }

--- a/spec/services/catalog/submit_order_spec.rb
+++ b/spec/services/catalog/submit_order_spec.rb
@@ -1,4 +1,4 @@
-describe Catalog::SubmitOrder do
+describe Catalog::SubmitOrder, :type => [:service, :topology, :current_forwardable] do
   let(:service_offering_ref) { "998" }
   let(:service_plan_ref) { "991" }
   let(:order) { create(:order) }
@@ -34,18 +34,10 @@ describe Catalog::SubmitOrder do
   let(:topo_service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => [topo_service_plan]) }
   let(:service_plan_response) { topo_service_plan_response }
 
-  around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology", :SOURCES_URL => "http://localhost") do
-      example.call
-    end
-  end
-
   before do
     allow(Catalog::ValidateSource).to receive(:new).with(portfolio_item.service_offering_source_ref).and_return(validater)
     allow(validater).to receive(:process).and_return(validater)
     allow(validater).to receive(:valid).and_return(validity)
-
-    allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
 
     stub_request(:get, topological_url("service_offerings/#{service_offering_ref}/service_plans"))
       .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceOffering::AddToPortfolioItem, :type => :service do
+describe ServiceOffering::AddToPortfolioItem, :type => [:service, :topology] do
   include ServiceOfferingHelper
   let(:service_offering_ref) { "1" }
   let(:subject) { described_class.new(params) }
@@ -12,7 +12,7 @@ describe ServiceOffering::AddToPortfolioItem, :type => :service do
 
   around do |example|
     Insights::API::Common::Request.with_request(default_request) do
-      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology", :SOURCES_URL => "http://localhost") do
+      with_modified_env(:SOURCES_URL => "http://localhost") do
         example.call
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,8 @@ RSpec.configure do |config|
   # ------------------------ #
 
   config.include ServiceSpecHelper
+  config.include TopologySpecHelper, :type => :topology
+  config.include CurrentForwardableSpecHelper, :type => :current_forwardable
 
   config.use_transactional_fixtures = true
 

--- a/spec/support/current_forwardable_spec_helper.rb
+++ b/spec/support/current_forwardable_spec_helper.rb
@@ -1,7 +1,7 @@
 module CurrentForwardableSpecHelper
   RSpec.configure do |config|
     config.before(:example, :type => :current_forwardable) do
-      allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
+      allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
     end
   end
 end

--- a/spec/support/current_forwardable_spec_helper.rb
+++ b/spec/support/current_forwardable_spec_helper.rb
@@ -1,0 +1,7 @@
+module CurrentForwardableSpecHelper
+  RSpec.configure do |config|
+    config.before(:example, :type => :current_forwardable) do
+      allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
+    end
+  end
+end

--- a/spec/support/topology_spec_helper.rb
+++ b/spec/support/topology_spec_helper.rb
@@ -1,0 +1,9 @@
+module TopologySpecHelper
+  RSpec.configure do |config|
+    config.around(:example, :type => :topology) do |example|
+      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
+        example.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
I got annoyed having to continually write out the `with_modified_env` and the whole stubbing of the `current_forwardable` headers, so I figured there would be a cleaner way to do it with rspec types.

Ideally we probably move the approval and sources `with_modified_env`s into their own spec helpers, and change the `localhost`s there to `approval` and `sources` respectively so that when you are stubbing/expecting your requests, it ensures that it's going to the "correct" endpoint.

@syncrou @lindgrenj6 Please Review.