### PR TITLE
Add survey comparison check during #show action for service plans

### DIFF
--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -19,7 +19,8 @@ module Api
       end
 
       def show
-        svc = Catalog::ServicePlanJson.new(:service_plan_id => params.require(:id))
+        service_plan = Catalog::ServicePlanCompare.new(params.require(:id)).process.service_plan
+        svc = Catalog::ServicePlanJson.new(:service_plans => [service_plan])
         render :json => svc.process.json
       end
 

--- a/app/services/catalog/service_plan_compare.rb
+++ b/app/services/catalog/service_plan_compare.rb
@@ -1,0 +1,21 @@
+module Catalog
+  class ServicePlanCompare
+    attr_reader :service_plan
+
+    def initialize(service_plan_id)
+      @service_plan = ServicePlan.find(service_plan_id)
+    end
+
+    def process
+      raise Catalog::InvalidSurvey, "Base survey does not match Topology" if survey_changed?
+
+      self
+    end
+
+    private
+
+    def survey_changed?
+      Catalog::SurveyCompare.changed?(@service_plan)
+    end
+  end
+end

--- a/app/services/catalog/service_plan_json.rb
+++ b/app/services/catalog/service_plan_json.rb
@@ -7,6 +7,8 @@ module Catalog
         @service_plans = ServicePlan.where(:id => opts[:service_plan_id])
       elsif opts.key?(:portfolio_item_id)
         @service_plans = ServicePlan.where(:portfolio_item_id => opts[:portfolio_item_id])
+      elsif opts.key?(:service_plans)
+        @service_plans = opts[:service_plans]
       end
 
       @opts = opts

--- a/spec/lib/catalog/survey_compare_spec.rb
+++ b/spec/lib/catalog/survey_compare_spec.rb
@@ -1,0 +1,45 @@
+describe Catalog::SurveyCompare do
+  let!(:portfolio_item) { service_plan.portfolio_item }
+  let!(:service_offering_ref) { portfolio_item.service_offering_ref }
+  let(:valid_ddf) { JSON.parse(File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json"))) }
+
+  let(:topo_service_plan) do
+    TopologicalInventoryApiClient::ServicePlan.new(
+      :name               => "The Plan",
+      :id                 => "1",
+      :description        => "A Service Plan",
+      :create_json_schema => valid_ddf
+    )
+  end
+
+  let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => [topo_service_plan]) }
+
+  around do |example|
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology", :BYPASS_RBAC => 'true') do
+      Insights::API::Common::Request.with_request(default_request) { example.call }
+    end
+  end
+
+  before do
+    stub_request(:get, topological_url("service_offerings/#{service_offering_ref}/service_plans"))
+      .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)
+  end
+
+  describe "#changed?" do
+    context "when the base has changed from topology" do
+      let(:service_plan) { create(:service_plan) }
+
+      it "returns true" do
+        expect(Catalog::SurveyCompare.changed?(service_plan)).to be true
+      end
+    end
+
+    context "when the base has not changed from topology" do
+      let(:service_plan) { create(:service_plan, :base => valid_ddf) }
+
+      it "returns false" do
+        expect(Catalog::SurveyCompare.changed?(service_plan)).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1.0/service_plans_spec.rb
+++ b/spec/requests/api/v1.0/service_plans_spec.rb
@@ -67,13 +67,23 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1] do
       get "#{api_version}/service_plans/#{service_plan.id}", :headers => default_headers
     end
 
-    it "returns a 200" do
-      expect(response).to have_http_status :ok
+    context "when the service plan base is different than Topology's base" do
+      let(:service_plan) { create(:service_plan) }
+
+      it "returns a 400" do
+        expect(response).to have_http_status(400)
+      end
     end
 
-    it "returns the specified service_plan" do
-      expect(json["id"]).to eq service_plan.id.to_s
-      expect(json.keys).to match_array %w[service_offering_id create_json_schema portfolio_item_id id description name modified]
+    context "when the service plan has not changed" do
+      it "returns a 200" do
+        expect(response).to have_http_status :ok
+      end
+
+      it "returns the specified service_plan" do
+        expect(json["id"]).to eq service_plan.id.to_s
+        expect(json.keys).to match_array %w[service_offering_id create_json_schema portfolio_item_id id description name modified]
+      end
     end
   end
 

--- a/spec/services/catalog/service_plan_compare_spec.rb
+++ b/spec/services/catalog/service_plan_compare_spec.rb
@@ -1,0 +1,31 @@
+describe Catalog::ServicePlanCompare do
+  let(:subject) { described_class.new(service_plan.id) }
+
+  let(:service_plan) { create(:service_plan) }
+
+  before do
+    allow(Catalog::SurveyCompare).to receive(:changed?).with(service_plan).and_return(changed)
+  end
+
+  describe "#process" do
+    context "when the base has changed from topology" do
+      let(:changed) { true }
+
+      it "raises a Catalog::InvalidSurvey error" do
+        expect { subject.process }.to raise_error(Catalog::InvalidSurvey, "Base survey does not match Topology")
+      end
+    end
+
+    context "when the base has not changed from topology" do
+      let(:changed) { false }
+
+      it "does not raise an error" do
+        expect { subject.process }.not_to raise_error
+      end
+
+      it "sets the service plan attribute" do
+        expect(subject.process.service_plan).to eq(service_plan)
+      end
+    end
+  end
+end

--- a/spec/services/catalog/service_plan_json_spec.rb
+++ b/spec/services/catalog/service_plan_json_spec.rb
@@ -20,6 +20,14 @@ describe Catalog::ServicePlanJson, :type => :service do
       end
     end
 
+    context "when rendering a service plan from a list of service plans" do
+      let(:params) { {:service_plans => [service_plan]} }
+
+      it "renders the specified service_plan schema" do
+        expect(subject["create_json_schema"]).to eq service_plan.modified
+      end
+    end
+
     context "when specifying the collection flag" do
       let(:params) { {:service_plan_id => service_plan.id, :collection => true} }
 


### PR DESCRIPTION
When we edit a service plan the UI will first be calling the #show method to fetch it for displaying, so we compare the surveys at this time. If Topology has changed the base survey we throw an error so the UI can figure out what to do from there.

@Hyperkid123 Just a heads-up you will potentially have to worry about the 400 error after this goes through so you can reset or do whatever you need to do :).

@syncrou @lindgrenj6 Please review.

https://projects.engineering.redhat.com/browse/SSP-1002