### PR TITLE
Update to use new Approval API objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'topological_inventory-api-client', '~> 1.0', :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby"
 
-gem 'approval-api-client-ruby', :git => 'https://github.com/mkanoor/approval-client', :branch => "master"
+gem 'approval-api-client-ruby', :git => 'https://github.com/RedHatInsights/approval-api-client-ruby', :branch => "master"
 gem 'rbac-api-client', :git => "https://github.com/RedHatInsights/insights-rbac-api-client-ruby", :branch => "master"
 gem 'sources-api-client', :git => 'https://github.com/ManageIQ/sources-api-client-ruby.git', :branch => "master"

--- a/app/services/catalog/cancel_order.rb
+++ b/app/services/catalog/cancel_order.rb
@@ -12,7 +12,7 @@ module Catalog
 
       approval_requests.each do |approval_request|
         Approval::Service.call(ApprovalApiClient::ActionApi) do |api|
-          api.create_action_by_request(approval_request.first.approval_request_ref, canceled_action)
+          api.create_action(approval_request.first.approval_request_ref, canceled_action)
         end
       end
 
@@ -29,7 +29,7 @@ module Catalog
     end
 
     def canceled_action
-      @canceled_action ||= ApprovalApiClient::ActionIn.new(:operation => "cancel")
+      @canceled_action ||= ApprovalApiClient::Action.new(:operation => "cancel")
     end
 
     def raise_uncancelable_error

--- a/spec/factories/approval_requests.rb
+++ b/spec/factories/approval_requests.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :approval_request, :traits => [:has_tenant] do
-    approval_request_ref { "MyString" }
+    sequence(:approval_request_ref)
     state { :undecided }
 
     order_item


### PR DESCRIPTION
Switch to using the `RedHatInsights` approval gem and update our APIs to use the new Approval objects. 