### PR TITLE
Fix service_plan return to return the proper `create_json_schema` payload

### DIFF
--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -9,7 +9,7 @@ module Api
         if portfolio_item.service_plans.empty?
           render :json => Catalog::ServicePlans.new(portfolio_item.id).process.items
         else
-          render :json => portfolio_item.service_plans
+          render :json => Catalog::ServicePlanJson.new(:portfolio_item_id => portfolio_item.id, :collection => true).process.json
         end
       end
 
@@ -19,20 +19,20 @@ module Api
       end
 
       def show
-        plan = ServicePlan.find(params.require(:id))
-        render :json => plan
+        svc = Catalog::ServicePlanJson.new(:service_plan_id => params.require(:id))
+        render :json => svc.process.json
       end
 
       def base
-        plan = ServicePlan.find(params.require(:service_plan_id))
-        render :json => plan.base
+        svc = Catalog::ServicePlanJson.new(:service_plan_id => params.require(:service_plan_id), :schema => "base")
+        render :json => svc.process.json
       end
 
       def modified
-        plan = ServicePlan.find(params.require(:service_plan_id))
+        plan = Catalog::ServicePlanJson.new(:service_plan_id => params.require(:service_plan_id)).process.json
 
-        if plan.modified.present?
-          render :json => plan.modified
+        if plan["create_json_schema"]
+          render :json => plan
         else
           head :no_content
         end

--- a/app/services/catalog/service_plan_json.rb
+++ b/app/services/catalog/service_plan_json.rb
@@ -1,0 +1,43 @@
+module Catalog
+  class ServicePlanJson
+    include JsonSchemaReader
+
+    def initialize(opts)
+      if opts.key?(:service_plan_id)
+        @service_plans = ServicePlan.where(:id => opts[:service_plan_id])
+      elsif opts.key?(:portfolio_item_id)
+        @service_plans = ServicePlan.where(:portfolio_item_id => opts[:portfolio_item_id])
+      end
+
+      @opts = opts
+      @json = []
+    end
+
+    def process
+      relevant_service_plans.each do |plan|
+        @reference = plan.portfolio_item.service_offering_ref
+        @portfolio_item_id = plan.portfolio_item.id
+        @service_plan = OpenStruct.new(
+          :id                 => plan.id,
+          :create_json_schema => plan.send(@opts[:schema] || "modified"),
+          :name               => plan.name,
+          :description        => plan.description
+        )
+
+        @json << read_json_schema("service_plan.erb")
+      end
+
+      self
+    end
+
+    def json
+      @opts[:collection] ? @json : @json.first
+    end
+
+    private
+
+    def relevant_service_plans
+      @opts[:collection] ? @service_plans : [@service_plans.first]
+    end
+  end
+end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2552,6 +2552,15 @@
         ],
         "summary": "Patch Service Plan Modified Schema",
         "operationId": "patchServicePlanModified",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchModifiedServicePlan"
+              }
+            }
+          }
+        },
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
@@ -2839,6 +2848,19 @@
             "title": "Portfolio Item ID",
             "description": "The Portfolio Item this Icon belongs to",
             "example": "1"
+          }
+        }
+      },
+      "PatchModifiedServicePlan": {
+        "type": "object",
+        "properties": {
+          "modified": {
+            "type": "object",
+            "title": "Modified Schema",
+            "description": "the new modified schema for the service plan",
+            "example": {
+              "$ref": "#/components/schemas/DataDrivenFormSchema"
+            }
           }
         }
       },
@@ -3315,16 +3337,11 @@
             "description": "The service plan description.",
             "readOnly": true
           },
-          "base": {
+          "create_json_schema": {
             "type": "object",
-            "title": "base",
-            "description": "The base schema imported from Topology",
+            "title": "JSON Schema",
+            "description": "JSON schema for the object.",
             "readOnly": true
-          },
-          "modified": {
-            "type": "object",
-            "title": "modified",
-            "description": "The modified schema for Catalog"
           },
           "portfolio_item_id": {
             "type": "string",

--- a/schemas/json/no_service_plan.erb
+++ b/schemas/json/no_service_plan.erb
@@ -10,5 +10,6 @@
         "label": "This product requires no user input and is fully configured by the system.\nClick submit to order this item."
       }]
     }
