### PR TITLE
Add logging and progress message when topology tasks do not conform

### DIFF
--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -13,6 +13,12 @@ module Catalog
         Catalog::UpdateOrderItem.new(@topic, @task).process
       elsif @task.context.has_key_path?(:applied_inventories)
         Catalog::CreateApprovalRequest.new(@task).process
+      else
+        item = OrderItem.find_by!(:topology_task_ref => @task.id)
+        item.update_message(:error, "Topology task error")
+        Rails.logger.error(
+          "Topology error during task. State: #{@task.state}. Status: #{@task.status}. Context: #{@task.context}"
+        )
       end
 
       self


### PR DESCRIPTION
Topology currently is blowing up computing `AppliedInventories` and we have no real indication that anything went amiss.

Likewise, if any other tasks come back with errors, we haven't had any logging. This will add that as well as update the item with a progress message so we know that it got stuck here.

@miq-bot add_reviewer @syncrou 