### PR TITLE
Added support for AccessControlEntries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'simplecov'
   gem 'webmock'
+  gem 'shoulda-matchers'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rspec-mocks'
   gem 'rspec-rails'
+  gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'webmock'
-  gem 'shoulda-matchers'
 end
 
 group :development do

--- a/app/controllers/api/v1/mixins/ace_mixin.rb
+++ b/app/controllers/api/v1/mixins/ace_mixin.rb
@@ -3,8 +3,7 @@ module Api
     module Mixins
       module ACEMixin
         def ace_ids(verb, klass)
-          permission = "#{ENV['APP_NAME']}:#{klass.table_name}:#{verb}"
-          params = { :group_uuid => my_group_uuids, :permission => permission, :aceable_type => klass.to_s }
+          params = { :group_uuid => my_group_uuids, :permission => verb, :aceable_type => klass.to_s }
           AccessControlEntry.where(params).collect { |ace| ace.aceable_id.to_s }
         end
 

--- a/app/controllers/api/v1/mixins/ace_mixin.rb
+++ b/app/controllers/api/v1/mixins/ace_mixin.rb
@@ -10,9 +10,7 @@ module Api
 
         def my_group_uuids
           @my_group_uuids ||= Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
-            Insights::API::Common::RBAC::Service.paginate(api, :list_groups, {:scope => 'principal'}).collect do |group| 
-              group.uuid
-            end
+            Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :scope => 'principal').collect(&:uuid)
           end
         end
       end

--- a/app/controllers/api/v1/mixins/ace_mixin.rb
+++ b/app/controllers/api/v1/mixins/ace_mixin.rb
@@ -1,0 +1,21 @@
+module Api
+  module V1
+    module Mixins
+      module ACEMixin
+        def ace_ids(verb, klass)
+          permission = "#{ENV['APP_NAME']}:#{klass.table_name}:#{verb}"
+          params = { :group_uuid => my_group_uuids, :permission => permission, :aceable_type => klass.to_s }
+          AccessControlEntry.where(params).collect { |ace| ace.aceable_id.to_s }
+        end
+
+        def my_group_uuids
+          @my_group_uuids ||= Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+            Insights::API::Common::RBAC::Service.paginate(api, :list_groups, {:scope => 'principal'}).collect do |group| 
+              group.uuid
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1/mixins/index_mixin.rb
@@ -35,7 +35,7 @@ module Api
           if access_obj.owner_scoped?
             relation.by_owner
           else
-            ids = access_obj.id_list
+            ids = ace_ids('read', relation.model)
             ids.any? ? relation.where(:id => ids) : relation
           end
         end

--- a/app/controllers/api/v1/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1/mixins/rbac_mixin.rb
@@ -24,7 +24,6 @@ module Api
         def resource_check(verb, id = params[:id], klass = controller_name.classify.constantize)
           return unless Insights::API::Common::RBAC::Access.enabled?
           return if catalog_administrator?
-
           ids = access_id_list(verb, klass)
           raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" if ids.any? && ids.exclude?(id)
         end
@@ -47,10 +46,10 @@ module Api
         end
 
         def access_id_list(verb, klass)
-          access_obj = Insights::API::Common::RBAC::Access.new(controller_name.classify.constantize.table_name, verb).process
+          table_name = controller_name.classify.constantize.table_name
+          access_obj = Insights::API::Common::RBAC::Access.new(table_name, verb).process
           raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" unless access_obj.accessible?
-
-          access_obj.id_list
+          ace_ids(verb, klass)
         end
       end
     end

--- a/app/controllers/api/v1/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1/mixins/rbac_mixin.rb
@@ -24,7 +24,8 @@ module Api
         def resource_check(verb, id = params[:id], klass = controller_name.classify.constantize)
           return unless Insights::API::Common::RBAC::Access.enabled?
           return if catalog_administrator?
-          ids = access_id_list(verb, klass)
+
+          ids = ace_ids(verb, klass)
           raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" if ids.any? && ids.exclude?(id)
         end
 
@@ -46,10 +47,10 @@ module Api
         end
 
         def access_id_list(verb, klass)
-          table_name = controller_name.classify.constantize.table_name
-          access_obj = Insights::API::Common::RBAC::Access.new(table_name, verb).process
+          access_obj = Insights::API::Common::RBAC::Access.new(controller_name.classify.constantize.table_name, verb).process
           raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" unless access_obj.accessible?
-          ace_ids(verb, klass)
+
+          access_obj.id_list
         end
       end
     end

--- a/app/controllers/api/v1/portfolios_controller.rb
+++ b/app/controllers/api/v1/portfolios_controller.rb
@@ -65,40 +65,32 @@ module Api
 
       def share
         portfolio = Portfolio.find(params.require(:portfolio_id))
-        options = {:app_name      => ENV['APP_NAME'],
-                   :resource_name => 'portfolios',
-                   :resource_ids  => [portfolio.id.to_s],
-                   :permissions   => params[:permissions],
-                   :group_uuids   => params.require(:group_uuids)}
-        Insights::API::Common::RBAC::ShareResource.new(options).process
+        options = {:object      => portfolio,
+                   :permissions => params[:permissions],
+                   :group_uuids => params.require(:group_uuids)}
+        Catalog::ShareResource.new(options).process
         head :no_content
       end
 
       def unshare
         portfolio = Portfolio.find(params.require(:portfolio_id))
-        options = {:app_name      => ENV['APP_NAME'],
-                   :resource_name => 'portfolios',
-                   :resource_ids  => [portfolio.id.to_s],
-                   :permissions   => params[:permissions],
-                   :group_uuids   => params[:group_uuids] || []}
-        Insights::API::Common::RBAC::UnshareResource.new(options).process
+        options = {:object      => portfolio,
+                   :permissions => params[:permissions],
+                   :group_uuids => params.require(:group_uuids)}
+        Catalog::UnshareResource.new(options).process
         head :no_content
       end
 
       def share_info
         portfolio = Portfolio.find(params.require(:portfolio_id))
-        options = {:app_name      => ENV['APP_NAME'],
-                   :resource_name => 'portfolios',
-                   :resource_id   => portfolio.id.to_s}
-        obj = Insights::API::Common::RBAC::QuerySharedResource.new(options).process
-        render :json => obj.share_info
+        options = {:object => portfolio}
+        render :json => Catalog::ShareInfo.new(options).process.result
       end
 
       def copy
         svc = Catalog::CopyPortfolio.new(portfolio_copy_params)
         render :json => svc.process.new_portfolio
       end
