### PR TITLE
Bypass remote inventory collection for now

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -24,7 +24,7 @@ module Api
       def submit_order
         # order = Catalog::CreateRequestForAppliedInventories.new(params.require(:order_id)).process.order
 
-        order = Catalog::CreateApprovalRequest.new(order_id: params.require(:order_id)).process.order
+        order = Catalog::CreateApprovalRequest.new(:order_id => params.require(:order_id)).process.order
         render :json => order
       end
 

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -22,7 +22,9 @@ module Api
       end
 
       def submit_order
-        order = Catalog::CreateRequestForAppliedInventories.new(params.require(:order_id)).process.order
+        # order = Catalog::CreateRequestForAppliedInventories.new(params.require(:order_id)).process.order
+
+        order = Catalog::CreateApprovalRequest.new(order_id: params.require(:order_id)).process.order
         render :json => order
       end
 

--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -2,9 +2,13 @@ module Catalog
   class CreateApprovalRequest
     attr_reader :order
 
-    def initialize(task)
+    def initialize(task: nil, order_id: nil)
       @task = task
-      @order = OrderItem.find_by!(:topology_task_ref => task.id).order
+      if @task.nil?
+        @order = Order.find(order_id)
+      else
+        @order = OrderItem.find_by!(:topology_task_ref => @task.id).order
+      end
     end
 
     def process

--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -3,12 +3,14 @@ module Catalog
     attr_reader :order
 
     def initialize(task: nil, order_id: nil)
+      raise Catalog::InvalidParameter if task.nil? && order_id.nil?
+
       @task = task
-      if @task.nil?
-        @order = Order.find(order_id)
-      else
-        @order = OrderItem.find_by!(:topology_task_ref => @task.id).order
-      end
+      @order = if @task.nil?
+                 Order.find(order_id)
+               else
+                 OrderItem.find_by!(:topology_task_ref => @task.id).order
+               end
     end
 
     def process

--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -12,7 +12,7 @@ module Catalog
       if @task.context.has_key_path?(:service_instance, :id)
         Catalog::UpdateOrderItem.new(@topic, @task).process
       elsif @task.context.has_key_path?(:applied_inventories)
-        Catalog::CreateApprovalRequest.new(@task).process
+        Catalog::CreateApprovalRequest.new(task: @task).process
       else
         item = OrderItem.find_by!(:topology_task_ref => @task.id)
         item.update_message(:error, "Topology task error")

--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -12,7 +12,7 @@ module Catalog
       if @task.context.has_key_path?(:service_instance, :id)
         Catalog::UpdateOrderItem.new(@topic, @task).process
       elsif @task.context.has_key_path?(:applied_inventories)
-        Catalog::CreateApprovalRequest.new(task: @task).process
+        Catalog::CreateApprovalRequest.new(:task => @task).process
       else
         item = OrderItem.find_by!(:topology_task_ref => @task.id)
         item.update_message(:error, "Topology task error")

--- a/app/services/tags/topology/remote_inventory.rb
+++ b/app/services/tags/topology/remote_inventory.rb
@@ -16,6 +16,11 @@ module Tags
       private
 
       def consolidate_inventory_tags
+        # This is meant to bypass the heavy logic but also assign an empty array
+        # It appears to return "true" but the #process method returns self so I
+        # only needed this for assignment and bypass purposes in one line
+        return @tag_resources = [] if @task.nil?
+
         @tag_resources = all_tag_collections.collect do |tag_collection|
           tags = tag_collection.collect do |tag|
             tag.to_hash.slice(:name, :namespace, :value)

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -10,21 +10,32 @@ describe "OrderRequests", :type => :request do
 
   # TODO: Update this context with new logic. Will be fixed with
   # https://projects.engineering.redhat.com/browse/SSP-237
-  context "submit order" do
-    let(:svc_object) { instance_double("Catalog::CreateRequestForAppliedInventories") }
+  describe "#submit_order" do
+    # let(:svc_object) { instance_double("Catalog::CreateRequestForAppliedInventories") }
+
+    let(:svc_object) { instance_double("Catalog::CreateApprovalRequest") }
     let(:topo_ex) { Catalog::TopologyError.new("kaboom") }
     let(:params) { order.id.to_s }
 
     before do
-      allow(Catalog::CreateRequestForAppliedInventories).to receive(:new).with(params).and_return(svc_object)
+      # allow(Catalog::CreateRequestForAppliedInventories).to receive(:new).with(params).and_return(svc_object)
+
+      allow(Catalog::CreateApprovalRequest).to receive(:new).with(order_id: params).and_return(svc_object)
       allow(svc_object).to receive(:process).and_return(svc_object)
       allow(svc_object).to receive(:order).and_return(order)
