### PR TITLE
Resolve tenant collection return

### DIFF
--- a/app/controllers/api/v1/tenants_controller.rb
+++ b/app/controllers/api/v1/tenants_controller.rb
@@ -1,8 +1,10 @@
 module Api
   module V1
     class TenantsController < ApplicationController
+      include Api::V1::Mixins::IndexMixin
+
       def index
-        render :json => Tenant.scoped_tenants
+        collection(Tenant.scoped_tenants)
       end
 
       def show

--- a/spec/requests/tenant_spec.rb
+++ b/spec/requests/tenant_spec.rb
@@ -32,6 +32,7 @@ describe 'Group Seed API' do
 
   describe 'GET /tenants' do
     before do
+      allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(true)
       get "#{api}/tenants", :headers => default_headers
     end
 
@@ -40,8 +41,8 @@ describe 'Group Seed API' do
     end
 
     it 'returns all scoped tenants' do
-      expect(json.first['external_tenant']).to eq tenant.external_tenant
-      expect(json.first['id']).to eq tenant.id.to_s
+      expect(json["data"].first['external_tenant']).to eq tenant.external_tenant
+      expect(json["data"].first['id']).to eq tenant.id.to_s
     end
   end
 


### PR DESCRIPTION
Running a lookup without the open api client `curl /tenants` resulted in a false positive for the response.

Using a tool to do the lookup using the Open API ruby client for catalog: https://github.com/syncrou/catalog-api-client-tests

I was able to see that we weren't wrapping the lookup with the correct `IndexMixin` `collection` method.

JIRA: https://projects.engineering.redhat.com/browse/SSP-947