-
 
       private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   include Response
+  include Api::V1::Mixins::ACEMixin
   include Api::V1::Mixins::RBACMixin
   include Insights::API::Common::ApplicationControllerMixins::ApiDoc
   include Insights::API::Common::ApplicationControllerMixins::Common

--- a/app/models/access_control_entry.rb
+++ b/app/models/access_control_entry.rb
@@ -1,0 +1,4 @@
+class AccessControlEntry < ApplicationRecord
+  acts_as_tenant(:tenant)
+  belongs_to :aceable, :polymorphic => true
+end

--- a/app/models/concerns/aceable.rb
+++ b/app/models/concerns/aceable.rb
@@ -1,0 +1,7 @@
+module Aceable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :access_control_entries, :as => :aceable
+  end
+end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -2,6 +2,7 @@ class Portfolio < ApplicationRecord
   include OwnerField
   include Discard::Model
   include Catalog::DiscardRestore
+  include Aceable
   destroy_dependencies :portfolio_items
 
   acts_as_tenant(:tenant)

--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -1,0 +1,31 @@
+module Catalog
+  class ShareInfo
+    require 'rbac-api-client'
+    attr_reader :result
+
+    def initialize(options)
+      @object      = options[:object]
+    end
+
+    def process
+      group_permissions = {}
+      @object.access_control_entries.each do |ace|
+        group_permissions[ace.group_uuid] = group_permissions.fetch(ace.group_uuid, []) << ace.permission 
+      end
+      @result = group_permissions.each_with_object([]) do |(k,v), memo|
+        memo << { :group_name => group_names[k], :group_uuid => k, :permissions => v }
+      end
+      self
+    end
+
+    private
+
+    def group_names
+      @group_names ||= Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, {}).each_with_object({}) do |group, memo| 
+          memo[group.uuid] = group.name
+        end
+      end
+    end
+  end
+end

--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -12,8 +12,13 @@ module Catalog
       @object.access_control_entries.each do |ace|
         group_permissions[ace.group_uuid] = group_permissions.fetch(ace.group_uuid, []) << ace.permission
       end
-      @result = group_permissions.each_with_object([]) do |(k, v), memo|
-        memo << { :group_name => group_names[k], :group_uuid => k, :permissions => v }
+
+      @result = group_permissions.each_with_object([]) do |(uuid, permissions), memo|
+        if group_names.key?(uuid)
+          memo << { :group_name => group_names[uuid], :group_uuid => uuid, :permissions => permissions }
+        else
+          Rails.logger.warn("Skipping group UUID: #{uuid} since its missing from RBAC service")
+        end
       end
       self
     end

--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -4,15 +4,15 @@ module Catalog
     attr_reader :result
 
     def initialize(options)
-      @object      = options[:object]
+      @object = options[:object]
     end
 
     def process
       group_permissions = {}
       @object.access_control_entries.each do |ace|
-        group_permissions[ace.group_uuid] = group_permissions.fetch(ace.group_uuid, []) << ace.permission 
+        group_permissions[ace.group_uuid] = group_permissions.fetch(ace.group_uuid, []) << ace.permission
       end
-      @result = group_permissions.each_with_object([]) do |(k,v), memo|
+      @result = group_permissions.each_with_object([]) do |(k, v), memo|
         memo << { :group_name => group_names[k], :group_uuid => k, :permissions => v }
       end
       self
@@ -22,7 +22,7 @@ module Catalog
 
     def group_names
       @group_names ||= Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
-        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, {}).each_with_object({}) do |group, memo| 
+        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, {}).each_with_object({}) do |group, memo|
           memo[group.uuid] = group.name
         end
       end

--- a/app/services/catalog/share_resource.rb
+++ b/app/services/catalog/share_resource.rb
@@ -1,0 +1,24 @@
+module Catalog
+  class ShareResource
+    require 'rbac-api-client'
+    include Insights::API::Common::RBAC::Utilities
+
+    def initialize(options)
+      @group_uuids = SortedSet.new(options.fetch(:group_uuids, []))
+      @permissions = options[:permissions]
+      @object      = options[:object]
+    end
+
+    def process
+      validate_groups
+      @group_uuids.each do |group_uuid|
+        @permissions.each do |permission|
+          AccessControlEntry.find_or_create_by(:group_uuid  => group_uuid,
+                                               :permission  => permission,
+                                               :aceable     => @object)
+        end
+      end
+      self
+    end
+  end
+end

--- a/app/services/catalog/share_resource.rb
+++ b/app/services/catalog/share_resource.rb
@@ -13,9 +13,9 @@ module Catalog
       validate_groups
       @group_uuids.each do |group_uuid|
         @permissions.each do |permission|
-          AccessControlEntry.find_or_create_by(:group_uuid  => group_uuid,
-                                               :permission  => permission,
-                                               :aceable     => @object)
+          AccessControlEntry.find_or_create_by(:group_uuid => group_uuid,
+                                               :permission => permission,
+                                               :aceable    => @object)
         end
       end
       self

--- a/app/services/catalog/unshare_resource.rb
+++ b/app/services/catalog/unshare_resource.rb
@@ -13,9 +13,9 @@ module Catalog
       validate_groups
       @group_uuids.each do |group_uuid|
         @permissions.each do |permission|
-          AccessControlEntry.where(:group_uuid  => group_uuid,
-                                   :permission  => permission,
-                                   :aceable     => @object).destroy_all
+          AccessControlEntry.where(:group_uuid => group_uuid,
+                                   :permission => permission,
+                                   :aceable    => @object).destroy_all
         end
       end
       self

--- a/app/services/catalog/unshare_resource.rb
+++ b/app/services/catalog/unshare_resource.rb
@@ -1,0 +1,24 @@
+module Catalog
+  class UnshareResource
+    require 'rbac-api-client'
+    include Insights::API::Common::RBAC::Utilities
+
+    def initialize(options)
+      @group_uuids = SortedSet.new(options.fetch(:group_uuids, []))
+      @permissions = options[:permissions]
+      @object      = options[:object]
+    end
+
+    def process
+      validate_groups
+      @group_uuids.each do |group_uuid|
+        @permissions.each do |permission|
+          AccessControlEntry.where(:group_uuid  => group_uuid,
+                                   :permission  => permission,
+                                   :aceable     => @object).destroy_all
+        end
+      end
+      self
+    end
+  end
+end

