### PR TITLE
Validate image size when creating/updating an icon

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,11 +1,13 @@
 class Image < ApplicationRecord
   XML_HEADER = "<?xml version=\"1.0\"?>".freeze
+  MAX_IMAGE_SIZE = 250.kilobytes
   acts_as_tenant(:tenant)
 
   validates :content, :presence => true
   validates :extension,
             :presence  => true,
             :inclusion => { :in => %w[PNG JPEG SVG], :message => 'must be a PNG, JPEG, or SVG' }
+  validate :image_size
 
   has_many :icons, :dependent => :nullify
 
@@ -29,5 +31,13 @@ class Image < ApplicationRecord
 
   def decoded_image
     @decoded_image ||= Base64.decode64(content)
+  end
+
+  private
+
+  def image_size
+    if decoded_image.bytes.count > MAX_IMAGE_SIZE
+      raise Catalog::InvalidParameter, "Image size exceeds max limit of #{MAX_IMAGE_SIZE.to_s(:human_size)}"
+    end
   end
 end

--- a/spec/requests/api/v1.0/icons_spec.rb
+++ b/spec/requests/api/v1.0/icons_spec.rb
@@ -50,8 +50,11 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
              :content   => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.png"))),
              :extension => "PNG")
     end
+    let(:max_image_size) { Image::MAX_IMAGE_SIZE }
 
     before do
+      stub_const("Image::MAX_IMAGE_SIZE", max_image_size)
+
       post "#{api_version}/icons", :params => params, :headers => default_headers, :as => :form
     end
 
@@ -136,6 +139,18 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
 
       it "makes a new image and icon" do
         expect(json["image_id"]).to_not eq image.id
+      end
+    end
+
+    context "when uploading an image that is too large" do
+      let(:params) do
+        {:content           => form_upload_test_image("miq_logo.jpg"),
+         :portfolio_item_id => portfolio_item.id}
+      end
+      let(:max_image_size) { 1.kilobyte }
+
+      it "returns bad request" do
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1094

Short and sweet: limit the size of icons uploaded by the user

Long and drawn out: we don't want people uploading 10MB PNGs and wondering why Catalog is slow for them, so we add a check in the `Image` model so that it checks the size before saving the new image, this accounts for both create/update. Heres an example of the error message since I'm using `Integer#to_s` with a nifty parameter `:to_human_size` that will adapt if we eve change this: `Catalog::InvalidParameter: Image too large, must be 250 KB or lower`

(bonus: found 3 specs that weren't actually doing the right thing, fixed those too)

@miq-bot add_reviewer syncrou
@miq-bot add_reviewer eclarizio
@miq-bot add_reviewer mkanoor