### PR TITLE
Remove Image URL from Portfolio since we host our own icons

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -10,7 +10,6 @@ class Portfolio < ApplicationRecord
   belongs_to :icon, :optional => true
 
   validates :name, :presence => true, :uniqueness => { :scope => %i(tenant_id discarded_at) }
-  validates :image_url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :allow_blank => true
   validates :enabled_before_type_cast, :format => { :with => /\A(true|false)\z/i }, :allow_blank => true
 
   has_many :portfolio_items, :dependent => :destroy

--- a/db/migrate/20191118220525_remove_image_url_from_portfolio.rb
+++ b/db/migrate/20191118220525_remove_image_url_from_portfolio.rb
@@ -1,0 +1,5 @@
+class RemoveImageUrlFromPortfolio < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :portfolios, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_04_192052) do
+ActiveRecord::Schema.define(version: 2019_11_18_220525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,7 +137,6 @@ ActiveRecord::Schema.define(version: 2019_11_04_192052) do
     t.string "name"
     t.string "description"
     t.boolean "enabled"
-    t.string "image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2807,12 +2807,6 @@
             "default": false,
             "example": false
           },
-          "image_url": {
-            "type": "string",
-            "title": "Image URL",
-            "format": "url",
-            "example": "The public facing image url for a portfolio."
-          },
           "owner": {
             "type": "string",
             "title": "Owner",

--- a/spec/factories/portfolios.rb
+++ b/spec/factories/portfolios.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :portfolio, :traits => [:has_owner, :has_tenant] do
     sequence(:name)         { |n| "Portfolio_name_#{n}" }
     sequence(:description)  { |n| "Portfolio_description_#{n}" }
-    sequence(:image_url)    { |n| "https://portfolio#{n}.com/image/#{n}" }
     enabled                 { "true" }
   end
 end

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -7,11 +7,6 @@ describe Portfolio do
   let(:portfolio_item_id) { portfolio_item.id }
 
   context "when setting portfolio fields" do
-    it "fails validation with a bad uri" do
-      portfolio.image_url = "notreallyaurl"
-      expect(portfolio).to_not be_valid
-    end
-
     it "fails validation with a non %w(true false) value" do
       portfolio.enabled = "tralse"
       expect(portfolio).to_not be_valid


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-952

We don't need the `image_url` field on Portfolio anymore since we host our own Icons. 