--- a/db/migrate/20191206182459_create_access_control_entry.rb
+++ b/db/migrate/20191206182459_create_access_control_entry.rb
@@ -5,6 +5,7 @@ class CreateAccessControlEntry < ActiveRecord::Migration[5.2]
       t.bigint :tenant_id
       t.string :permission
       t.references :aceable, :name => :access_control_entries, :polymorphic => true, :index => true
+      t.index [:group_uuid, :aceable_type, :permission], :name => "index_on_group_uuid_aceable_type_permission"
 
       t.timestamps
     end

--- a/db/migrate/20191206182459_create_access_control_entry.rb
+++ b/db/migrate/20191206182459_create_access_control_entry.rb
@@ -1,0 +1,12 @@
+class CreateAccessControlEntry < ActiveRecord::Migration[5.2]
+  def change
+    create_table :access_control_entries do |t|
+      t.string :group_uuid
+      t.bigint :tenant_id
+      t.string :permission
+      t.references :aceable, :name => :access_control_entries, :polymorphic => true, :index => true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_18_220525) do
+ActiveRecord::Schema.define(version: 2019_12_06_182459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "access_control_entries", force: :cascade do |t|
+    t.string "group_uuid"
+    t.bigint "tenant_id"
+    t.string "permission"
+    t.string "aceable_type"
+    t.bigint "aceable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["aceable_type", "aceable_id"], name: "index_access_control_entries_on_aceable_type_and_aceable_id"
+  end
 
   create_table "approval_requests", force: :cascade do |t|
     t.string "approval_request_ref"
@@ -45,8 +56,8 @@ ActiveRecord::Schema.define(version: 2019_11_18_220525) do
   create_table "images", force: :cascade do |t|
     t.binary "content"
     t.string "extension"
-    t.bigint "tenant_id"
     t.string "hashcode"
+    t.bigint "tenant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["tenant_id"], name: "index_images_on_tenant_id"
@@ -66,8 +77,8 @@ ActiveRecord::Schema.define(version: 2019_11_18_220525) do
     t.bigint "portfolio_item_id"
     t.jsonb "service_parameters"
     t.jsonb "provider_control_parameters"
-    t.jsonb "context"
     t.string "owner"
+    t.jsonb "context"
     t.string "external_url"
     t.string "insights_request_id"
     t.datetime "discarded_at"
@@ -115,6 +126,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_220525) do
     t.string "distributor"
     t.string "documentation_url"
     t.string "support_url"
+    t.string "service_offering_icon_ref"
     t.datetime "discarded_at"
     t.string "owner"
     t.string "service_offering_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,7 +127,6 @@ ActiveRecord::Schema.define(version: 2019_12_06_182459) do
     t.string "distributor"
     t.string "documentation_url"
     t.string "support_url"
-    t.string "service_offering_icon_ref"
     t.datetime "discarded_at"
     t.string "owner"
     t.string "service_offering_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2019_12_06_182459) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["aceable_type", "aceable_id"], name: "index_access_control_entries_on_aceable_type_and_aceable_id"
+    t.index ["group_uuid", "aceable_type", "permission"], name: "index_on_group_uuid_aceable_type_permission"
   end
 
   create_table "approval_requests", force: :cascade do |t|

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -3572,22 +3572,22 @@
           "permissions": {
             "type": "array",
             "title": "Name",
-            "description": "The permissions to apply for this share. Each permission comprises of 3 parts catalog:portfolios:verb separated by :. The valid verbs are read, update, delete and order",
+            "description": "The permissions to apply for this share. The valid values are read, update, delete and order",
             "items": {
               "type": "string",
               "enum": [
-                "catalog:portfolios:read",
-                "catalog:portfolios:update",
-                "catalog:portfolios:delete",
-                "catalog:portfolios:order"
+                "read",
+                "update",
+                "delete",
+                "order"
               ]
             },
             "minItems": 1,
             "example": [
-              "catalog:portfolios:read",
-              "catalog:portfolios:update",
-              "catalog:portfolios:delete",
-              "catalog:portfolios:order"
+              "read",
+              "update",
+              "delete",
+              "order"
             ]
           },
           "group_uuids": {
@@ -3614,10 +3614,10 @@
             "items": {
               "type": "string",
               "enum": [
-                "catalog:portfolios:read",
-                "catalog:portfolios:update",
-                "catalog:portfolios:delete",
-                "catalog:portfolios:order"
+                "read",
+                "update",
+                "delete",
+                "order"
               ]
             },
             "minItems": 1
@@ -3737,10 +3737,10 @@
             "items": {
               "type": "string",
               "enum": [
-                "catalog:portfolios:read",
-                "catalog:portfolios:update",
-                "catalog:portfolios:delete",
-                "catalog:portfolios:order"
+                "read",
+                "update",
+                "delete",
+                "order"
               ]
             }
           }

--- a/spec/factories/access_control_entry.rb
+++ b/spec/factories/access_control_entry.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :access_control_entry, :traits => [:has_tenant] do
     group_uuid { "123-456" }
     aceable_id { "6756" }
-    permission { "catalog:portfolios:read" }
+    permission { "read" }
     aceable_type { "Portfolio" }
   end
 end

--- a/spec/factories/access_control_entry.rb
+++ b/spec/factories/access_control_entry.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :access_control_entry, :traits => [:has_tenant] do
+    group_uuid { "123-456" }
+    aceable_id { "6756" }
+    permission { "catalog:portfolios:read" }
+    aceable_type { "Portfolio" }
+  end
+end

--- a/spec/models/access_control_entry_spec.rb
+++ b/spec/models/access_control_entry_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe AccessControlEntry, :type => :model do
+  it { is_expected.to have_db_column(:aceable_id).of_type(:integer) }
+  it { is_expected.to have_db_column(:aceable_type).of_type(:string) }
+
+  it { is_expected.to belong_to(:aceable) }
+end

