### PR TITLE
Create a progress message and mark order as failed if approval error

### DIFF
--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -15,10 +15,8 @@ module Catalog
       @order.update(:state => "Approval Pending", :order_request_sent_at => Time.now.utc)
       self
     rescue Catalog::ApprovalError => e
+      fail_order
       Rails.logger.error("Error putting in approval Request for #{order.id}: #{e.message}")
-      raise
-    rescue ActiveRecord::RecordInvalid => e
-      Rails.logger.error("Error creating ApprovalRequest object for #{order.id}: #{e.message}")
       raise
     end
 
@@ -36,6 +34,11 @@ module Catalog
       )
 
       order_item.update_message("info", "Approval Request Submitted for ID: #{order_item.approval_requests.last.id}")
+    end
+
+    def fail_order
+      @order.order_items.first.update_message(:error, "Error while creating approval request")
+      @order.update!(:state => "Failed")
     end
   end
 end

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -68,6 +68,21 @@ describe Catalog::CreateApprovalRequest, :type => :service do
         expect { subject.process }.to raise_exception(Catalog::ApprovalError)
         expect(ApprovalRequest.count).to eq(0)
       end
+
+      it "creates a progress message" do
+        expect do
+          subject.process
+          expect(ProgressMessage.last.message).to eq("Error while creating approval request")
+        end
+      end
+
+      it "fails the order" do
+        expect do
+          subject.process
+          order.reload
+          expect(order.state).to eq("Failed")
+        end
+      end
     end
 
     context "without a tenant on the request" do


### PR DESCRIPTION
After digging through an issue with @syncrou and @lindgrenj6, we traced it to a 400 being returned while creating an approval request. However, our progress messages seem to indicate that it got stuck waiting for inventories. This PR creates a new progress message for when it gets stuck in this stage.

I also removed the rescue for the `ActiveRecord::RecordInvalid` because there was no spec for it, and when I went to attempt to create it, I couldn't figure out a way (aside from just straight up mocking `create!`) to return that error. @lindgrenj6 I git-praised the rescue line and you were the one who added it with a spec, but that spec used `ActsAsTenant.without_tenant`.  Now that we have a spec that proves it can work without a tenant, I think removing the rescue is ok. Would like a second pair of eyes on that, though.

@syncrou @lindgrenj6 Please Review.