+
+      post "#{api}/orders/#{order.id}/submit_order", :headers => default_headers
     end
 
-    it "v1.0 successfully creates requests for applied inventories" do
-      post "#{api}/orders/#{order.id}/submit_order", :headers => default_headers
+    it "returns the order as json" do
+      expect(JSON.parse(response.body)["id"]).to eq(order.id.to_s)
+    end
 
+    it "returns json" do
       expect(response.content_type).to eq("application/json")
+    end
+
+    it "returns a 200" do
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -20,7 +20,7 @@ describe "OrderRequests", :type => :request do
     before do
       # allow(Catalog::CreateRequestForAppliedInventories).to receive(:new).with(params).and_return(svc_object)
 
-      allow(Catalog::CreateApprovalRequest).to receive(:new).with(order_id: params).and_return(svc_object)
+      allow(Catalog::CreateApprovalRequest).to receive(:new).with(:order_id => params).and_return(svc_object)
       allow(svc_object).to receive(:process).and_return(svc_object)
       allow(svc_object).to receive(:order).and_return(order)
 

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -1,5 +1,5 @@
 describe Catalog::CreateApprovalRequest, :type => :service do
-  let(:subject) { described_class.new(task: task, order_id: order_id) }
+  let(:subject) { described_class.new(:task => task, :order_id => order_id) }
   let(:task) { nil }
   let(:order_id) { nil }
 
@@ -53,8 +53,8 @@ describe Catalog::CreateApprovalRequest, :type => :service do
       context "when the approval fails" do
         before do
           stub_request(:post, "http://localhost/api/approval/v1.0/requests")
-          .with(:body => request_body_from)
-          .to_return(:status => 401, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
+            .with(:body => request_body_from)
+            .to_return(:status => 401, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
         end
 
         it "raises an error and does not create an approval request" do
@@ -71,8 +71,8 @@ describe Catalog::CreateApprovalRequest, :type => :service do
       context "when the approval succeeds" do
         before do
           stub_request(:post, "http://localhost/api/approval/v1.0/requests")
-          .with(:body => request_body_from)
-          .to_return(:status => 200, :body => {:workflow_id => 7, :id => 7, :decision => "approved"}.to_json, :headers => {"Content-type" => "application/json"})
+            .with(:body => request_body_from)
+            .to_return(:status => 200, :body => {:workflow_id => 7, :id => 7, :decision => "approved"}.to_json, :headers => {"Content-type" => "application/json"})
         end
 
         it "submits the approval request" do
@@ -94,8 +94,8 @@ describe Catalog::CreateApprovalRequest, :type => :service do
       context "when the approval fails" do
         before do
           stub_request(:post, "http://localhost/api/approval/v1.0/requests")
-          .with(:body => request_body_from)
-          .to_return(:status => 401, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
+            .with(:body => request_body_from)
+            .to_return(:status => 401, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
         end
 
         it "raises an error and does not create an approval request" do
@@ -103,6 +103,12 @@ describe Catalog::CreateApprovalRequest, :type => :service do
           expect { subject.process }.to raise_exception(Catalog::ApprovalError)
           expect(ApprovalRequest.count).to eq(0)
         end
+      end
+    end
+
+    context "when neither a task id or an order id are passed in" do
+      it "raises an error" do
+        expect { subject.process }.to raise_exception(Catalog::InvalidParameter)
       end
     end
   end

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -38,7 +38,7 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
       let(:create_approval_request) { instance_double("Catalog::CreateApprovalRequest") }
 
       before do
-        allow(Catalog::CreateApprovalRequest).to receive(:new).with(task: task).and_return(create_approval_request)
+        allow(Catalog::CreateApprovalRequest).to receive(:new).with(:task => task).and_return(create_approval_request)
       end
 
       it "delegates to creating the approval request" do

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -38,7 +38,7 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
       let(:create_approval_request) { instance_double("Catalog::CreateApprovalRequest") }
 
       before do
-        allow(Catalog::CreateApprovalRequest).to receive(:new).with(task).and_return(create_approval_request)
+        allow(Catalog::CreateApprovalRequest).to receive(:new).with(task: task).and_return(create_approval_request)
       end
 
       it "delegates to creating the approval request" do

--- a/spec/services/tags/topology/remote_inventory_spec.rb
+++ b/spec/services/tags/topology/remote_inventory_spec.rb
@@ -12,49 +12,59 @@ describe Tags::Topology::RemoteInventory, :type => :service do
   end
 
   describe "#process" do
-    let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:applied_inventories => ["1", "2"]}) }
-    let(:tags_collection1) { TopologicalInventoryApiClient::TagsCollection.new(:data => [tag1, tag2]) }
-    let(:tag1) { TopologicalInventoryApiClient::Tag.new(:name => "tag1", :namespace => "tag1namespace", :value => "tag1value", :description => "tag1description") }
-    let(:tag2) { TopologicalInventoryApiClient::Tag.new(:name => "tag2", :namespace => "tag2namespace", :value => "tag2value") }
+    context "when the task does not exist" do
+      let(:task) { nil }
 
-    let(:tags_collection2) { TopologicalInventoryApiClient::TagsCollection.new(:data => [tag3, tag4]) }
-    let(:tag3) { TopologicalInventoryApiClient::Tag.new(:name => "tag3", :namespace => "tag3namespace", :value => "tag3value") }
-    let(:tag4) { TopologicalInventoryApiClient::Tag.new(:name => "tag4", :namespace => "tag4namespace", :value => "tag4value") }
-
-    before do
-      stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_inventories/1/tags").to_return(
-        :status  => 200,
-        :body    => tags_collection1.to_json,
-        :headers => default_headers
-      )
-      stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_inventories/2/tags").to_return(
-        :status  => 200,
-        :body    => tags_collection2.to_json,
-        :headers => default_headers
-      )
+      it "stores the tag resources as an empty array" do
+        expect(subject.process.tag_resources).to eq([])
+      end
     end
 
