### PR TITLE
Gem updates based on Hakiri scan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ gem 'mimemagic', '~> 0.3.3'
 gem 'more_core_extensions', '~>3.5'
 gem 'pg', '~> 1.0', :require => false
 gem 'prometheus-client', '~> 0.8.0'
-gem 'puma', '~> 3.0'
-gem 'rack-cors', '>= 0.4.1'
+gem 'puma', '~> 3.12.2'
+gem 'rack-cors', '>= 1.0.4'
 gem 'rest-client', '>= 1.8.0'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
Updated gems:
`gem 'puma', '~> 3.12.2'`
`gem 'rack-cors', '>= 1.0.4'`