### PR TITLE
Utilize OrderItem context for all task relevancy methods

### DIFF
--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -5,28 +5,39 @@ module Catalog
     end
 
     def process
-      Rails.logger.info("Looking for task in topology with topic: #{@topic}")
+      Insights::API::Common::Request.with_request(order_item_context) do
+        Rails.logger.info("Looking for task in topology with topic: #{@topic}")
 
-      @task = TopologicalInventory.call do |api|
-        api.show_task(@topic.payload["task_id"])
-      end
+        @task = TopologicalInventory.call do |api|
+          api.show_task(@topic.payload["task_id"])
+        end
 
-      Rails.logger.info("Found task: #{@task}")
+        Rails.logger.info("Found task: #{@task}")
 
-      if @task.context.has_key_path?(:service_instance, :id)
-        Catalog::UpdateOrderItem.new(@topic, @task).process
-      elsif @task.context.has_key_path?(:applied_inventories)
-        Rails.logger.info("Creating approval request for task")
-        Catalog::CreateApprovalRequest.new(@task).process
-      else
-        item = OrderItem.find_by!(:topology_task_ref => @task.id)
-        item.update_message(:error, "Topology task error")
-        Rails.logger.error(
-          "Topology error during task. State: #{@task.state}. Status: #{@task.status}. Context: #{@task.context}"
-        )
+        if @task.context.has_key_path?(:service_instance, :id)
+          Catalog::UpdateOrderItem.new(@topic, @task).process
+        elsif @task.context.has_key_path?(:applied_inventories)
+          Rails.logger.info("Creating approval request for task")
+          Catalog::CreateApprovalRequest.new(@task).process
+        else
+          order_item.update_message(:error, "Topology task error")
+          Rails.logger.error(
+            "Topology error during task. State: #{@task.state}. Status: #{@task.status}. Context: #{@task.context}"
+          )
+        end
       end
 
       self
+    end
+
+    private
+
+    def order_item
+      @order_item ||= OrderItem.find_by!(:topology_task_ref => @topic.payload["task_id"])
+    end
+
+    def order_item_context
+      order_item.context.transform_keys(&:to_sym)
     end
   end
 end

--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -15,11 +15,9 @@ module Catalog
       @order_item = find_order_item
       Rails.logger.info("Found OrderItem: #{@order_item.id}")
 
-      Insights::API::Common::Request.with_request(@order_item.context.transform_keys(&:to_sym)) do
-        @order_item.update_message("info", "Task update message received with payload: #{@payload}")
+      @order_item.update_message("info", "Task update message received with payload: #{@payload}")
 
-        mark_item_based_on_status
-      end
+      mark_item_based_on_status
     end
 
     private

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -8,6 +8,12 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
     end
   end
 
+  let!(:order_item) do
+    Insights::API::Common::Request.with_request(default_request) do
+      create(:order_item, :topology_task_ref => "123")
+    end
+  end
+
   before do
     allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
   end
@@ -55,7 +61,6 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
           :context => {:error => "Undefined method oh noes"}
         )
       end
-      let!(:order_item) { create(:order_item, :topology_task_ref => task.id) }
 
       it "updates the item with a progress message" do
         subject.process

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -5,11 +5,7 @@ describe Catalog::UpdateOrderItem, :type => :service do
 
   describe "#process" do
     let(:payload) { {"task_id" => "123", "status" => status, "state" => state, "context" => "payloadcontext"} }
-    let!(:item) do
-      Insights::API::Common::Request.with_request(default_request) do
-        create(:order_item, :topology_task_ref => topology_task_ref)
-      end
-    end
+    let!(:item) { create(:order_item, :topology_task_ref => topology_task_ref) }
     let(:order) { item.order }
 
     around do |example|


### PR DESCRIPTION
When I changed to use the notify_task endpoint and broke out the task handling into this `DetermineTaskRelevancy` class, I didn't realize that this was necessary. `UpdateOrderItem` was still passing through the order item context, but was no longer looking up the task. Now that the task is being looked up outside of the various task processing service classes, we need to supply the request with the order item context. When looking up a `task` in topology, we were not passing through the correct tenancy due to the internal endpoint using `ActsAsTenant.without_tenant`.

This should hopefully fix those issues and look up the task (and any other calls to topology that the other service classes make) with the correct tenant.

@syncrou @lindgrenj6 Please Review.