### PR TITLE
With no ACE's defined in the DB User should get an empty list

### DIFF
--- a/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1/mixins/index_mixin.rb
@@ -36,7 +36,11 @@ module Api
             relation.by_owner
           else
             ids = ace_ids('read', relation.model)
-            ids.any? ? relation.where(:id => ids) : relation
+            if relation.model.respond_to?(:aceable?) && relation.model.aceable?
+              relation.where(:id => ids)
+            else
+              relation
+            end
           end
         end
 

--- a/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1/mixins/index_mixin.rb
@@ -36,7 +36,7 @@ module Api
             relation.by_owner
           else
             ids = ace_ids('read', relation.model)
-            if relation.model.respond_to?(:aceable?) && relation.model.aceable?
+            if relation.model.try(:supports_access_control?)
               relation.where(:id => ids)
             else
               relation

--- a/app/controllers/api/v1/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1/mixins/rbac_mixin.rb
@@ -26,7 +26,7 @@ module Api
           return if catalog_administrator?
 
           ids = access_id_list(verb, klass)
-          if klass.respond_to?(:aceable?) && klass.aceable?
+          if klass.try(:supports_access_control?)
             raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" if ids.any? && ids.exclude?(id)
           end
         end

--- a/app/controllers/api/v1/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1/mixins/rbac_mixin.rb
@@ -25,8 +25,10 @@ module Api
           return unless Insights::API::Common::RBAC::Access.enabled?
           return if catalog_administrator?
 
-          ids = ace_ids(verb, klass)
-          raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" if ids.any? && ids.exclude?(id)
+          ids = access_id_list(verb, klass)
+          if klass.respond_to?(:aceable?) && klass.aceable?
+            raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" if ids.any? && ids.exclude?(id)
+          end
         end
 
         def permission_check(verb, klass = controller_name.classify.constantize)
@@ -50,7 +52,7 @@ module Api
           access_obj = Insights::API::Common::RBAC::Access.new(controller_name.classify.constantize.table_name, verb).process
           raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" unless access_obj.accessible?
 
-          access_obj.id_list
+          ace_ids(verb, klass)
         end
       end
     end

--- a/app/models/concerns/aceable.rb
+++ b/app/models/concerns/aceable.rb
@@ -4,7 +4,7 @@ module Aceable
   included do
     has_many :access_control_entries, :as => :aceable
 
-    def self.aceable?
+    def self.supports_access_control?
       true
     end
   end

--- a/app/models/concerns/aceable.rb
+++ b/app/models/concerns/aceable.rb
@@ -3,5 +3,9 @@ module Aceable
 
   included do
     has_many :access_control_entries, :as => :aceable
+
+    def self.aceable?
+      true
+    end
   end
 end

--- a/spec/requests/portfolios_rbac_read_access_spec.rb
+++ b/spec/requests/portfolios_rbac_read_access_spec.rb
@@ -32,6 +32,21 @@ describe 'Portfolios Read Access RBAC API' do
       end
     end
 
+    context "Catalog User should not see any portfolios by default" do
+      before do
+        allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
+        allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
+        allow(access_obj).to receive(:process).and_return(access_obj)
+      end
+
+      it "gets an empty list" do
+        get "#{api('1.0')}/portfolios", :headers => default_headers
+        expect(response).to have_http_status(:ok)
+        expect(json['meta']['count']).to be_zero
+        expect(json['data']).to be_empty
+      end
+    end
+
     context "Catalog Administrator can see all" do
       before do
         allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(true)


### PR DESCRIPTION
Previously the user was seeing all portfolios when no ACEs existed
in the DB. This PR checks if the class supports ACE's and limits
what the users can see

Fixes #522 