### PR TITLE
Force payload parameter to be a hash instead of a parameter object

### DIFF
--- a/app/controllers/internal/v0/notify_controller.rb
+++ b/app/controllers/internal/v0/notify_controller.rb
@@ -18,7 +18,7 @@ module Internal
       def notify_task
         Rails.logger.info("#notify_task incoming parameters: #{params}")
         task_id = params.require(:task_id)
-        payload = params.require(:payload)
+        payload = params.require(:payload).permit!.to_h
         message = params.require(:message)
 
         Rails.logger.info("Notification about task id: #{task_id}, payload: #{payload}, message: #{message}")

--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -20,6 +20,7 @@ module Catalog
     rescue StandardError => exception
       add_update_message(:error) unless @task.nil?
       Rails.logger.error(exception.inspect)
+      raise
     end
 
     private

--- a/spec/controllers/internal/v1x0/notify_controller_spec.rb
+++ b/spec/controllers/internal/v1x0/notify_controller_spec.rb
@@ -35,6 +35,15 @@ describe Internal::V1x0::NotifyController, :type => [:request, :v1_internal] do
       allow(determine_task_relevancy).to receive(:process)
     end
 
+    it "converts the payload into a hash" do
+      RSpec::Matchers.define :not_a_parameter do
+        match { |actual| actual.class != ActionController::Parameters }
+      end
+
+      expect(Catalog::DetermineTaskRelevancy).to receive(:new).with(having_attributes(:payload => not_a_parameter))
+      post "#{api_version}/notify/task/321", :headers => default_headers, :params => {:payload => {:status => "test"}, :message => "message"}
+    end
+
     it "delegates to another service" do
       expect(determine_task_relevancy).to receive(:process)
       post "#{api_version}/notify/task/321", :headers => default_headers, :params => {:payload => {:status => "test"}, :message => "message"}


### PR DESCRIPTION
The `ActionController::Parameters` class, despite being a subclass of `Hash`, for some reason does not allow the `with_indifferent_access` method on it. This forces the `payload` parameter to be a hash so that we can then treat it indifferently.

@syncrou @lindgrenj6 