-    it "stores tag names, namespaces and values in a specific object format" do
-      expect(subject.process.tag_resources).to eq(
-        [
-          {
-            :app_name    => "topology",
-            :object_type => "ServiceInventory",
-            :tags        => [
-              {:name => "tag1", :namespace => "tag1namespace", :value => "tag1value"},
-              {:name => "tag2", :namespace => "tag2namespace", :value => "tag2value"}
-            ]
-          },
-          {
-            :app_name    => "topology",
-            :object_type => "ServiceInventory",
-            :tags        => [
-              {:name => "tag3", :namespace => "tag3namespace", :value => "tag3value"},
-              {:name => "tag4", :namespace => "tag4namespace", :value => "tag4value"}
-            ]
-          }
-        ]
-      )
+    context "when the task exists" do
+      let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:applied_inventories => ["1", "2"]}) }
+      let(:tags_collection1) { TopologicalInventoryApiClient::TagsCollection.new(:data => [tag1, tag2]) }
+      let(:tag1) { TopologicalInventoryApiClient::Tag.new(:name => "tag1", :namespace => "tag1namespace", :value => "tag1value", :description => "tag1description") }
+      let(:tag2) { TopologicalInventoryApiClient::Tag.new(:name => "tag2", :namespace => "tag2namespace", :value => "tag2value") }
+
+      let(:tags_collection2) { TopologicalInventoryApiClient::TagsCollection.new(:data => [tag3, tag4]) }
+      let(:tag3) { TopologicalInventoryApiClient::Tag.new(:name => "tag3", :namespace => "tag3namespace", :value => "tag3value") }
+      let(:tag4) { TopologicalInventoryApiClient::Tag.new(:name => "tag4", :namespace => "tag4namespace", :value => "tag4value") }
+
+      before do
+        stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_inventories/1/tags").to_return(
+          :status  => 200,
+          :body    => tags_collection1.to_json,
+          :headers => default_headers
+        )
+        stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_inventories/2/tags").to_return(
+          :status  => 200,
+          :body    => tags_collection2.to_json,
+          :headers => default_headers
+        )
+      end
+
+      it "stores tag names, namespaces and values in a specific object format" do
+        expect(subject.process.tag_resources).to eq(
+          [
+            {
+              :app_name    => "topology",
+              :object_type => "ServiceInventory",
+              :tags        => [
+                {:name => "tag1", :namespace => "tag1namespace", :value => "tag1value"},
+                {:name => "tag2", :namespace => "tag2namespace", :value => "tag2value"}
+              ]
+            },
+            {
+              :app_name    => "topology",
+              :object_type => "ServiceInventory",
+              :tags        => [
+                {:name => "tag3", :namespace => "tag3namespace", :value => "tag3value"},
+                {:name => "tag4", :namespace => "tag4namespace", :value => "tag4value"}
+              ]
+            }
+          ]
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
For now, I decided to override the constructor for `CreateApprovalRequest` to either take in a `task` or an `order_id` with named arguments so that it's simpler to change later. Remote inventory is still "collected", but it simply always returns an empty array if there isn't a task (which there won't be for now).

@mkanoor @syncrou @lindgrenj6 Please Review