--- a/spec/models/concerns/aceable_shared.rb
+++ b/spec/models/concerns/aceable_shared.rb
@@ -1,0 +1,3 @@
+shared_examples "aceable" do
+  it { is_expected.to have_many(:access_control_entries) }
+end

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -1,3 +1,4 @@
+require "models/concerns/aceable_shared"
 describe Portfolio do
   let(:tenant1)           { create(:tenant, :external_tenant => "1") }
   let(:tenant2)           { create(:tenant, :external_tenant => "2") }
@@ -5,6 +6,8 @@ describe Portfolio do
   let(:portfolio_id)      { portfolio.id }
   let!(:portfolio_item)   { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant1.id) }
   let(:portfolio_item_id) { portfolio_item.id }
+
+  it_behaves_like "aceable"
 
   context "when setting portfolio fields" do
     it "fails validation with a non %w(true false) value" do

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -1,5 +1,5 @@
 describe "OpenAPI stuff" do
-  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags images icons service_plans].freeze
+  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags images icons service_plans access_control_entries].freeze
   let(:rails_routes) do
     Rails.application.routes.routes.each_with_object([]) do |route, array|
       r = ActionDispatch::Routing::RouteWrapper.new(route)

--- a/spec/requests/orders_rbac_spec.rb
+++ b/spec/requests/orders_rbac_spec.rb
@@ -11,11 +11,6 @@ describe "OrderRequests", :type => :request do
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
-  around do |example|
-    with_modified_env(:APP_NAME => "catalog") do
-      example.call
-    end
-  end
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)

--- a/spec/requests/orders_rbac_spec.rb
+++ b/spec/requests/orders_rbac_spec.rb
@@ -7,15 +7,14 @@ describe "OrderRequests", :type => :request do
   let(:user_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :owner_scoped? => true, :accessible? => true) }
 
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
-  let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return(groups)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])
   end
   shared_examples_for "#index" do
     it "fetch all allowed orders" do

--- a/spec/requests/portfolio_items_rbac_spec.rb
+++ b/spec/requests/portfolio_items_rbac_spec.rb
@@ -11,11 +11,6 @@ describe 'Portfolio Items RBAC API' do
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
-  around do |example|
-    with_modified_env(:APP_NAME => "catalog") do
-      example.call
-    end
-  end
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)

--- a/spec/requests/portfolio_items_rbac_spec.rb
+++ b/spec/requests/portfolio_items_rbac_spec.rb
@@ -7,15 +7,14 @@ describe 'Portfolio Items RBAC API' do
 
   let(:block_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => false) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
-  let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return(groups)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])
   end
 
   describe "GET /portfolio_items" do

--- a/spec/requests/portfolio_items_rbac_spec.rb
+++ b/spec/requests/portfolio_items_rbac_spec.rb
@@ -2,10 +2,26 @@ describe 'Portfolio Items RBAC API' do
   let(:portfolio) { create(:portfolio) }
   let!(:portfolio_item1) { create(:portfolio_item, :portfolio => portfolio) }
   let!(:portfolio_item2) { create(:portfolio_item) }
-  let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio_item1.id.to_s]) }
-  let(:double_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio_item1.id.to_s, portfolio_item2.id.to_s]) }
+  let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => true) }
+  let(:double_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => true) }
 
   let(:block_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => false) }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:groups) { [group1] }
+  let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:api_instance) { double }
+  let(:principal_options) { {:scope=>"principal"} }
+  around do |example|
+    with_modified_env(:APP_NAME => "catalog") do
+      example.call
+    end
+  end
+
+  before do
+    allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+  end
 
   describe "GET /portfolio_items" do
     it 'returns status code 200' do
@@ -47,7 +63,7 @@ describe 'Portfolio Items RBAC API' do
   end
 
   context "when user has RBAC update portfolios access" do
-    let(:portfolio_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => false, :id_list => [portfolio.id.to_s]) }
+    let(:portfolio_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => false) }
     before do
       allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolio_items', 'read').and_return(access_obj)

--- a/spec/requests/portfolios_rbac_read_access_spec.rb
+++ b/spec/requests/portfolios_rbac_read_access_spec.rb
@@ -1,12 +1,29 @@
 describe 'Portfolios Read Access RBAC API' do
   let!(:portfolio1) { create(:portfolio) }
   let!(:portfolio2) { create(:portfolio) }
-  let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :owner_scoped? => false, :accessible? => true, :id_list => id_list) }
+  let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :owner_scoped? => false, :accessible? => true ) }
   let(:valid_attributes) { {:name => 'Fred', :description => "Fred's Portfolio" } }
-  let(:id_list) { [] }
   let(:block_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => false) }
   let(:graphql_query) { '{ portfolios { id name } }' }
   let(:graphql_body) { { 'query' => graphql_query } }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:permission) { 'catalog:portfolios:read' }
+  let(:ace1) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1) }
+  let(:ace2) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio2) }
+  let(:groups) { [group1] }
+  let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:api_instance) { double }
+  let(:list_group_options) { {:scope=>"principal"} }
+  around do |example|
+    with_modified_env(:APP_NAME => "catalog") do
+      example.call
+    end
+  end
+
+  before do
+    allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return(groups)
+  end
 
   describe "GET /portfolios" do
     context "no permission to read portfolios" do
@@ -37,12 +54,13 @@ describe 'Portfolios Read Access RBAC API' do
     end
 
     context "permission to read specific portfolios" do
-      let(:id_list) { [portfolio1.id.to_s] }
-
       before do
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
         allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
+        allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return(groups)
         allow(access_obj).to receive(:process).and_return(access_obj)
+        ace1
       end
 
       it 'ok' do

--- a/spec/requests/portfolios_rbac_read_access_spec.rb
+++ b/spec/requests/portfolios_rbac_read_access_spec.rb
@@ -7,21 +7,19 @@ describe 'Portfolios Read Access RBAC API' do
   let(:graphql_query) { '{ portfolios { id name } }' }
   let(:graphql_body) { { 'query' => graphql_query } }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
-  let(:permission) { 'read' }
-  let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:list_group_options) { {:scope=>"principal"} }
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return([group1])
   end
 
   describe "GET /portfolios" do
     context "no permission to read portfolios" do
       before do
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio2)
+        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'read', :aceable => portfolio2)
       end
 
       it "no access" do
@@ -56,9 +54,9 @@ describe 'Portfolios Read Access RBAC API' do
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
         allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
         allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return(groups)
