### PR TITLE
Look up service_plan_ref when creating order_item

### DIFF
--- a/app/services/catalog/add_to_order.rb
+++ b/app/services/catalog/add_to_order.rb
@@ -8,14 +8,20 @@ module Catalog
 
     def process
       order = Order.find_by!(:id => @params[:order_id])
-      @order_item = order.order_items.create!(order_item_params)
+      @params.delete(:service_plan_ref)
+      @order_item = order.order_items.create!(order_item_params.merge!(:service_plan_ref => service_plan_ref))
       self
     end
 
     private
 
     def order_item_params
-      @params.permit(:order_id, :portfolio_item_id, :service_plan_ref, :count, :service_parameters => {}, :provider_control_parameters => {})
+      @params.permit(:order_id, :portfolio_item_id, :count, :service_parameters => {}, :provider_control_parameters => {})
+    end
+
+    def service_plan_ref
+      plans = Catalog::ServicePlans.new(@params[:portfolio_item_id]).process.items
+      plans.first["id"]
     end
   end
 end

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -4,12 +4,19 @@ describe "OrderItemsRequests", :type => :request do
       example.call
     end
   end
+  let(:service_plans_instance) { instance_double(Catalog::ServicePlans, :items => [OpenStruct.new(:id => "1")]) }
+
+  before do
+    allow(Catalog::ServicePlans).to receive(:new).and_return(service_plans_instance)
+    allow(service_plans_instance).to receive(:process).and_return(service_plans_instance)
+  end
 
   let!(:order_1) { create(:order) }
   let!(:order_2) { create(:order) }
   let!(:order_3) { create(:order) }
   let!(:order_item_1) { create(:order_item, :order => order_1) }
   let!(:order_item_2) { create(:order_item, :order => order_2) }
+  let!(:portfolio_item) { order_item_1.portfolio_item }
   let(:params) do
     { 'order_id'                    => order_1.id.to_s,
       'portfolio_item_id'           => order_item_1.portfolio_item.id.to_s,


### PR DESCRIPTION
As discussed in #513, now that we're ansible-only we don't really have to worry about there being multiple service_plans on an `order_item`. So when submitting an order we can just look up the proper `service_plan_ref` on the backend.

This is the first step to making `service_plans` more of a `has_one` relationship rather than `has_many`.