### PR TITLE
Use payload instead of looking up task in Topology

### DIFF
--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -1,11 +1,10 @@
 describe Catalog::DetermineTaskRelevancy, :type => :service do
   let(:subject) { described_class.new(topic) }
-  let(:topic) { OpenStruct.new(:payload => {"task_id" => "123"}, :message => "message") }
-
-  around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology/") do
-      example.call
-    end
+  let(:topic) do
+    OpenStruct.new(
+      :payload => {"task_id" => "123", "status" => status, "state" => state, "context" => payload_context},
+      :message => "message"
+    )
   end
 
   let!(:order_item) do
@@ -19,85 +18,122 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
   end
 
   describe "#process" do
-    before do
-      stub_request(:get, topological_url("tasks/123")).to_return(
-        :status => 200, :body => task.to_json, :headers => default_headers
-      )
-    end
+    context "when the state is running" do
+      let(:state) { "running" }
+      let(:status) { "ok" }
+      let(:payload_context) { nil }
 
-    context "when the task context has a key path of [:service_instance][:id]" do
-      let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:id => "321"}}) }
-      let(:update_order_item) { instance_double("Catalog::UpdateOrderItem") }
-
-      before do
-        allow(Catalog::UpdateOrderItem).to receive(:new).with(topic, task).and_return(update_order_item)
-      end
-
-      it "delegates to updating the order item" do
-        expect(update_order_item).to receive(:process)
+      it "updates the item with a progress message" do
         subject.process
-      end
-    end
-
-    context "when the task context has a key path of [:applied_inventories]" do
-      let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:applied_inventories => ["1", "2"]}) }
-      let(:create_approval_request) { instance_double("Catalog::CreateApprovalRequest") }
-
-      before do
-        allow(Catalog::CreateApprovalRequest).to receive(:new).with(task).and_return(create_approval_request)
+        progress_message = ProgressMessage.last
+        expect(progress_message.level).to eq("info")
+        expect(progress_message.message).to match(/Task update/)
+        expect(progress_message.order_item_id).to eq(order_item.id.to_s)
       end
 
-      it "delegates to creating the approval request" do
-        expect(create_approval_request).to receive(:process)
-        subject.process
-      end
-    end
-
-    context "when the task context does not have either key path" do
-      let(:task) do
-        TopologicalInventoryApiClient::Task.new(
-          :state   => "Completed",
-          :status  => status,
-          :context => {:error => "Undefined method oh noes"}
+      it "logs an info message" do
+        allow(Rails.logger).to receive(:info).with(anything)
+        expect(Rails.logger).to receive(:info).with(
+          "Task update. State: running. Status: ok. Context: "
         )
+        subject.process
+      end
+    end
+
+    context "when the state is something else" do
+      let(:state) { "what" }
+      let(:status) { "ok" }
+      let(:payload_context) { nil }
+
+      it "updates the item with a progress message" do
+        subject.process
+        progress_message = ProgressMessage.last
+        expect(progress_message.level).to eq("info")
+        expect(progress_message.message).to match(/Task update/)
+        expect(progress_message.order_item_id).to eq(order_item.id.to_s)
       end
 
-      context "when the status is 'error'" do
-        let(:status) { "error" }
+      it "logs an info message" do
+        allow(Rails.logger).to receive(:info).with(anything)
+        expect(Rails.logger).to receive(:info).with(
+          "Task update. State: what. Status: ok. Context: "
+        )
+        subject.process
+      end
+    end
 
-        it "updates the item with a progress message" do
-          subject.process
-          progress_message = ProgressMessage.last
-          expect(progress_message.level).to eq("error")
-          expect(progress_message.message).to match(/Topology task update/)
-          expect(progress_message.order_item_id).to eq(order_item.id.to_s)
+    context "when the state is completed" do
+      let(:state) { "completed" }
+      let(:status) { "ok" }
+
+      context "when the task context has a key path of [:service_instance][:id]" do
+        let(:payload_context) { {"service_instance" => {"id" => "321"}} }
+        let(:update_order_item) { instance_double("Catalog::UpdateOrderItem") }
+
+        before do
+          allow(Catalog::UpdateOrderItem).to receive(:new).and_return(update_order_item)
         end
 
-        it "logs an error" do
-          expect(Rails.logger).to receive(:error).with(
-            "Topology task update. State: #{task.state}. Status: #{task.status}. Context: #{task.context}"
-          )
+        it "delegates to updating the order item" do
+          expect(update_order_item).to receive(:process)
           subject.process
         end
       end
 
-      context "when the status is not 'error'" do
-        let(:status) { "updated" }
+      context "when the task context has a key path of [:applied_inventories]" do
+        let(:payload_context) { {"applied_inventories" => ["1", "2"]} }
+        let(:create_approval_request) { instance_double("Catalog::CreateApprovalRequest") }
 
-        it "updates the item with a progress message" do
-          subject.process
-          progress_message = ProgressMessage.last
-          expect(progress_message.level).to eq("info")
-          expect(progress_message.message).to match(/Topology task update/)
-          expect(progress_message.order_item_id).to eq(order_item.id.to_s)
+        before do
+          allow(Catalog::CreateApprovalRequest).to receive(:new).and_return(create_approval_request)
         end
 
-        it "logs an info message" do
-          allow(Rails.logger).to receive(:info).with(anything)
-          expect(Rails.logger).to receive(:info).with(
-            "Topology task update. State: #{task.state}. Status: #{task.status}. Context: #{task.context}"
-          )
+        it "delegates to creating the approval request" do
+          expect(create_approval_request).to receive(:process)
           subject.process
+        end
+      end
+
+      context "when the task context does not have either key path" do
+        let(:payload_context) { {"error" => "Undefined method oh noes"} }
+
+        context "when the status is 'error'" do
+          let(:status) { "error" }
+
+          it "updates the item with a progress message" do
+            subject.process
+            progress_message = ProgressMessage.last
+            expect(progress_message.level).to eq("error")
+            expect(progress_message.message).to match(/Task update/)
+            expect(progress_message.order_item_id).to eq(order_item.id.to_s)
+          end
+
+          it "logs an error" do
+            expect(Rails.logger).to receive(:error).with(
+              "Task update. State: completed. Status: error. Context: #{payload_context}"
+            )
+            subject.process
+          end
+        end
+
+        context "when the status is not 'error'" do
+          let(:status) { "updated" }
+
+          it "updates the item with a progress message" do
+            subject.process
+            progress_message = ProgressMessage.last
+            expect(progress_message.level).to eq("info")
+            expect(progress_message.message).to match(/Task update/)
+            expect(progress_message.order_item_id).to eq(order_item.id.to_s)
+          end
+
+          it "logs an info message" do
+            allow(Rails.logger).to receive(:info).with(anything)
+            expect(Rails.logger).to receive(:info).with(
+              "Task update. State: completed. Status: updated. Context: #{payload_context}"
+            )
+            subject.process
+          end
         end
       end
     end


### PR DESCRIPTION
Previously, from my understanding, the only thing we were getting back from the task events was the `task_id` itself, but after looking at the logs, we get back the status, state, and context (if it exists). This means we don't have to look up the task from Topology, since it's sent already to us.

So instead, we use this payload and build our own local task object (this could be changed later to simply use the payload, but I didn't want to make a bunch of underlying changes to the other classes using the `task` object).

This also includes a check to ensure that only the logic to determine what to do gets ran when the task is "completed", and otherwise it logs a message and adds a progress message to the order item.

@syncrou @lindgrenj6 @mkanoor Please Review.