### PR TITLE
Update icon responses to include `format: binary` so they show up in …

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -582,7 +582,22 @@
             "description": "Portfolio Icon",
             "content": {
               "image/svg+xml": {
-                "example": "<svg rel=\"stylesheet\">thing</svg>"
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
               }
             }
           },
@@ -1937,7 +1952,22 @@
             "description": "Portfolio Item Icon",
             "content": {
               "image/svg+xml": {
-                "example": "<svg rel=\"stylesheet\">thing</svg>"
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
               }
             }
           },
@@ -2162,7 +2192,22 @@
             "description": "Portfolio Item Icon",
             "content": {
               "image/svg+xml": {
-                "example": "<svg rel=\"stylesheet\">thing</svg>"
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
               }
             }
           },


### PR DESCRIPTION
…the client correctly.

https://projects.engineering.redhat.com/browse/SSP-1088

Found out the `responses` objects cna handle multiple types, so updated this to handle _all_ of the icon return types (without having to use a `oneOf`!), also changing the format to binary makes the client handle the binary download. 

@miq-bot add_reviewer syncrou
@miq-bot add_reviewer mkanoor