### PR TITLE
Change progress messages for when tasks update

### DIFF
--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -20,10 +20,7 @@ module Catalog
           Rails.logger.info("Creating approval request for task")
           Catalog::CreateApprovalRequest.new(@task).process
         else
-          order_item.update_message(:error, "Topology task error")
-          Rails.logger.error(
-            "Topology error during task. State: #{@task.state}. Status: #{@task.status}. Context: #{@task.context}"
-          )
+          add_task_update_message
         end
       end
 
@@ -38,6 +35,16 @@ module Catalog
 
     def order_item_context
       order_item.context.transform_keys(&:to_sym)
+    end
+
+    def add_task_update_message
+      @task.status == "error" ? add_update_message(:error) : add_update_message(:info)
+    end
+
+    def add_update_message(state)
+      message = "Topology task update. State: #{@task.state}. Status: #{@task.status}. Context: #{@task.context}"
+      order_item.update_message(state, message)
+      Rails.logger.send(state, message)
     end
   end
 end


### PR DESCRIPTION
Even though we got orders working, every time a task was being updated without either the `[:applied_inventories]` or `[:service_instance][:id]` keys, I was creating an 'error' progress message, which looks a bit weird.

This should fix that to only create error progress messages when we actually have a task error, otherwise it creates a regular info update message with the same pertinent information.

@syncrou @lindgrenj6 Please Review.