### PR TITLE
Add nullable to OrderItem fields that can be null when there is not a service plan present

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -3165,11 +3165,8 @@
       "OrderItem": {
         "type": "object",
         "required": [
-          "service_parameters",
           "count",
-          "service_plan_ref",
-          "portfolio_item_id",
-          "provider_control_parameters"
+          "portfolio_item_id"
         ],
         "properties": {
           "id": {
@@ -3183,17 +3180,20 @@
           },
           "service_parameters": {
             "type": "object",
-            "title": "JSON object with provisioning parameters"
+            "title": "JSON object with provisioning parameters",
+            "nullable": true
           },
           "provider_control_parameters": {
             "type": "object",
             "title": "Provider Control Parameters",
-            "description": "The provider specific parameters needed to provision this service. This might include namespaces, special keys."
+            "description": "The provider specific parameters needed to provision this service. This might include namespaces, special keys.",
+            "nullable": true
           },
           "service_plan_ref": {
             "type": "string",
             "title": "The Service Plan ref",
-            "description": "Stores the service plan ref from the Topology Service."
+            "description": "Stores the service plan ref from the Topology Service.",
+            "nullable": true
           },
           "portfolio_item_id": {
             "type": "string",


### PR DESCRIPTION
Forgot to add `nullable: true` to the fields that can be null when there is not a service plan present, this way the order will go through when we don't have an ID on the service_plan.