### PR TITLE
Use fully qualified tag_value instead of separate name, tag, value

### DIFF
--- a/app/services/tags/collect_local_order_resources.rb
+++ b/app/services/tags/collect_local_order_resources.rb
@@ -31,7 +31,7 @@ module Tags
     end
 
     def minimal_tags(tags)
-      tags.collect { |t| { :name => t.name, :namespace => t.namespace, :value => t.value } }
+      tags.collect { |t| { :tag => t.to_tag_string } }
     end
   end
 end

--- a/spec/services/tags/collect_local_order_resources_spec.rb
+++ b/spec/services/tags/collect_local_order_resources_spec.rb
@@ -18,10 +18,10 @@ describe Tags::CollectLocalOrderResources do
         expect(tag_resources).to match(
           [{ :app_name    => 'catalog',
              :object_type => 'PortfolioItem',
-             :tags        => [{ :name => 'Gnocchi', :namespace => 'Charkie', :value => 'Hundley' }] },
+             :tags        => [{ :tag => "/Charkie/Gnocchi=Hundley" }] },
            { :app_name    => 'catalog',
              :object_type => 'Portfolio',
-             :tags        => [{ :name => 'Curious George', :namespace => 'Compass', :value => 'Jumpy Squirrel' }]}]
+             :tags        => [{ :tag => "/Compass/Curious George=Jumpy Squirrel" }] }]
         )
       end
     end
@@ -35,7 +35,7 @@ describe Tags::CollectLocalOrderResources do
         expect(tag_resources).to match(
           [{ :app_name    => 'catalog',
              :object_type => 'PortfolioItem',
-             :tags        => [{ :name => 'Gnocchi', :namespace => 'Charkie', :value => 'Hundley' }] }]
+             :tags        => [{ :tag => "/Charkie/Gnocchi=Hundley" }] }]
         )
       end
     end


### PR DESCRIPTION
The earlier version of tagging used 3 attributes to communicate
tag information between systems (namspace, name and value)
The new version uses a single field called tag => /namespace/name=value