### PR TITLE
Fix Service Plan Base64 Sanity Check with Topology

### DIFF
--- a/lib/catalog/survey_compare.rb
+++ b/lib/catalog/survey_compare.rb
@@ -4,21 +4,19 @@ module Catalog
     class << self
       def changed?(plan)
         potential = new(plan)
-        encoded_base = Base64.strict_encode64(potential.base.to_json)
-        encoded_topo = Base64.strict_encode64(potential.topo_base.to_json)
-        encoded_topo != encoded_base
+        potential.topo_base != potential.base
       end
     end
 
     def initialize(plan)
-      @base = plan.base
+      @base = plan.base.deep_stringify_keys
       @reference = plan.portfolio_item.service_offering_ref
     end
 
     def topo_base
       TopologicalInventory.call do |api_instance|
         survey = api_instance.list_service_offering_service_plans(@reference)
-        survey.data.first.create_json_schema
+        survey.data.first.create_json_schema.deep_stringify_keys
       end
     end
   end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -3844,10 +3844,64 @@
                         "value": 10
                       }
                     ],
-                    "component": "text-field",
+                    "component": "textarea-field",
                     "helperText": "",
                     "isRequired": true,
                     "initialValue": 5
+                  },
+                  {
+                    "name": "date picker",
+                    "label": "Date Picker",
+                    "component": "date-picker"
+                  },
+                  {
+                    "name": "checkbox",
+                    "label": "Checkbox",
+                    "component": "checkbox"
+                  },
+                  {
+                    "component": "checkbox",
+                    "name": "checkbox multiple",
+                    "label": "Checkbox Multiple",
+                    "options": [
+                      {
+                        "label": "first",
+                        "value": "1"
+                      },
+                      {
+                        "label": "second",
+                        "value": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "time picker",
+                    "label": "Time Picker",
+                    "component": "time-picker"
+                  },
+                  {
+                    "component": "radio",
+                    "label": "Radio",
+                    "name": "radio",
+                    "options": [
+                      {
+                        "label": "Dogs",
+                        "value": "1"
+                      },
+                      {
+                        "label": "Cats",
+                        "value": "2"
+                      },
+                      {
+                        "label": "Hamsters",
+                        "value": "3"
+                      }
+                    ]
+                  },
+                  {
+                    "component": "switch-field",
+                    "label": "Switch",
+                    "name": "switch"
                   }
                 ],
                 "description": ""

--- a/spec/support/ddf/valid_service_plan_ddf.json
+++ b/spec/support/ddf/valid_service_plan_ddf.json
@@ -91,10 +91,64 @@
             "value": 10
           }
         ],
-        "component": "text-field",
+        "component": "textarea-field",
         "helperText": "",
         "isRequired": true,
         "initialValue": 5
+      },
+      {
+        "name": "date picker",
+        "label": "Date Picker",
+        "component": "date-picker"
+      },
+      {
+        "name": "checkbox",
+        "label": "Checkbox",
+        "component": "checkbox"
+      },
+      {
+        "component": "checkbox",
+        "name": "checkbox multiple",
+        "label": "Checkbox Multiple",
+        "options": [
+          {
+            "label": "first",
+            "value": "1"
+          },
+          {
+            "label": "second",
+            "value": "2"
+          }
+        ]
+      },
+      {
+        "name": "time picker",
+        "label": "Time Picker",
+        "component": "time-picker"
+      },
+      {
+        "component": "radio",
+        "label": "Radio",
+        "name": "radio",
+        "options": [
+          {
+            "label": "Dogs",
+            "value": "1"
+          },
+          {
+            "label": "Cats",
+            "value": "2"
+          },
+          {
+            "label": "Hamsters",
+            "value": "3"
+          }
+        ]
+      },
+      {
+        "component": "switch-field",
+        "label": "Switch",
+        "name": "switch"
       }
     ],
     "description": ""


### PR DESCRIPTION
Found a bug when adding test-data for the DDF validator: when calling `Hash#to_json` on the create_json_schema hash the output was not consistently putting the keys in alphabetical order (specifically when calling from topology), it made us realize we cannot trust the order of the keys. 

This PR changes the check to use `Hash#eql?` instead since it compares the keys/values but NOT the ordering, docs here: https://docs.ruby-lang.org/en/2.5.0/Hash.html#method-i-3D-3D

#471 needs to go first

\# TODO:
- [x] specs validating changing order but NOT contents will still pass. 