-  }.to_json %>
+  }.to_json %>,
+  "portfolio_item_id": "<%= @portfolio_item_id %>"
 }

--- a/schemas/json/service_plan.erb
+++ b/schemas/json/service_plan.erb
@@ -3,5 +3,6 @@
   "id": "<%= @service_plan.id %>",
   "create_json_schema": <%= @service_plan.create_json_schema.to_json %>,
   "name": "<%= @service_plan.name %>",
-  "description": "<%= @service_plan.description %>"
+  "description": "<%= @service_plan.description %>",
+  "portfolio_item_id": "<%= @portfolio_item_id %>"
 }

--- a/spec/requests/service_plans_spec.rb
+++ b/spec/requests/service_plans_spec.rb
@@ -67,7 +67,7 @@ describe "ServicePlansRequests", :type => :request do
 
     it "returns the specified service_plan" do
       expect(json["id"]).to eq service_plan.id.to_s
-      expect(json.keys).to match_array %w[base modified portfolio_item_id id]
+      expect(json.keys).to match_array %w[service_offering_id create_json_schema portfolio_item_id id description name]
     end
   end
 
@@ -95,7 +95,7 @@ describe "ServicePlansRequests", :type => :request do
     end
 
     it "returns the base schema from the service_plan" do
-      expect(json["schema"]).to eq service_plan.base["schema"]
+      expect(json["create_json_schema"]["schema"]).to eq service_plan.base["schema"]
     end
   end
 
@@ -110,8 +110,8 @@ describe "ServicePlansRequests", :type => :request do
       end
 
       it "returns the modified schema from the service_plan" do
-        expect(json["schema"]).to eq service_plan.modified["schema"]
-        expect(json["schema"]).not_to eq service_plan.base["schema"]
+        expect(json["create_json_schema"]["schema"]).to eq service_plan.modified["schema"]
+        expect(json["create_json_schema"]["schema"]).not_to eq service_plan.base["schema"]
       end
     end
 

--- a/spec/services/catalog/service_plan_json_spec.rb
+++ b/spec/services/catalog/service_plan_json_spec.rb
@@ -1,0 +1,39 @@
+describe Catalog::ServicePlanJson, :type => :service do
+  let(:service_plan) { create(:service_plan) }
+  let(:subject) { described_class.new(params).process.json }
+  let(:portfolio_item) { service_plan.portfolio_item }
+
+  describe "#process" do
+    context "when rending a service plan with no options" do
+      let(:params) { {:service_plan_id => service_plan.id} }
+
+      it "renders the specified service_plan schema" do
+        expect(subject["create_json_schema"]).to eq service_plan.modified
+      end
+    end
+
+    context "when rendering a service plan from a portfolio item" do
+      let(:params) { {:portfolio_item_id => portfolio_item.id} }
+
+      it "renders the specified service_plan schema" do
+        expect(subject["create_json_schema"]).to eq service_plan.modified
+      end
+    end
+
+    context "when specifying the collection flag" do
+      let(:params) { {:service_plan_id => service_plan.id, :collection => true} }
+
+      it "returns a collection" do
+        expect(subject.class).to eq Array
+      end
+    end
+
+    context "when specifying the schema type" do
+      let(:params) { {:service_plan_id => service_plan.id, :schema => "base"} }
+
+      it "returns the specified schema" do
+        expect(subject["create_json_schema"]).to eq service_plan.base
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-942

~Forgot to change the erb schemas to match the OpenAPI spec changes made in #452.~

There was a miscommunication on my part when doing the development - I thought we were changing the schema. I was supposed to keep compatibility with the schema while adding support to change it. This PR adds that functionality. 