### PR TITLE
Copy the Icon/ServicePlan when copying a portfolio/portfolio_item

### DIFF
--- a/app/services/catalog/copy_portfolio.rb
+++ b/app/services/catalog/copy_portfolio.rb
@@ -1,5 +1,6 @@
 module Catalog
   class CopyPortfolio
+    include IconMixin
     attr_reader :new_portfolio
 
     def initialize(params)
@@ -18,6 +19,9 @@ module Catalog
     def make_copy
       @portfolio.dup.tap do |new_portfolio|
         new_portfolio.name = @name || Catalog::NameAdjust.create_copy_name(@portfolio.name, Portfolio.all.pluck(:name))
+
+        duplicate_icon(@portfolio, new_portfolio) if @portfolio.icon_id.present?
+
         new_portfolio.save!
 
         copy_portfolio_items(new_portfolio.id)

--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -1,5 +1,6 @@
 module Catalog
   class CopyPortfolioItem
+    include IconMixin
     attr_reader :new_portfolio_item
 
     def initialize(params)
@@ -25,6 +26,15 @@ module Catalog
     def make_copy
       @portfolio_item.dup.tap do |new_portfolio_item|
         new_portfolio_item.name = new_name(@portfolio_item.name)
+
+        duplicate_icon(@portfolio_item, new_portfolio_item) if @portfolio_item.icon_id.present?
+
+        @portfolio_item.service_plans.each do |plan|
+          new_plan = plan.dup
+          new_plan.save!
+          new_portfolio_item.service_plans << new_plan
+        end
+
         new_portfolio_item.save
       end
     end

--- a/app/services/concerns/icon_mixin.rb
+++ b/app/services/concerns/icon_mixin.rb
@@ -1,0 +1,5 @@
+module IconMixin
+  def duplicate_icon(src, dest)
+    dest.create_icon!(:restore_to => src, :image_id => src.icon.image_id)
+  end
+end

--- a/spec/services/catalog/copy_portfolio_spec.rb
+++ b/spec/services/catalog/copy_portfolio_spec.rb
@@ -1,5 +1,5 @@
 describe Catalog::CopyPortfolio, :type => :service do
-  let(:portfolio) { create(:portfolio) }
+  let(:portfolio) { create(:portfolio, :icon => create(:icon)) }
   let!(:portfolio_item1) { create(:portfolio_item, :portfolio => portfolio) }
   let!(:portfolio_item2) { create(:portfolio_item, :portfolio => portfolio) }
 
@@ -16,6 +16,13 @@ describe Catalog::CopyPortfolio, :type => :service do
 
       it "modifies the name" do
         expect(new_portfolio.name).to match(/^Copy of.*/)
+      end
+
+      it "copies over the icon" do
+        new = copy_portfolio.new_portfolio
+
+        expect(new.icon_id).not_to eq portfolio.icon_id
+        expect(new.icon.image_id).to eq portfolio.icon.image_id
       end
 
       it "copies over all of the portfolio items" do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1041

Fixes a bug that occurs when copying a portfolio_item (handles portfolios as well), before the `icon_id` reference would still point to the parent product's icon, which if the one of the two was updated to a new icon the other would be reverted to the default icon since the old icon would be discarded. 

While investigating had discussions about copying over any modified service_plans for custom dialogs that exist as well, came to the conclusion that the copied product should show the same dialog, so added logic to copy the service_plans over as well. 

\# TODO:
- [x] copy service_plans over as well. 