### PR TITLE
Do not allow ordering if the service offering has been archived

### DIFF
--- a/app/controllers/api/v1/mixins/service_offering_mixin.rb
+++ b/app/controllers/api/v1/mixins/service_offering_mixin.rb
@@ -1,0 +1,20 @@
+module Api
+  module V1
+    module Mixins
+      module ServiceOfferingMixin
+        private
+
+        def service_offering_check
+          order_id = params.require(:order_id)
+          service_offering_service = Catalog::ServiceOffering.new(order_id).process
+          if service_offering_service.archived
+            Rails.logger.error("Service offering for order #{order_id} has been archived and can no longer be ordered")
+            raise Catalog::ServiceOfferingArchived, "Service offering for order #{order_id} has been archived and can no longer be ordered"
+          else
+            @order = service_offering_service.order
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -45,9 +45,11 @@ module Api
       private
 
       def service_offering_check
-        service_offering_service = Catalog::ServiceOffering.new(params.require(:order_id)).process
+        order_id = params.require(:order_id)
+        service_offering_service = Catalog::ServiceOffering.new(order_id).process
         if service_offering_service.archived
-          raise Catalog::ServiceOfferingArchived.new("This service offering has been archived and can no longer be ordered")
+          Rails.logger.error("Service offering for order #{order_id} has been archived and can no longer be ordered")
+          raise Catalog::ServiceOfferingArchived, "Service offering for order #{order_id} has been archived and can no longer be ordered"
         else
           @order = service_offering_service.order
         end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V1
     class OrdersController < ApplicationController
       include Api::V1::Mixins::IndexMixin
+      include Api::V1::Mixins::ServiceOfferingMixin
+
       before_action :read_access_check, :only => %i[show]
       before_action :service_offering_check, :only => %i[submit_order]
 
@@ -40,19 +42,6 @@ module Api
         Catalog::SoftDeleteRestore.new(order, params.require(:restore_key)).process
 
         render :json => order
-      end
-
-      private
-
-      def service_offering_check
-        order_id = params.require(:order_id)
-        service_offering_service = Catalog::ServiceOffering.new(order_id).process
-        if service_offering_service.archived
-          Rails.logger.error("Service offering for order #{order_id} has been archived and can no longer be ordered")
-          raise Catalog::ServiceOfferingArchived, "Service offering for order #{order_id} has been archived and can no longer be ordered"
-        else
-          @order = service_offering_service.order
-        end
       end
     end
   end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -23,7 +23,7 @@ module Api
       end
 
       def submit_order
-        order = Catalog::CreateRequestForAppliedInventories.new(params.require(:order_id)).process.order
+        order = Catalog::CreateRequestForAppliedInventories.new(@order).process.order
         render :json => order
       end
 

--- a/app/services/catalog/create_request_for_applied_inventories.rb
+++ b/app/services/catalog/create_request_for_applied_inventories.rb
@@ -2,8 +2,8 @@ module Catalog
   class CreateRequestForAppliedInventories
     attr_reader :order
 
-    def initialize(order_id)
-      @order = Order.find_by!(:id => order_id)
+    def initialize(order)
+      @order = order
       @item = @order.order_items.first
     end
 

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -15,6 +15,7 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "Catalog::NotAuthorized"             => :forbidden,
   "Catalog::OrderUncancelable"         => :bad_request,
   "Catalog::RBACError"                 => :service_unavailable,
+  "Catalog::ServiceOfferingArchived"   => :bad_request,
   "Catalog::SourcesError"              => :service_unavailable,
   "Catalog::TopologyError"             => :service_unavailable,
   "Discard::DiscardError"              => :bad_request

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -6,6 +6,7 @@ module Catalog
   class NotAuthorized < StandardError; end
   class OrderUncancelable < StandardError; end
   class RBACError < StandardError; end
+  class ServiceOfferingArchived < StandardError; end
   class SourcesError < StandardError; end
   class TopologyError < StandardError; end
 end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -10,7 +10,6 @@ describe "OrderRequests", :type => :request do
 
   describe "#submit_order" do
     let(:service_offering_service) { instance_double("Catalog::ServiceOffering") }
-    let(:service_offering) { TopologicalInventoryApiClient::ServiceOffering.new(:archived_at => archived_at) }
 
     before do
       allow(Catalog::ServiceOffering).to receive(:new).with(order.id.to_s).and_return(service_offering_service)

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -52,7 +52,13 @@ describe "OrderRequests", :type => :request do
     context "when the service offering has been archived" do
       let(:archived) { true }
 
-      it "raises an exception and gives a 400" do
+      it "logs the error" do
+        expect(Rails.logger).to receive(:error).with(/Service offering for order #{order.id} has been archived/)
+
+        post "#{api}/orders/#{order.id}/submit_order", :headers => default_headers
+      end
+
+      it "returns a 400" do
         post "#{api}/orders/#{order.id}/submit_order", :headers => default_headers
 
         expect(response).to have_http_status(:bad_request)

--- a/spec/services/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/catalog/create_request_for_applied_inventories_spec.rb
@@ -1,5 +1,5 @@
 describe Catalog::CreateRequestForAppliedInventories, :type => :service do
-  let(:subject) { described_class.new(order_item.order.id) }
+  let(:subject) { described_class.new(order_item.order) }
   let!(:order_item) { create(:order_item, :portfolio_item => portfolio_item, :service_parameters => "service_parameters") }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => 123) }
 

--- a/spec/services/catalog/service_offering_spec.rb
+++ b/spec/services/catalog/service_offering_spec.rb
@@ -17,7 +17,7 @@ describe Catalog::ServiceOffering do
     let(:service_offering_response) { TopologicalInventoryApiClient::ServiceOffering.new(:archived_at => archived_at) }
 
     before do
-      stub_request(:get, "http://topology/api/topological-inventory/v1.0/service_offerings/123")
+      stub_request(:get, "http://topology/api/topological-inventory/v2.0/service_offerings/123")
         .to_return(:status => 200, :body => service_offering_response.to_json, :headers => default_headers)
     end
 

--- a/spec/services/catalog/service_offering_spec.rb
+++ b/spec/services/catalog/service_offering_spec.rb
@@ -22,7 +22,7 @@ describe Catalog::ServiceOffering do
     end
 
     context "when archived_at is present" do
-      let(:archived_at) { Time.now }
+      let(:archived_at) { Time.current }
 
       it "sets archived to true" do
         expect(subject.process.archived).to be(true)

--- a/spec/services/catalog/service_offering_spec.rb
+++ b/spec/services/catalog/service_offering_spec.rb
@@ -27,6 +27,10 @@ describe Catalog::ServiceOffering do
       it "sets archived to true" do
         expect(subject.process.archived).to be(true)
       end
+
+      it "exposes order" do
+        expect(subject.process.order).to eq(order_item.order)
+      end
     end
 
     context "when archived_at is not present" do
@@ -34,6 +38,10 @@ describe Catalog::ServiceOffering do
 
       it "sets archived to false" do
         expect(subject.process.archived).to be(false)
+      end
+
+      it "exposes order" do
+        expect(subject.process.order).to eq(order_item.order)
       end
     end
   end


### PR DESCRIPTION
This PR looks a little wonky because I'm using `Catalog::ServiceOffering` which existed before, but wasn't used anywhere. So, essentially it's an old file that I deleted and recreated, and the diff isn't very happy. Probably easier to review by looking at both the whole `app/services/catalog/service_offering.rb` file and corresponding spec instead of at the diff for those.

https://projects.engineering.redhat.com/browse/SSP-1020

@syncrou @lindgrenj6 @mkanoor Any of you three please review :)