### PR TITLE
Force handling of ActiveRecord::RecordInvalid errors on create!s

### DIFF
--- a/app/services/catalog/add_to_order.rb
+++ b/app/services/catalog/add_to_order.rb
@@ -10,7 +10,11 @@ module Catalog
       order = Order.find_by!(:id => @params[:order_id])
       @params.delete(:service_plan_ref)
       @order_item = order.order_items.create!(order_item_params.merge!(:service_plan_ref => service_plan_ref))
+
       self
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error("Error creating order item for order_id #{order.id}: #{e.message}")
+      raise
     end
 
     private

--- a/app/services/catalog/create_icon.rb
+++ b/app/services/catalog/create_icon.rb
@@ -23,6 +23,9 @@ module Catalog
       @destination.update!(:icon_id => @icon.id)
 
       self
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error("Error creating Icon object for #{@destination.class} #{@destination.id}: #{e.message}")
+      raise
     end
   end
 end

--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -22,6 +22,9 @@ module Catalog
       @service_plans = @portfolio_item.service_plans
 
       self
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error("Error creating service plan with schemas: #{service_plan_schemas}, #{e.message}")
+      raise
     end
 
     def service_plan_schemas

--- a/spec/services/catalog/add_to_order_spec.rb
+++ b/spec/services/catalog/add_to_order_spec.rb
@@ -22,6 +22,7 @@ describe Catalog::AddToOrder, :type => :service do
   end
 
   let(:subject) { described_class.new(params).process }
+
   let(:request) { default_request }
   let(:service_plans_instance) { instance_double(Catalog::ServicePlans) }
 
@@ -37,8 +38,17 @@ describe Catalog::AddToOrder, :type => :service do
     end
   end
 
-  it "invalid parameters" do
-    expect { described_class.new(invalid_params).process }.to raise_error(ActiveRecord::RecordInvalid)
+  context "when the parameters are invalid" do
+    let(:invalid_params) do
+      ActionController::Parameters.new('order_id'          => order.id,
+                                       'portfolio_item_id' => portfolio_item.id,
+                                       'count'             => 1)
+    end
+
+    it "raises an ActiveRecord::RecordInvalid exception and logs a message" do
+      expect(Rails.logger).to receive(:error).with(/Error creating order item for order_id #{order_id}/)
+      expect { described_class.new(invalid_params).process }.to raise_error(ActiveRecord::RecordInvalid)
+    end
   end
 
   context "invalid order" do

--- a/spec/services/catalog/create_icon_spec.rb
+++ b/spec/services/catalog/create_icon_spec.rb
@@ -77,5 +77,20 @@ describe Catalog::CreateIcon, :type => :service do
 
       it_behaves_like "#process handling generic object"
     end
+
+    context "when there is an error creating the image" do
+      let(:destination) { create(:portfolio) }
+      let(:destination_params) { {:portfolio_id => destination.id} }
+      let(:image_params) { {:content => form_upload_test_image("ocp_logo.jpg")} }
+
+      before do
+        allow(Icon).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      it "logs an error and raises" do
+        expect(Rails.logger).to receive(:error).with(/Error creating Icon object/)
+        expect { subject.process }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
   end
 end


### PR DESCRIPTION
Any time we're doing a `create!`, if we weren't already handling the error, this PR adds handling and specs for those cases. This stems from testing and hitting tenancy issues and it being a major pain to track why `create!` was failing.

I propose that going forward, any new code that utilizes `create!` be "wrapped" with handling so that we can at the very least get more information on what happened when/if it blows up.

@lindgrenj6 @syncrou  👀please