### PR TITLE
Use tag strings for remote tags instead of hash with separate values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'rest-client', '>= 1.8.0'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'topological_inventory-api-client', '~> 1.0', :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby"
+gem 'topological_inventory-api-client', '~> 2.0', :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby"
 
 gem 'approval-api-client-ruby', :git => 'https://github.com/RedHatInsights/approval-api-client-ruby', :branch => "master"
 gem 'rbac-api-client', :git => "https://github.com/RedHatInsights/insights-rbac-api-client-ruby", :branch => "master"

--- a/app/services/tags/topology/remote_inventory.rb
+++ b/app/services/tags/topology/remote_inventory.rb
@@ -18,7 +18,7 @@ module Tags
       def consolidate_inventory_tags
         @tag_resources = all_tag_collections.collect do |tag_collection|
           tags = tag_collection.collect do |tag|
-            {:tag => "#{tag.namespace}/#{tag.name}=#{tag.value}"}
+            {:tag => tag.tag}
           end
 
           {

--- a/app/services/tags/topology/remote_inventory.rb
+++ b/app/services/tags/topology/remote_inventory.rb
@@ -18,7 +18,7 @@ module Tags
       def consolidate_inventory_tags
         @tag_resources = all_tag_collections.collect do |tag_collection|
           tags = tag_collection.collect do |tag|
-            tag.to_hash.slice(:name, :namespace, :value)
+            {:tag => "#{tag.namespace}/#{tag.name}=#{tag.value}"}
           end
 
           {

--- a/spec/services/tags/topology/remote_inventory_spec.rb
+++ b/spec/services/tags/topology/remote_inventory_spec.rb
@@ -41,16 +41,16 @@ describe Tags::Topology::RemoteInventory, :type => :service do
             :app_name    => "topology",
             :object_type => "ServiceInventory",
             :tags        => [
-              {:name => "tag1", :namespace => "tag1namespace", :value => "tag1value"},
-              {:name => "tag2", :namespace => "tag2namespace", :value => "tag2value"}
+              {:tag => "tag1namespace/tag1=tag1value"},
+              {:tag => "tag2namespace/tag2=tag2value"}
             ]
           },
           {
             :app_name    => "topology",
             :object_type => "ServiceInventory",
             :tags        => [
-              {:name => "tag3", :namespace => "tag3namespace", :value => "tag3value"},
-              {:name => "tag4", :namespace => "tag4namespace", :value => "tag4value"}
+              {:tag => "tag3namespace/tag3=tag3value"},
+              {:tag => "tag4namespace/tag4=tag4value"}
             ]
           }
         ]

--- a/spec/services/tags/topology/remote_inventory_spec.rb
+++ b/spec/services/tags/topology/remote_inventory_spec.rb
@@ -14,20 +14,20 @@ describe Tags::Topology::RemoteInventory, :type => :service do
   describe "#process" do
     let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:applied_inventories => ["1", "2"]}) }
     let(:tags_collection1) { TopologicalInventoryApiClient::TagsCollection.new(:data => [tag1, tag2]) }
-    let(:tag1) { TopologicalInventoryApiClient::Tag.new(:name => "tag1", :namespace => "tag1namespace", :value => "tag1value", :description => "tag1description") }
-    let(:tag2) { TopologicalInventoryApiClient::Tag.new(:name => "tag2", :namespace => "tag2namespace", :value => "tag2value") }
+    let(:tag1) { TopologicalInventoryApiClient::Tag.new(:tag => "/tag1namespace/tag1=tag1value") }
+    let(:tag2) { TopologicalInventoryApiClient::Tag.new(:tag => "/tag2namespace/tag2=tag2value") }
 
     let(:tags_collection2) { TopologicalInventoryApiClient::TagsCollection.new(:data => [tag3, tag4]) }
-    let(:tag3) { TopologicalInventoryApiClient::Tag.new(:name => "tag3", :namespace => "tag3namespace", :value => "tag3value") }
-    let(:tag4) { TopologicalInventoryApiClient::Tag.new(:name => "tag4", :namespace => "tag4namespace", :value => "tag4value") }
+    let(:tag3) { TopologicalInventoryApiClient::Tag.new(:tag => "/tag3namespace/tag3=tag3value") }
+    let(:tag4) { TopologicalInventoryApiClient::Tag.new(:tag => "/tag4namespace/tag4=tag4value") }
 
     before do
-      stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_inventories/1/tags").to_return(
+      stub_request(:get, "http://localhost/api/topological-inventory/v2.0/service_inventories/1/tags").to_return(
         :status  => 200,
         :body    => tags_collection1.to_json,
         :headers => default_headers
       )
-      stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_inventories/2/tags").to_return(
+      stub_request(:get, "http://localhost/api/topological-inventory/v2.0/service_inventories/2/tags").to_return(
         :status  => 200,
         :body    => tags_collection2.to_json,
         :headers => default_headers
@@ -41,16 +41,16 @@ describe Tags::Topology::RemoteInventory, :type => :service do
             :app_name    => "topology",
             :object_type => "ServiceInventory",
             :tags        => [
-              {:tag => "tag1namespace/tag1=tag1value"},
-              {:tag => "tag2namespace/tag2=tag2value"}
+              {:tag => "/tag1namespace/tag1=tag1value"},
+              {:tag => "/tag2namespace/tag2=tag2value"}
             ]
           },
           {
             :app_name    => "topology",
             :object_type => "ServiceInventory",
             :tags        => [
-              {:tag => "tag3namespace/tag3=tag3value"},
-              {:tag => "tag4namespace/tag4=tag4value"}
+              {:tag => "/tag3namespace/tag3=tag3value"},
+              {:tag => "/tag4namespace/tag4=tag4value"}
             ]
           }
         ]


### PR DESCRIPTION
As a corollary to #530 for remote tags, this PR uses the built in tag strings instead of separating out name, namespace, and value into a hash.

@mkanoor Please Review.