### PR TITLE
Include task ID in task creation as a reference for the order_item

### DIFF
--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -7,6 +7,7 @@ module Catalog
     def process
       Insights::API::Common::Request.with_request(order_item_context) do
         @task = TopologicalInventoryApiClient::Task.new(
+          :id      => @topic.payload["task_id"],
           :state   => @topic.payload["state"],
           :status  => @topic.payload["status"],
           :context => @topic.payload["context"].try(&:with_indifferent_access)

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -83,9 +83,27 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
       context "when the task context has a key path of [:applied_inventories]" do
         let(:payload_context) { {"applied_inventories" => ["1", "2"]} }
         let(:create_approval_request) { instance_double("Catalog::CreateApprovalRequest") }
+        let(:task) do
+          TopologicalInventoryApiClient::Task.new(
+            :id      => "123",
+            :state   => "completed",
+            :status  => "ok",
+            :context => {"applied_inventories" => ["1", "2"]}
+          )
+        end
 
         before do
-          allow(Catalog::CreateApprovalRequest).to receive(:new).and_return(create_approval_request)
+          allow(Catalog::CreateApprovalRequest).to receive(:new).with(task).and_return(create_approval_request)
+        end
+
+        it "creates a task with id, state, status and context" do
+          expect(TopologicalInventoryApiClient::Task).to receive(:new).with(
+            :id      => "123",
+            :state   => "completed",
+            :status  => "ok",
+            :context => {"applied_inventories" => ["1", "2"]}
+          ).and_return(task)
+          subject.process
         end
 
         it "delegates to creating the approval request" do


### PR DESCRIPTION
Forgot to include the task id itself, which means when we go to look up the order item by `topology_task_ref` in `CreateApprovalRequest`, we don't find anything. Woopsies.

@syncrou Please review.