### PR TITLE
Remove service_plan_ref from spec

### DIFF
--- a/app/services/catalog/add_to_order.rb
+++ b/app/services/catalog/add_to_order.rb
@@ -8,14 +8,20 @@ module Catalog
 
     def process
       order = Order.find_by!(:id => @params[:order_id])
-      @order_item = order.order_items.create!(order_item_params)
+      @params.delete(:service_plan_ref)
+      @order_item = order.order_items.create!(order_item_params.merge!(:service_plan_ref => service_plan_ref))
       self
     end
 
     private
 
     def order_item_params
-      @params.permit(:order_id, :portfolio_item_id, :service_plan_ref, :count, :service_parameters => {}, :provider_control_parameters => {})
+      @params.permit(:order_id, :portfolio_item_id, :count, :service_parameters => {}, :provider_control_parameters => {})
+    end
+
+    def service_plan_ref
+      plans = Catalog::ServicePlans.new(@params[:portfolio_item_id]).process.items
+      plans.first["id"]
     end
   end
 end

--- a/app/services/catalog/add_to_order.rb
+++ b/app/services/catalog/add_to_order.rb
@@ -8,7 +8,6 @@ module Catalog
 
     def process
       order = Order.find_by!(:id => @params[:order_id])
-      @params.delete(:service_plan_ref)
       @order_item = order.order_items.create!(order_item_params.merge!(:service_plan_ref => service_plan_ref))
       self
     end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -3304,12 +3304,6 @@
             "description": "The provider specific parameters needed to provision this service. This might include namespaces, special keys.",
             "nullable": true
           },
-          "service_plan_ref": {
-            "type": "string",
-            "title": "The Service Plan ref",
-            "description": "Stores the service plan ref from the Topology Service.",
-            "nullable": true
-          },
           "portfolio_item_id": {
             "type": "string",
             "title": "Portfolio Item ID",

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -4,12 +4,19 @@ describe "OrderItemsRequests", :type => :request do
       example.call
     end
   end
+  let(:service_plans_instance) { instance_double(Catalog::ServicePlans, :items => [OpenStruct.new(:id => "1")]) }
+
+  before do
+    allow(Catalog::ServicePlans).to receive(:new).and_return(service_plans_instance)
+    allow(service_plans_instance).to receive(:process).and_return(service_plans_instance)
+  end
 
   let!(:order_1) { create(:order) }
   let!(:order_2) { create(:order) }
   let!(:order_3) { create(:order) }
   let!(:order_item_1) { create(:order_item, :order => order_1) }
   let!(:order_item_2) { create(:order_item, :order => order_2) }
+  let!(:portfolio_item) { order_item_1.portfolio_item }
   let(:params) do
     { 'order_id'                    => order_1.id.to_s,
       'portfolio_item_id'           => order_item_1.portfolio_item.id.to_s,

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -22,8 +22,7 @@ describe "OrderItemsRequests", :type => :request do
       'portfolio_item_id'           => order_item_1.portfolio_item.id.to_s,
       'count'                       => 1,
       'service_parameters'          => {'name' => 'fred'},
-      'provider_control_parameters' => {'age' => 50},
-      'service_plan_ref'            => '10' }
+      'provider_control_parameters' => {'age' => 50}}
   end
 
   describe "CRUD" do

--- a/spec/services/catalog/add_to_order_spec.rb
+++ b/spec/services/catalog/add_to_order_spec.rb
@@ -11,8 +11,7 @@ describe Catalog::AddToOrder, :type => :service do
                                      'portfolio_item_id'           => portfolio_item_id,
                                      'count'                       => 1,
                                      'service_parameters'          => {'name' => 'fred'},
-                                     'provider_control_parameters' => {'age' => 50},
-                                     'service_plan_ref'            => '10')
+                                     'provider_control_parameters' => {'age' => 50})
   end
 
   let(:invalid_params) do


### PR DESCRIPTION
Stage 2 of what was started in #520, this makes the API error out if anyone passes in a `service_plan_ref` through the API when creating an OrderItem.

cc @Hyperkid123 going to need a UI change for this one to be merged. 

cc @gmcculloug @syncrou @eclarizio 