+        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return([group1])
         allow(access_obj).to receive(:process).and_return(access_obj)
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1)
+        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'read', :aceable => portfolio1)
       end
 
       it 'ok' do

--- a/spec/requests/portfolios_rbac_read_access_spec.rb
+++ b/spec/requests/portfolios_rbac_read_access_spec.rb
@@ -1,7 +1,7 @@
 describe 'Portfolios Read Access RBAC API' do
   let!(:portfolio1) { create(:portfolio) }
   let!(:portfolio2) { create(:portfolio) }
-  let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :owner_scoped? => false, :accessible? => true ) }
+  let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :owner_scoped? => false, :accessible? => true) }
   let(:valid_attributes) { {:name => 'Fred', :description => "Fred's Portfolio" } }
   let(:block_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => false) }
   let(:graphql_query) { '{ portfolios { id name } }' }

--- a/spec/requests/portfolios_rbac_read_access_spec.rb
+++ b/spec/requests/portfolios_rbac_read_access_spec.rb
@@ -30,6 +30,7 @@ describe 'Portfolios Read Access RBAC API' do
       it "no access" do
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(block_access_obj)
         allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
+        ace2
         allow(block_access_obj).to receive(:process).and_return(block_access_obj)
         get "#{api('1.0')}/portfolios/#{portfolio1.id}", :headers => default_headers
         expect(response).to have_http_status(:forbidden)

--- a/spec/requests/portfolios_rbac_read_access_spec.rb
+++ b/spec/requests/portfolios_rbac_read_access_spec.rb
@@ -21,7 +21,7 @@ describe 'Portfolios Read Access RBAC API' do
   describe "GET /portfolios" do
     context "no permission to read portfolios" do
       before do
-       create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio2)
+        create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio2)
       end
 
       it "no access" do

--- a/spec/requests/portfolios_rbac_spec.rb
+++ b/spec/requests/portfolios_rbac_spec.rb
@@ -10,11 +10,6 @@ describe 'Portfolios RBAC API' do
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
-  around do |example|
-    with_modified_env(:APP_NAME => "catalog") do
-      example.call
-    end
-  end
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
@@ -40,7 +35,7 @@ describe 'Portfolios RBAC API' do
 
   describe "DELETE /portfolios/{id}" do
     it "success" do
-      permission = 'catalog:portfolios:delete'
+      permission = 'delete'
       create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1)
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'delete').and_return(access_obj)
       allow(access_obj).to receive(:process).and_return(access_obj)
@@ -62,7 +57,7 @@ describe 'Portfolios RBAC API' do
     end
 
     it 'returns status code 200' do
-      permission = 'catalog:portfolios:read'
+      permission = 'read'
       create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1)
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
       allow(access_obj).to receive(:process).and_return(access_obj)
@@ -83,7 +78,7 @@ describe 'Portfolios RBAC API' do
 
     context "with filtering" do
       before do
-        permission = 'catalog:portfolios:read'
+        permission = 'read'
         create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1)
         create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio2)
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
@@ -122,8 +117,8 @@ describe 'Portfolios RBAC API' do
     context "when user has RBAC update portfolios access" do
       let(:portfolio_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => true) }
       before do
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'catalog:portfolios:read', :aceable => portfolio1)
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'catalog:portfolios:update', :aceable => portfolio1)
+        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'read', :aceable => portfolio1)
+        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'update', :aceable => portfolio1)
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'create').and_return(access_obj)
         allow(access_obj).to receive(:process).and_return(access_obj)
@@ -160,7 +155,7 @@ describe 'Portfolios RBAC API' do
   context "when the permissions array is proper" do
     describe "#share" do
       it "goes through validation" do
-        permissions = ["catalog:portfolios:update"]
+        permissions = ["update"]
         post "#{api}/portfolios/#{portfolio1.id}/share", :headers => default_headers, :params => {
           :permissions => permissions,
           :group_uuids => [group1.uuid]
@@ -172,8 +167,8 @@ describe 'Portfolios RBAC API' do
 
     describe "#unshare" do
       it "goes through validation" do
-        permissions = ["catalog:portfolios:update"]
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'catalog:portfolios:update', :aceable => portfolio1)
+        permissions = ["update"]
+        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'update', :aceable => portfolio1)
         post "#{api}/portfolios/#{portfolio1.id}/unshare", :headers => default_headers, :params => {
           :permissions => permissions,
           :group_uuids => [group1.uuid]

--- a/spec/requests/portfolios_rbac_update_access_spec.rb
+++ b/spec/requests/portfolios_rbac_update_access_spec.rb
@@ -6,7 +6,7 @@ describe 'Portfolios Write Access RBAC API' do
   let(:updated_attributes) { {:name => 'Barney', :description => "Barney's Portfolio" } }
   let(:block_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => false) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
-  let(:permission) { 'catalog:portfolios:update' }
+  let(:permission) { 'update' }
   let(:ace1) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1) }
   let(:ace2) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio2) }
   let(:groups) { [group1] }

--- a/spec/requests/portfolios_rbac_update_access_spec.rb
+++ b/spec/requests/portfolios_rbac_update_access_spec.rb
@@ -1,11 +1,23 @@
 describe 'Portfolios Write Access RBAC API' do
   let!(:portfolio1) { create(:portfolio) }
   let!(:portfolio2) { create(:portfolio) }
-  let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :id_list => id_list) }
+  let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true) }
   let(:valid_attributes) { {:name => 'Fred', :description => "Fred's Portfolio" } }
   let(:updated_attributes) { {:name => 'Barney', :description => "Barney's Portfolio" } }
-  let(:id_list) { [] }
   let(:block_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => false) }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:permission) { 'catalog:portfolios:update' }
+  let(:ace1) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1) }
+  let(:ace2) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio2) }
+  let(:groups) { [group1] }
+  let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:api_instance) { double }
+  let(:list_group_options) { {:scope=>"principal"} }
+  around do |example|
+    with_modified_env(:APP_NAME => "catalog") do
+      example.call
+    end
+  end
 
   describe "POST /portfolios" do
     it 'creates a portfolio' do
@@ -30,13 +42,14 @@ describe 'Portfolios Write Access RBAC API' do
   end
 
   describe "PATCH /portfolios" do
-    let(:id_list) { [portfolio1.id.to_s] }
-
     before do
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'update').and_return(access_obj)
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'create').and_return(access_obj)
       allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
       allow(access_obj).to receive(:process).and_return(access_obj)
