### PR TITLE
Add `topology_plan_ref` to store the original service_plan id for ordering

### DIFF
--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -13,6 +13,7 @@ module Catalog
           :description       => schema["description"],
           :base              => schema["create_json_schema"],
           :modified          => schema["create_json_schema"],
+          :topology_plan_ref => schema["id"],
           :portfolio_item_id => @portfolio_item.id
         )
       end

--- a/db/migrate/20191212225130_add_topology_plan_ref_to_service_plans.rb
+++ b/db/migrate/20191212225130_add_topology_plan_ref_to_service_plans.rb
@@ -1,0 +1,5 @@
+class AddTopologyPlanRefToServicePlans < ActiveRecord::Migration[5.2]
+  def change
+    add_column :service_plans, :topology_plan_ref, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_18_220525) do
+ActiveRecord::Schema.define(version: 2019_12_12_225130) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,8 +20,8 @@ ActiveRecord::Schema.define(version: 2019_11_18_220525) do
     t.integer "order_item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "reason"
     t.integer "state", default: 0
+    t.string "reason"
     t.bigint "tenant_id"
     t.datetime "request_completed_at"
     t.index ["tenant_id"], name: "index_approval_requests_on_tenant_id"
@@ -45,8 +45,8 @@ ActiveRecord::Schema.define(version: 2019_11_18_220525) do
   create_table "images", force: :cascade do |t|
     t.binary "content"
     t.string "extension"
-    t.bigint "tenant_id"
     t.string "hashcode"
+    t.bigint "tenant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["tenant_id"], name: "index_images_on_tenant_id"
@@ -177,6 +177,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_220525) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.string "description"
+    t.bigint "topology_plan_ref"
     t.index ["discarded_at"], name: "index_service_plans_on_discarded_at"
     t.index ["tenant_id"], name: "index_service_plans_on_tenant_id"
   end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -3413,6 +3413,12 @@
             "description": "The reference ID of the Portfolio Item",
             "readOnly": true
           },
+          "topology_plan_ref": {
+            "type": "string",
+            "title": "Topology Plan Ref",
+            "description": "The plan reference ID for the ServicePlan",
+            "readOnly": true
+          },
           "id": {
             "type": "string",
             "title": "ID",

--- a/spec/services/catalog/import_service_plans_spec.rb
+++ b/spec/services/catalog/import_service_plans_spec.rb
@@ -46,6 +46,10 @@ describe Catalog::ImportServicePlans, :type => :service do
       it "adds the ServicePlan to the portfolio_item" do
         expect(portfolio_item.service_plans.count).to eq 1
       end
+
+      it "sets the topology_plan_ref to the id of the service_plan" do
+        expect(portfolio_item.service_plans.collect(&:topology_plan_ref)).to match_array [1]
+      end
     end
 
     context "when there are multiple plans" do
@@ -57,6 +61,10 @@ describe Catalog::ImportServicePlans, :type => :service do
 
       it "adds both the ServicePlans to the portfolio_item" do
         expect(portfolio_item.service_plans.count).to eq 2
+      end
+
+      it "sets the topology_plan_ref to the id of the service_plan" do
+        expect(portfolio_item.service_plans.collect(&:topology_plan_ref)).to match_array [1, 1]
       end
     end
   end


### PR DESCRIPTION
Found when submitting an order after editing a survey, we were passing the ID of the service plan in our database which wasn't right. This adds a new field to store it so we can reference this when actually submitting the order.

@eclarizio @syncrou :eyes: have a looksee!

@Hyperkid123 gonna need a change on the frontend for this one, just key off of `topology_plan_ref` for the OrderItem's `service_plan_ref` when there is an edited survey being submitted for order. 