### PR TITLE
Throw a 409 if a ServicePlan has already been imported for a PortfolioItem

### DIFF
--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -4,6 +4,8 @@ module Catalog
 
     def initialize(portfolio_item_id)
       @portfolio_item = PortfolioItem.find(portfolio_item_id)
+
+      raise Catalog::ConflictError, "Service Plan already exists for PortfolioItem: #{portfolio_item_id}" if @portfolio_item.service_plans.any?
     end
 
     def process

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -16,5 +16,6 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "Catalog::ApprovalError"             => :service_unavailable,
   "Catalog::SourcesError"              => :service_unavailable,
   "Catalog::RBACError"                 => :service_unavailable,
-  "Discard::DiscardError"              => :bad_request
+  "Discard::DiscardError"              => :bad_request,
+  "Catalog::ConflictError"             => :conflict
 )

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -6,16 +6,16 @@
 ############################################################################
 
 ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
+  "ActionController::ParameterMissing" => :bad_request,
   "ActiveRecord::RecordNotSaved"       => :bad_request,
   "ActiveRecord::RecordInvalid"        => :bad_request,
-  "ActionController::ParameterMissing" => :bad_request,
+  "Catalog::ApprovalError"             => :service_unavailable,
+  "Catalog::ConflictError"             => :conflict,
   "Catalog::InvalidParameter"          => :bad_request,
   "Catalog::NotAuthorized"             => :forbidden,
   "Catalog::OrderUncancelable"         => :bad_request,
-  "Catalog::TopologyError"             => :service_unavailable,
-  "Catalog::ApprovalError"             => :service_unavailable,
-  "Catalog::SourcesError"              => :service_unavailable,
   "Catalog::RBACError"                 => :service_unavailable,
-  "Discard::DiscardError"              => :bad_request,
-  "Catalog::ConflictError"             => :conflict
+  "Catalog::SourcesError"              => :service_unavailable,
+  "Catalog::TopologyError"             => :service_unavailable,
+  "Discard::DiscardError"              => :bad_request
 )

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -7,4 +7,5 @@ module Catalog
   class OrderUncancelable < StandardError; end
   class SourcesError < StandardError; end
   class InvalidSurvey < StandardError; end
+  class ConflictError < StandardError; end
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,11 +1,11 @@
 module Catalog
-  class TopologyError < StandardError; end
-  class RBACError < StandardError; end
   class ApprovalError < StandardError; end
-  class NotAuthorized < StandardError; end
-  class InvalidParameter < StandardError; end
-  class OrderUncancelable < StandardError; end
-  class SourcesError < StandardError; end
-  class InvalidSurvey < StandardError; end
   class ConflictError < StandardError; end
+  class InvalidParameter < StandardError; end
+  class InvalidSurvey < StandardError; end
+  class NotAuthorized < StandardError; end
+  class OrderUncancelable < StandardError; end
+  class RBACError < StandardError; end
+  class SourcesError < StandardError; end
+  class TopologyError < StandardError; end
 end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2467,6 +2467,9 @@
           },
           "404": {
             "description": "Service Plan Not Found."
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
           }
         }
       }
@@ -2802,6 +2805,9 @@
     "responses": {
       "BadRequest": {
         "description": "The entity being created does not have either all the required parameters specified or the parameter value is invalid."
+      },
+      "Conflict": {
+        "description": "The request could not be completed due to a conflict with the current state of the resource."
       },
       "Forbidden": {
         "description": "The caller is forbidden to perform the action."

--- a/spec/requests/service_plans_spec.rb
+++ b/spec/requests/service_plans_spec.rb
@@ -74,16 +74,29 @@ describe "ServicePlansRequests", :type => :request do
   end
 
   describe "#create" do
-    before do
-      post "#{api}/service_plans", :headers => default_headers, :params => {:portfolio_item_id => portfolio_item_without_service_plan.id.to_s}
+    context "when there is not a service_plan for the portfolio_item speicifed" do
+      before do
+        post "#{api}/service_plans", :headers => default_headers, :params => {:portfolio_item_id => portfolio_item_without_service_plan.id.to_s}
+      end
+
+      it "pulls in the service plans" do
+        expect(portfolio_item_without_service_plan.service_plans.count).to eq 1
+      end
+
+      it "returns the imported service plans" do
+        expect(json.first["id"]).to eq portfolio_item_without_service_plan.service_plans.first.id.to_s
+      end
     end
 
-    it "pulls in the service plans" do
-      expect(portfolio_item_without_service_plan.service_plans.count).to eq 1
-    end
+    context "when a service_plan already exists for the portfolio_item specified" do
+      before do
+        post "#{api}/service_plans", :headers => default_headers, :params => {:portfolio_item_id => portfolio_item_without_service_plan.id.to_s}
+        post "#{api}/service_plans", :headers => default_headers, :params => {:portfolio_item_id => portfolio_item_without_service_plan.id.to_s}
+      end
 
-    it "returns the imported service plans" do
-      expect(json.first["id"]).to eq portfolio_item_without_service_plan.service_plans.first.id.to_s
+      it "returns a conflict response" do
+        expect(response).to have_http_status(409)
+      end
     end
   end
 

--- a/spec/requests/service_plans_spec.rb
+++ b/spec/requests/service_plans_spec.rb
@@ -74,7 +74,7 @@ describe "ServicePlansRequests", :type => :request do
   end
 
   describe "#create" do
-    context "when there is not a service_plan for the portfolio_item speicifed" do
+    context "when there is not a service_plan for the portfolio_item specified" do
       before do
         post "#{api}/service_plans", :headers => default_headers, :params => {:portfolio_item_id => portfolio_item_without_service_plan.id.to_s}
       end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1046

Found during QA testing: one can create a bunch of orphaned ServicePlans on a PortfolioItem by using the POST /service_plans endpoint. 

This change makes it so a 409 CONFLICT is thrown when there are already ServicePlans on the specified PortfolioItem.