### PR TITLE
Set the Tenant manually when creating an ApprovalRequest since ActsAsTenant is not set

### DIFF
--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -31,7 +31,8 @@ module Catalog
 
       order_item.approval_requests.create!(
         :approval_request_ref => response.id,
-        :state                => response.decision.to_sym
+        :state                => response.decision.to_sym,
+        :tenant_id            => order_item.tenant_id
       )
 
       order_item.update_message("info", "Approval Request Submitted for ID: #{order_item.approval_requests.last.id}")

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -70,16 +70,16 @@ describe Catalog::CreateApprovalRequest, :type => :service do
       end
     end
 
-    context "when creating the approval request fails" do
+    context "without a tenant on the request" do
       before do
         stub_request(:post, "http://localhost/api/approval/v1.0/requests")
           .with(:body => request_body_from)
           .to_return(:status => 200, :body => {:workflow_id => 7, :id => 7, :decision => "approved"}.to_json, :headers => {"Content-type" => "application/json"})
       end
 
-      it "raises an error" do
+      it "does not raise an error" do
         ActsAsTenant.without_tenant do
-          expect { subject.process }.to raise_exception(ActiveRecord::RecordInvalid)
+          expect { subject.process }.to_not raise_error
         end
       end
     end


### PR DESCRIPTION
The Tenant on the Approval Request wasn't getting set since ActsAsTenant wasn't set, this sets it manually.