+      allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return(groups)
+      ace1
     end
 
     it 'only allows updating a specific portfolio' do

--- a/spec/requests/portfolios_rbac_update_access_spec.rb
+++ b/spec/requests/portfolios_rbac_update_access_spec.rb
@@ -7,7 +7,6 @@ describe 'Portfolios Write Access RBAC API' do
   let(:block_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => false) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
   let(:permission) { 'update' }
-  let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:list_group_options) { {:scope=>"principal"} }
@@ -41,7 +40,7 @@ describe 'Portfolios Write Access RBAC API' do
       allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
       allow(access_obj).to receive(:process).and_return(access_obj)
       allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return(groups)
+      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return([group1])
       create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1)
     end
 

--- a/spec/requests/portfolios_rbac_update_access_spec.rb
+++ b/spec/requests/portfolios_rbac_update_access_spec.rb
@@ -7,17 +7,10 @@ describe 'Portfolios Write Access RBAC API' do
   let(:block_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => false) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
   let(:permission) { 'update' }
-  let(:ace1) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1) }
-  let(:ace2) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio2) }
   let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:list_group_options) { {:scope=>"principal"} }
-  around do |example|
-    with_modified_env(:APP_NAME => "catalog") do
-      example.call
-    end
-  end
 
   describe "POST /portfolios" do
     it 'creates a portfolio' do
@@ -49,7 +42,7 @@ describe 'Portfolios Write Access RBAC API' do
       allow(access_obj).to receive(:process).and_return(access_obj)
       allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
       allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return(groups)
-      ace1
+      create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1)
     end
 
     it 'only allows updating a specific portfolio' do

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -295,26 +295,22 @@ describe 'Portfolios API' do
       end
     end
 
-    RSpec.shared_context "sharing_objects" do
-      let(:group_uuids) { %w[1 2 3] }
-      let(:permissions) { %w[catalog:portfolios:read] }
-      let(:app_name) { "catalog" }
-      let(:http_status) { '204' }
-      let(:dummy) { double("Insights::API::Common::RBAC::ShareResource", :process => self) }
-      let(:attributes) { {:group_uuids => group_uuids, :permissions => permissions} }
-    end
 
     shared_examples_for "#shared_test" do
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
-          options = {:app_name      => app_name,
-                     :resource_ids  => [portfolio.id.to_s],
-                     :resource_name => 'portfolios',
+          options = {:resource_ids  => [shared_portfolio.id.to_s],
                      :permissions   => permissions,
                      :group_uuids   => group_uuids}
-          allow(Insights::API::Common::RBAC::ShareResource).to receive(:new).with(options).and_return(dummy)
-          post "#{api}/portfolios/#{portfolio.id}/share", :params => attributes, :headers => default_headers
+
+          allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+          allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+          post "#{api}/portfolios/#{shared_portfolio.id}/share", :params => attributes, :headers => default_headers
           expect(response).to have_http_status(http_status)
+          if http_status == 204
+            shared_portfolio.reload
+            expect(shared_portfolio.access_control_entries.count).to eq(groups.count)
+          end
         end
       end
     end
@@ -363,34 +359,38 @@ describe 'Portfolios API' do
     context 'unshare' do
       include_context "sharing_objects"
       let(:unsharing_attributes) { {:group_uuids => group_uuids, :permissions => permissions} }
-      let(:dummy) { double("Insights::API::Common::RBAC::UnshareResource", :process => self) }
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
-          options = {:app_name      => app_name,
-                     :resource_ids  => [portfolio.id.to_s],
-                     :resource_name => 'portfolios',
+          options = {:resource_ids  => [portfolio.id.to_s],
                      :permissions   => permissions,
                      :group_uuids   => group_uuids}
-          expect(Insights::API::Common::RBAC::UnshareResource).to receive(:new).with(options).and_return(dummy)
-          post "#{api}/portfolios/#{portfolio.id}/unshare", :params => unsharing_attributes, :headers => default_headers
+          allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+          allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+          ace1
+          ace2
+          ace3
+          expect(shared_portfolio.access_control_entries.count).to eq(3)
+          post "#{api}/portfolios/#{shared_portfolio.id}/unshare", :params => unsharing_attributes, :headers => default_headers
+          shared_portfolio.reload
           expect(response).to have_http_status(204)
+          expect(shared_portfolio.access_control_entries.count).to eq(0)
         end
       end
     end
 
     context 'share_info' do
       include_context "sharing_objects"
-      let(:dummy_response) { double(:share_info => {'a' => 1}) }
-      let(:dummy) { double("Insights::API::Common::RBAC::UnshareResource", :process => dummy_response) }
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
-          options = {:app_name      => app_name,
-                     :resource_id   => portfolio.id.to_s,
-                     :resource_name => 'portfolios'}
-          expect(Insights::API::Common::RBAC::QuerySharedResource).to receive(:new).with(options).and_return(dummy)
-          get "#{api}/portfolios/#{portfolio.id}/share_info", :headers => default_headers
-
+          options = {:resource_id   => portfolio.id.to_s}
+          allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+          allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+          ace1
+          ace2
+          ace3
+          get "#{api}/portfolios/#{shared_portfolio.id}/share_info", :headers => default_headers
           expect(response).to have_http_status(200)
+          expect(json.pluck('group_uuid')).to match_array(group_uuids)
         end
       end
     end

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -299,10 +299,6 @@ describe 'Portfolios API' do
     shared_examples_for "#shared_test" do
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
-          options = {:resource_ids  => [shared_portfolio.id.to_s],
-                     :permissions   => permissions,
-                     :group_uuids   => group_uuids}
-
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
           allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
           post "#{api}/portfolios/#{shared_portfolio.id}/share", :params => attributes, :headers => default_headers
@@ -361,9 +357,6 @@ describe 'Portfolios API' do
       let(:unsharing_attributes) { {:group_uuids => group_uuids, :permissions => permissions} }
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
-          options = {:resource_ids  => [portfolio.id.to_s],
-                     :permissions   => permissions,
-                     :group_uuids   => group_uuids}
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
           allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
           ace1
@@ -382,7 +375,6 @@ describe 'Portfolios API' do
       include_context "sharing_objects"
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
-          options = {:resource_id   => portfolio.id.to_s}
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
           allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
           ace1

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -303,10 +303,6 @@ describe 'Portfolios API' do
           allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
           post "#{api}/portfolios/#{shared_portfolio.id}/share", :params => attributes, :headers => default_headers
           expect(response).to have_http_status(http_status)
-          if http_status == 204
-            shared_portfolio.reload
-            expect(shared_portfolio.access_control_entries.count).to eq(groups.count)
-          end
         end
       end
     end
@@ -321,22 +317,7 @@ describe 'Portfolios API' do
       let(:http_status) { '400' }
 
       context 'invalid verb in permissions' do
-        let(:permissions) { %w[catalog:portfolios:something] }
-        it_behaves_like "#shared_test"
-      end
-
-      context 'invalid appname in permissions' do
-        let(:permissions) { %w[bad:portfolios:something] }
-        it_behaves_like "#shared_test"
-      end
-
-      context 'invalid object in permissions' do
-        let(:permissions) { %w[catalog:bad:read] }
-        it_behaves_like "#shared_test"
-      end
-
-      context 'invalid object type in permissions' do
-        let(:permissions) { [123] }
+        let(:permissions) { %w[something] }
         it_behaves_like "#shared_test"
       end
 
@@ -355,6 +336,8 @@ describe 'Portfolios API' do
     context 'unshare' do
       include_context "sharing_objects"
       let(:unsharing_attributes) { {:group_uuids => group_uuids, :permissions => permissions} }
+      before do
+      end
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -336,8 +336,6 @@ describe 'Portfolios API' do
     context 'unshare' do
       include_context "sharing_objects"
       let(:unsharing_attributes) { {:group_uuids => group_uuids, :permissions => permissions} }
-      before do
-      end
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -2,7 +2,6 @@ describe Catalog::ShareInfo, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
   let(:permissions) { ['read', 'update'] }
-  let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
@@ -11,8 +10,8 @@ describe Catalog::ShareInfo, :type => :service do
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return(groups)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])
     create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => portfolio)
     create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[1], :aceable => portfolio)
   end

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -24,11 +24,25 @@ describe Catalog::ShareInfo, :type => :service do
 
   let(:subject) { described_class.new(params) }
 
