### PR TITLE
Do not populate ServicePlan#modified by default

### DIFF
--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -29,7 +29,7 @@ module Api
       end
 
       def modified
-        plan = Catalog::ServicePlanJson.new(:service_plan_id => params.require(:service_plan_id)).process.json
+        plan = Catalog::ServicePlanJson.new(:service_plan_id => params.require(:service_plan_id), :schema => "modified").process.json
 
         if plan["create_json_schema"]
           render :json => plan

--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -14,7 +14,6 @@ module Catalog
           :name              => schema["name"],
           :description       => schema["description"],
           :base              => schema["create_json_schema"],
-          :modified          => schema["create_json_schema"],
           :portfolio_item_id => @portfolio_item.id
         )
       end

--- a/app/services/catalog/service_plan_json.rb
+++ b/app/services/catalog/service_plan_json.rb
@@ -17,9 +17,10 @@ module Catalog
       relevant_service_plans.each do |plan|
         @reference = plan.portfolio_item.service_offering_ref
         @portfolio_item_id = plan.portfolio_item.id
+        @modified = plan.modified.present?
         @service_plan = OpenStruct.new(
           :id                 => plan.id,
-          :create_json_schema => plan.send(@opts[:schema] || "modified"),
+          :create_json_schema => relevant_schema(plan),
           :name               => plan.name,
           :description        => plan.description
         )
@@ -38,6 +39,17 @@ module Catalog
 
     def relevant_service_plans
       @opts[:collection] ? @service_plans : [@service_plans.first]
+    end
+
+    def relevant_schema(plan)
+      case @opts[:schema]
+      when "base"
+        plan.base
+      when "modified"
+        plan.modified
+      else
+        plan.send(:modified) || plan.send(:base)
+      end
     end
   end
 end

--- a/app/services/catalog/service_plans.rb
+++ b/app/services/catalog/service_plans.rb
@@ -10,6 +10,7 @@ module Catalog
 
     def process
       @reference = PortfolioItem.find(@portfolio_item_id).service_offering_ref
+      @modified = false
 
       TopologicalInventory.call do |api_instance|
         service_offering = api_instance.show_service_offering(@reference)

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -3524,6 +3524,12 @@
             "title": "ID",
             "description": "The unique identifier for this service plan.",
             "readOnly": true
+          },
+          "modified": {
+            "type": "boolean",
+            "title": "Modified",
+            "description": "Whether or not the ServicePlan has a modified create_json_schema property",
+            "readOnly": true
           }
         }
       },

--- a/schemas/json/service_plan.erb
+++ b/schemas/json/service_plan.erb
@@ -4,5 +4,6 @@
   "create_json_schema": <%= @service_plan.create_json_schema.to_json %>,
   "name": "<%= @service_plan.name %>",
   "description": "<%= @service_plan.description %>",
-  "portfolio_item_id": "<%= @portfolio_item_id %>"
+  "portfolio_item_id": "<%= @portfolio_item_id %>",
+  "modified": <%= @modified %>
 }

--- a/spec/requests/api/v1.0/service_plans_spec.rb
+++ b/spec/requests/api/v1.0/service_plans_spec.rb
@@ -55,6 +55,10 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1] do
       it "returns the newly created ServicePlan in an array" do
         expect(json.first["create_json_schema"]).to eq topo_service_plan.create_json_schema
       end
+
+      it "shows modified as false" do
+        expect(json.first["modified"]).to be_falsey
+      end
     end
   end
 
@@ -69,7 +73,7 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1] do
 
     it "returns the specified service_plan" do
       expect(json["id"]).to eq service_plan.id.to_s
-      expect(json.keys).to match_array %w[service_offering_id create_json_schema portfolio_item_id id description name]
+      expect(json.keys).to match_array %w[service_offering_id create_json_schema portfolio_item_id id description name modified]
     end
   end
 
@@ -127,6 +131,10 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1] do
       it "returns the modified schema from the service_plan" do
         expect(json["create_json_schema"]["schema"]).to eq service_plan.modified["schema"]
         expect(json["create_json_schema"]["schema"]).not_to eq service_plan.base["schema"]
+      end
+
+      it "shows modified as true" do
+        expect(json["modified"]).to be_truthy
       end
     end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1047

After speaking with @Hyperkid123 he (currently) has no way to tell if a survey has been edited yet. 

To fix this, we can just stop populating the modified column by default and let it return a `204` when he tries to query it, that way he knows it hasn't been modified until someone actually modifies the survey. 

_EDIT:_ We are also adding a field to the `ServicePlan` response per the ticket, to tell whether or not the survey has been modified. That way it saves one request. 

@miq-bot add_reviewer syncrou