### PR TITLE
Change IconsController#raw_data method to remove 400's in the logs

### DIFF
--- a/app/controllers/api/v1/icons_controller.rb
+++ b/app/controllers/api/v1/icons_controller.rb
@@ -50,9 +50,9 @@ module Api
         if ids[:icon_id].present?
           Icon.find(ids[:icon_id])
         elsif ids[:portfolio_item_id].present?
-          PortfolioItem.find(ids[:portfolio_item_id]).icon
+          Icon.find_by!(:restore_to => PortfolioItem.find(ids[:portfolio_item_id]))
         elsif ids[:portfolio_id].present?
-          Portfolio.find(ids[:portfolio_id]).icon
+          Icon.find_by!(:restore_to => Portfolio.find(ids[:portfolio_id]))
         end
       end
     end

--- a/spec/requests/api/v1.0/icons_spec.rb
+++ b/spec/requests/api/v1.0/icons_spec.rb
@@ -185,8 +185,19 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
     end
 
     context "when the icon does not exist" do
+      before do
+        portfolio_item.icon.discard
+        portfolio.icon.discard
+      end
+
       it "/portfolio_items/{id}/icon returns no content" do
-        get "#{api_version}/portfolio_items/0/icon", :headers => default_headers
+        get "#{api_version}/portfolio_items/#{portfolio_item.id}/icon", :headers => default_headers
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "/portfolios/{id}/icon returns no content" do
+        get "#{api_version}/portfolios/#{portfolio.id}/icon", :headers => default_headers
 
         expect(response).to have_http_status(:no_content)
       end


### PR DESCRIPTION
I thought I handled this before - turns out that was only for the `/icons/:id/icon_data` endpoint OR when the PortfolioItem wasn't found for `/portfolio_items/:id/icon`.

This fixes it by looking up the icon by `:restore_to` object, so it returns a 204 when there is not an icon present for _all_ the icon related endpoints. 

@miq-bot add_reviewer syncrou
@miq-bot add_reviewer eclarizio