-  it "#process" do
-    info = subject.process.result
-    expect(info.count).to eq(1)
-    expect(info[0][:group_name]).to eq(group1.name)
-    expect(info[0][:group_uuid]).to eq(group1.uuid)
-    expect(info[0][:permissions]).to match_array(permissions)
+  shared_examples_for "#process" do
+    it "#process" do
+      info = subject.process.result
+      expect(info.count).to eq(1)
+      expect(info[0][:group_name]).to eq(group1.name)
+      expect(info[0][:group_uuid]).to eq(group1.uuid)
+      expect(info[0][:permissions]).to match_array(permissions)
+    end
+  end
+
+  context "when all group uuids exist" do
+    it_behaves_like "#process"
+  end
+
+  context "when only some group uuids exist" do
+    before do
+      create(:access_control_entry, :group_uuid => "non-existent", :permission => permissions[1], :aceable => portfolio)
+    end
+
+    it_behaves_like "#process"
   end
 end

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -1,16 +1,11 @@
 describe Catalog::ShareInfo, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
-  let(:permissions) { ['catalog:portfolios:read', 'catalog:portfolios:update'] }
+  let(:permissions) { ['read', 'update'] }
   let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
-  around do |example|
-    with_modified_env(:APP_NAME => "catalog") do
-      example.call
-    end
-  end
 
   let(:params) { { :object => portfolio } }
 

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -1,0 +1,34 @@
+describe Catalog::ShareInfo, :type => :service do
+  let(:portfolio) { create(:portfolio) }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:permissions) { ['catalog:portfolios:read', 'catalog:portfolios:update'] }
+  let(:groups) { [group1] }
+  let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:api_instance) { double }
+  let(:principal_options) { {:scope=>"principal"} }
+  around do |example|
+    with_modified_env(:APP_NAME => "catalog") do
+      example.call
+    end
+  end
+
+  let(:params) { { :object => portfolio } }
+
+  before do
+    allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+    create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => portfolio)
+    create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[1], :aceable => portfolio)
+  end
+
+  let(:subject) { described_class.new(params) }
+
+  it "#process" do
+    info = subject.process.result
+    expect(info.count).to eq(1)
+    expect(info[0][:group_name]).to eq(group1.name)
+    expect(info[0][:group_uuid]).to eq(group1.uuid)
+    expect(info[0][:permissions]).to match_array(permissions)
+  end
+end

--- a/spec/services/catalog/share_resource_spec.rb
+++ b/spec/services/catalog/share_resource_spec.rb
@@ -15,8 +15,7 @@ describe Catalog::ShareResource, :type => :service do
   let(:params) do
     { :group_uuids => [group1.uuid],
       :permissions => permissions,
-      :object      => portfolio
-    }
+      :object      => portfolio }
   end
 
   before do

--- a/spec/services/catalog/share_resource_spec.rb
+++ b/spec/services/catalog/share_resource_spec.rb
@@ -1,16 +1,11 @@
 describe Catalog::ShareResource, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
-  let(:permissions) { ['catalog:portfolios:read', 'catalog:portfolios:update'] }
+  let(:permissions) { ['read', 'update'] }
   let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
-  around do |example|
-    with_modified_env(:APP_NAME => "catalog") do
-      example.call
-    end
-  end
 
   let(:params) do
     { :group_uuids => [group1.uuid],

--- a/spec/services/catalog/share_resource_spec.rb
+++ b/spec/services/catalog/share_resource_spec.rb
@@ -1,0 +1,35 @@
+describe Catalog::ShareResource, :type => :service do
+  let(:portfolio) { create(:portfolio) }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:permissions) { ['catalog:portfolios:read', 'catalog:portfolios:update'] }
+  let(:groups) { [group1] }
+  let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:api_instance) { double }
+  let(:principal_options) { {:scope=>"principal"} }
+  around do |example|
+    with_modified_env(:APP_NAME => "catalog") do
+      example.call
+    end
+  end
+
+  let(:params) do
+    { :group_uuids => [group1.uuid],
+      :permissions => permissions,
+      :object      => portfolio
+    }
+  end
+
+  before do
+    allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+  end
+
+  let(:subject) { described_class.new(params) }
+
+  it "#process" do
+    subject.process
+    portfolio.reload
+    expect(portfolio.access_control_entries.count).to eq(2)
+  end
+end

