### PR TITLE
Change DNE references when there is no service_plan to null

### DIFF
--- a/app/services/catalog/order_item_sanitized_parameters.rb
+++ b/app/services/catalog/order_item_sanitized_parameters.rb
@@ -4,7 +4,6 @@ module Catalog
 
     MASKED_VALUE = "********".freeze
     FILTERED_PARAMS = %w[password token secret].freeze
-    SERVICE_PLAN_DOES_NOT_EXIST = "DNE".freeze
 
     def initialize(params)
       @params = params
@@ -64,7 +63,7 @@ module Catalog
     end
 
     def service_plan_does_not_exist?
-      service_plan_ref == SERVICE_PLAN_DOES_NOT_EXIST
+      service_plan_ref.nil?
     end
   end
 end

--- a/schemas/json/no_service_plan.erb
+++ b/schemas/json/no_service_plan.erb
@@ -1,6 +1,6 @@
 {
   "service_offering_id": "<%= @reference %>",
-  "id": "DNE",
+  "id": null,
   "create_json_schema": <%= {
     "schemaType": "default",
     "schema": {

--- a/spec/services/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/services/catalog/order_item_sanitized_parameters_spec.rb
@@ -77,8 +77,8 @@ describe Catalog::OrderItemSanitizedParameters, :type => :service do
       end
     end
 
-    context "when the service plan ref is 'DNE'" do
-      let(:service_plan_ref) { "DNE" }
+    context "when the service plan ref is 'null'" do
+      let(:service_plan_ref) { nil }
       let(:fields) { [] }
 
       it "does not call the api" do

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -32,8 +32,8 @@ describe Catalog::ServicePlans, :type => :service do
         expect(items.count).to eq(1)
       end
 
-      it "returns an array with one object with an ID of 'DNE'" do
-        expect(items.first["id"]).to eq("DNE")
+      it "returns an array with one object with an ID of 'null'" do
+        expect(items.first["id"]).to be_nil
       end
 
       it "returns an array with one object with a service_offering_id" do


### PR DESCRIPTION
Ordering was failing for products with no survey, due to the fact that here:
https://github.com/RedHatInsights/catalog-api/blob/288f669a90d967238bc3c51ad5f9a240df0ceff2/app/services/catalog/submit_order.rb#L41

it was failing to assign `DNE` to the ID field since it was a string but had to be an integer. This changes everything to use `null` instead for the ID since it wasn't used anywhere in the UI. 

@syncrou @eclarizio please review. 