### PR TITLE
[WIP] Checking Parents Access

### DIFF
--- a/app/controllers/api/v1/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1/mixins/rbac_mixin.rb
@@ -21,6 +21,12 @@ module Api
           resource_check('delete')
         end
 
+        def parent_check(parent_relation, verb, id = params[:id], klass = controller_name.classify.constantize)
+          obj = klass.find(id)
+          parent_obj = obj.send(parent_relation)
+          resource_check(verb, parent_obj.id.to_s, parent_obj.class)
+        end
+
         def resource_check(verb, id = params[:id], klass = controller_name.classify.constantize)
           return unless Insights::API::Common::RBAC::Access.enabled?
           return if catalog_administrator?
@@ -48,7 +54,7 @@ module Api
         end
 
         def access_id_list(verb, klass)
-          access_obj = Insights::API::Common::RBAC::Access.new(controller_name.classify.constantize.table_name, verb).process
+          access_obj = Insights::API::Common::RBAC::Access.new(klass.table_name, verb).process
           raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" unless access_obj.accessible?
 
           ace_ids(verb, klass)

--- a/app/controllers/api/v1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1/portfolio_items_controller.rb
@@ -3,12 +3,20 @@ module Api
     class PortfolioItemsController < ApplicationController
       include Api::V1::Mixins::IndexMixin
 
-      before_action :create_access_check, :only => %i[create]
-      before_action :update_access_check, :only => %i[update]
-      before_action :delete_access_check, :only => %i[destroy]
+      before_action :create_access_check, :only => %i[create] do
+        # TODO: Busted need the caller to pass in the portfolio id
+        # parent_check(:portfolio, 'update')
+        permission_check('create', Portfolio)
+      end
+      before_action :update_access_check, :only => %i[update] do
+        parent_check(:portfolio, 'update')
+      end
+      before_action :delete_access_check, :only => %i[destroy] do
+        parent_check(:portfolio, 'delete')
+      end
 
       before_action :only => [:copy] do
-        resource_check('read', params.require(:portfolio_item_id))
+        parent_check(:portfolio, 'read', params.require(:portfolio_item_id))
         permission_check('create', Portfolio)
         permission_check('update', Portfolio)
       end

--- a/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
@@ -42,7 +42,7 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
   context "when user does not have RBAC update portfolios access" do
     before do
       allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
-      allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolio_items', 'read').and_return(access_obj)
+      allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'create').and_return(access_obj)
       allow(access_obj).to receive(:process).and_return(access_obj)
 
@@ -60,12 +60,14 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
     let(:portfolio_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => false) }
     before do
       allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
-      allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolio_items', 'read').and_return(access_obj)
+      allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
       allow(access_obj).to receive(:process).and_return(access_obj)
 
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'update').and_return(portfolio_access_obj)
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'create').and_return(portfolio_access_obj)
       allow(portfolio_access_obj).to receive(:process).and_return(portfolio_access_obj)
+      create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'update', :aceable => portfolio)
+      create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'read', :aceable => portfolio)
     end
 
     it 'returns a 200' do


### PR DESCRIPTION
This WIP PR shows how to check the parents RBAC when validating a child resource.
Portfolios have RBAC defined but a Portfolio Item (aka Product) doesn't. So when we have to check the access for Portfolio Item we have to check the RBAC on the related Portfolio.