--- a/spec/services/catalog/share_resource_spec.rb
+++ b/spec/services/catalog/share_resource_spec.rb
@@ -2,7 +2,6 @@ describe Catalog::ShareResource, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
   let(:permissions) { ['read', 'update'] }
-  let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
@@ -15,8 +14,8 @@ describe Catalog::ShareResource, :type => :service do
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return(groups)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])
   end
 
   let(:subject) { described_class.new(params) }

--- a/spec/services/catalog/unshare_resource_spec.rb
+++ b/spec/services/catalog/unshare_resource_spec.rb
@@ -1,16 +1,11 @@
 describe Catalog::UnshareResource, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
-  let(:permissions) { ['catalog:portfolios:read', 'catalog:portfolios:update'] }
+  let(:permissions) { ['read', 'update'] }
   let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
-  around do |example|
-    with_modified_env(:APP_NAME => "catalog") do
-      example.call
-    end
-  end
 
   let(:params) do
     { :group_uuids => [group1.uuid],

--- a/spec/services/catalog/unshare_resource_spec.rb
+++ b/spec/services/catalog/unshare_resource_spec.rb
@@ -2,7 +2,6 @@ describe Catalog::UnshareResource, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
   let(:permissions) { ['read', 'update'] }
-  let(:groups) { [group1] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
@@ -15,8 +14,8 @@ describe Catalog::UnshareResource, :type => :service do
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return(groups)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])
     create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => portfolio)
     create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[1], :aceable => portfolio)
   end

--- a/spec/services/catalog/unshare_resource_spec.rb
+++ b/spec/services/catalog/unshare_resource_spec.rb
@@ -15,8 +15,7 @@ describe Catalog::UnshareResource, :type => :service do
   let(:params) do
     { :group_uuids => [group1.uuid],
       :permissions => permissions,
-      :object      => portfolio
-    }
+      :object      => portfolio }
   end
 
   before do

--- a/spec/services/catalog/unshare_resource_spec.rb
+++ b/spec/services/catalog/unshare_resource_spec.rb
@@ -1,0 +1,38 @@
+describe Catalog::UnshareResource, :type => :service do
+  let(:portfolio) { create(:portfolio) }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:permissions) { ['catalog:portfolios:read', 'catalog:portfolios:update'] }
+  let(:groups) { [group1] }
+  let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:api_instance) { double }
+  let(:principal_options) { {:scope=>"principal"} }
+  around do |example|
+    with_modified_env(:APP_NAME => "catalog") do
+      example.call
+    end
+  end
+
+  let(:params) do
+    { :group_uuids => [group1.uuid],
+      :permissions => permissions,
+      :object      => portfolio
+    }
+  end
+
+  before do
+    allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return(groups)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+    create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => portfolio)
+    create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[1], :aceable => portfolio)
+  end
+
+  let(:subject) { described_class.new(params) }
+
+  it "#process" do
+    expect(portfolio.access_control_entries.count).to eq(2)
+    subject.process
+    portfolio.reload
+    expect(portfolio.access_control_entries.count).to eq(0)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,8 +34,8 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.filter_rails_from_backtrace!
-  config.include(Shoulda::Matchers::ActiveModel, type: :model)
-  config.include(Shoulda::Matchers::ActiveRecord, type: :model)
+  config.include(Shoulda::Matchers::ActiveModel, :type => :model)
+  config.include(Shoulda::Matchers::ActiveRecord, :type => :model)
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'webmock/rspec'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 Dir[Insights::API::Common::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Insights::API::Common::Engine.root.join("lib/insights/api/common/rbac/*.rb")].each { |f| require f }
 
 begin
   ActiveRecord::Migration.maintain_test_schema!
@@ -33,6 +34,8 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.filter_rails_from_backtrace!
+  config.include(Shoulda::Matchers::ActiveModel, type: :model)
+  config.include(Shoulda::Matchers::ActiveRecord, type: :model)
 end
 
 RSpec.configure do |config|

--- a/spec/support/sharing_objects.rb
+++ b/spec/support/sharing_objects.rb
@@ -1,7 +1,7 @@
 RSpec.shared_context "sharing_objects" do
   let(:app_name) { 'catalog' }
   let!(:shared_portfolio) { create(:portfolio) }
-  let(:permissions) { %w[catalog:portfolios:read] }
+  let(:permissions) { %w[read] }
   let(:http_status) { '204' }
   let(:attributes) { {:group_uuids => group_uuids, :permissions => permissions} }
   let(:ace1) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => shared_portfolio) }

--- a/spec/support/sharing_objects.rb
+++ b/spec/support/sharing_objects.rb
@@ -1,0 +1,17 @@
+RSpec.shared_context "sharing_objects" do
+  let(:app_name) { 'catalog' }
+  let!(:shared_portfolio) { create(:portfolio) }
+  let(:permissions) { %w[catalog:portfolios:read] }
+  let(:http_status) { '204' }
+  let(:attributes) { {:group_uuids => group_uuids, :permissions => permissions} }
+  let(:ace1) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => shared_portfolio) }
+  let(:ace2) { create(:access_control_entry, :group_uuid => group2.uuid, :permission => permissions[0], :aceable => shared_portfolio) }
+  let(:ace3) { create(:access_control_entry, :group_uuid => group3.uuid, :permission => permissions[0], :aceable => shared_portfolio) }
+  let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:api_instance) { double }
+  let(:group_uuids) { [group1.uuid, group2.uuid, group3.uuid] }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:group2) { instance_double(RBACApiClient::GroupOut, :name => 'group2', :uuid => "12345") }
+  let(:group3) { instance_double(RBACApiClient::GroupOut, :name => 'group3', :uuid => "45665") }
+  let(:groups) { [group1, group2, group3] }
+end


### PR DESCRIPTION
This allows us to store the ACE's for our resources locally.
We create the ACE's when the user shares an object
We delete the ACE's when the user unshares an object
We read the ACE's based on the currently logged in users group
membership.

This PR also changes the permission strings so that we only have the verb and dont include the application name and object name

**catalog:portfolios:read** is now just **read**

Related PR: https://github.com/RedHatInsights/catalog-ui/pull/349