### PR TITLE
Added approval_url sources_url spec helpers

### DIFF
--- a/spec/lib/approval/service_spec.rb
+++ b/spec/lib/approval/service_spec.rb
@@ -2,7 +2,8 @@ describe Approval::Service, :type => :current_forwardable do
   let(:topo_ex) { ApprovalApiClient::ApiError.new("kaboom") }
 
   it "raises ApprovalError" do
-    with_modified_env :APPROVAL_URL => 'http://www.example.com' do
+    with_modified_env :APPROVAL_URL => 'http://approval.example.com' do
+      allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
       expect do
         described_class.call(ApprovalApiClient::RequestApi) do |_api|
           raise topo_ex

--- a/spec/lib/catalog/survey_compare_spec.rb
+++ b/spec/lib/catalog/survey_compare_spec.rb
@@ -1,4 +1,4 @@
-describe Catalog::SurveyCompare do
+describe Catalog::SurveyCompare, :type => [:current_forwardable, :topology] do
   let!(:portfolio_item) { service_plan.portfolio_item }
   let!(:service_offering_ref) { portfolio_item.service_offering_ref }
   let(:valid_ddf) { JSON.parse(File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json"))) }
@@ -13,12 +13,6 @@ describe Catalog::SurveyCompare do
   end
 
   let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => [topo_service_plan]) }
-
-  around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology", :BYPASS_RBAC => 'true') do
-      Insights::API::Common::Request.with_request(default_request) { example.call }
-    end
-  end
 
   before do
     stub_request(:get, topological_url("service_offerings/#{service_offering_ref}/service_plans"))

--- a/spec/lib/sources_spec.rb
+++ b/spec/lib/sources_spec.rb
@@ -2,7 +2,8 @@ describe Sources, :type => :current_forwardable do
   let(:sources_ex) { SourcesApiClient::ApiError.new("kaboom") }
 
   it "raises SourcesError" do
-    with_modified_env :SOURCES_URL => 'http://localhost' do
+    with_modified_env :SOURCES_URL => 'http://source.example.com' do
+      allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
       expect do
         described_class.call do |_klass|
           raise sources_ex

--- a/spec/models/service_plan_spec.rb
+++ b/spec/models/service_plan_spec.rb
@@ -5,7 +5,7 @@ describe ServicePlan do
   let(:valid_ddf) { JSON.parse(File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json"))) }
 
   around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology", :BYPASS_RBAC => 'true') do
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com", :BYPASS_RBAC => 'true') do
       Insights::API::Common::Request.with_request(default_request) { example.call }
     end
   end

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -218,7 +218,7 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
 
     context "when passing in valid attributes" do
       before do
-        stub_request(:get, "http://localhost/api/approval/v1.0/workflows/PatchWorkflowRef")
+        stub_request(:get, approval_url("workflows/PatchWorkflowRef"))
           .to_return(:status => 200, :body => "", :headers => {"Content-type" => "application/json"})
 
         patch "#{api_version}/portfolio_items/#{portfolio_item.id}", :params => valid_attributes, :headers => default_headers

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -1,7 +1,7 @@
 describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
   around do |example|
     bypass_rbac do
-      with_modified_env(:APPROVAL_URL => "http://localhost") { example.call }
+      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com", :APPROVAL_URL => "http://approval.example.com") { example.call }
     end
   end
 

--- a/spec/services/catalog/cancel_order_spec.rb
+++ b/spec/services/catalog/cancel_order_spec.rb
@@ -7,7 +7,7 @@ describe Catalog::CancelOrder, :type => [:service, :current_forwardable] do
 
   describe "#process" do
     around do |example|
-      with_modified_env(:APPROVAL_URL => "http://localhost") do
+      with_modified_env(:APPROVAL_URL => "http://approval.example.com") do
         example.call
       end
     end
@@ -42,7 +42,7 @@ describe Catalog::CancelOrder, :type => [:service, :current_forwardable] do
 
     describe "when the state of the order is anything else" do
       let(:state) { "Pending" }
-      let(:cancel_order_url) { "http://localhost/api/approval/v1.0/requests/#{approval_request.approval_request_ref}/actions" }
+      let(:cancel_order_url) { approval_url("requests/#{approval_request.approval_request_ref}/actions") }
 
       before do
         stub_request(:post, cancel_order_url).with(:body => {"operation" => "cancel"}).to_return(api_response)

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -3,7 +3,7 @@ describe Catalog::CreateApprovalRequest, :type => :service do
   let(:task) { TopologicalInventoryApiClient::Task.new(:id => "123") }
 
   around do |example|
-    with_modified_env(:APPROVAL_URL => "http://localhost") do
+    with_modified_env(:APPROVAL_URL => "http://approval") do
       Insights::API::Common::Request.with_request(default_request) { example.call }
     end
   end
@@ -18,14 +18,14 @@ describe Catalog::CreateApprovalRequest, :type => :service do
     allow(Catalog::CreateRequestBodyFrom).to receive(:new).with(order, order_item, task).and_return(create_request_body_from)
     allow(create_request_body_from).to receive(:process).and_return(create_request_body_from)
 
-    stub_request(:get, "http://localhost/api/approval/v1.0/workflows/1")
+    stub_request(:get, approval_url("workflows/1"))
       .to_return(:status => 200, :body => "", :headers => {"Content-type" => "application/json"})
   end
 
   describe "#process" do
     context "when the approval succeeds" do
       before do
-        stub_request(:post, "http://localhost/api/approval/v1.0/requests")
+        stub_request(:post, approval_url("requests"))
           .with(:body => request_body_from)
           .to_return(:status => 200, :body => {:workflow_id => 7, :id => 7, :decision => "approved"}.to_json, :headers => {"Content-type" => "application/json"})
       end
@@ -58,7 +58,7 @@ describe Catalog::CreateApprovalRequest, :type => :service do
 
     context "when the approval fails" do
       before do
-        stub_request(:post, "http://localhost/api/approval/v1.0/requests")
+        stub_request(:post, approval_url("requests"))
           .with(:body => request_body_from)
           .to_return(:status => 401, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
       end
@@ -87,7 +87,7 @@ describe Catalog::CreateApprovalRequest, :type => :service do
 
     context "without a tenant on the request" do
       before do
-        stub_request(:post, "http://localhost/api/approval/v1.0/requests")
+        stub_request(:post, approval_url("requests"))
           .with(:body => request_body_from)
           .to_return(:status => 200, :body => {:workflow_id => 7, :id => 7, :decision => "approved"}.to_json, :headers => {"Content-type" => "application/json"})
       end

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -3,7 +3,7 @@ describe Catalog::CreateApprovalRequest, :type => :service do
   let(:task) { TopologicalInventoryApiClient::Task.new(:id => "123") }
 
   around do |example|
-    with_modified_env(:APPROVAL_URL => "http://approval") do
+    with_modified_env(:APPROVAL_URL => "http://approval.example.com") do
       Insights::API::Common::Request.with_request(default_request) { example.call }
     end
   end

--- a/spec/services/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/catalog/create_request_for_applied_inventories_spec.rb
@@ -4,7 +4,7 @@ describe Catalog::CreateRequestForAppliedInventories, :type => :service do
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => 123) }
 
   around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com") do
       example.call
     end
   end

--- a/spec/services/catalog/service_offering_spec.rb
+++ b/spec/services/catalog/service_offering_spec.rb
@@ -6,7 +6,7 @@ describe Catalog::ServiceOffering do
   end
 
   around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com") do
       example.call
     end
   end
@@ -17,7 +17,7 @@ describe Catalog::ServiceOffering do
     let(:service_offering_response) { TopologicalInventoryApiClient::ServiceOffering.new(:archived_at => archived_at) }
 
     before do
-      stub_request(:get, "http://topology/api/topological-inventory/v2.0/service_offerings/123")
+      stub_request(:get, topological_url("service_offerings/123"))
         .to_return(:status => 200, :body => service_offering_response.to_json, :headers => default_headers)
     end
 

--- a/spec/services/catalog/submit_order_spec.rb
+++ b/spec/services/catalog/submit_order_spec.rb
@@ -34,6 +34,12 @@ describe Catalog::SubmitOrder, :type => [:service, :topology, :current_forwardab
   let(:topo_service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => [topo_service_plan]) }
   let(:service_plan_response) { topo_service_plan_response }
 
+  around do |example|
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com", :SOURCES_URL => "http://source.example.com") do
+      example.call
+    end
+  end
+
   before do
     allow(Catalog::ValidateSource).to receive(:new).with(portfolio_item.service_offering_source_ref).and_return(validater)
     allow(validater).to receive(:process).and_return(validater)

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -9,7 +9,7 @@ describe Catalog::UpdateOrderItem, :type => :service do
     let(:order) { item.order }
 
     around do |example|
-      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
+      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com") do
         example.call
       end
     end

--- a/spec/services/catalog/validate_source_spec.rb
+++ b/spec/services/catalog/validate_source_spec.rb
@@ -7,7 +7,7 @@ describe Catalog::ValidateSource do
   let(:validate_source) { described_class.new(portfolio_item.service_offering_source_ref).process }
 
   around do |example|
-    with_modified_env(:SOURCES_URL => "http://source") do
+    with_modified_env(:SOURCES_URL => "http://source.example.com") do
       Insights::API::Common::Request.with_request(default_request) { example.call }
     end
   end

--- a/spec/services/catalog/validate_source_spec.rb
+++ b/spec/services/catalog/validate_source_spec.rb
@@ -7,15 +7,15 @@ describe Catalog::ValidateSource do
   let(:validate_source) { described_class.new(portfolio_item.service_offering_source_ref).process }
 
   around do |example|
-    with_modified_env(:SOURCES_URL => "http://localhost") do
+    with_modified_env(:SOURCES_URL => "http://source") do
       Insights::API::Common::Request.with_request(default_request) { example.call }
     end
   end
 
   before do
-    stub_request(:get, "http://localhost/api/sources/v1.0/application_types")
+    stub_request(:get, sources_url("application_types"))
       .to_return(:status => 200, :body => catalog_application_type.to_json, :headers => response_headers)
-    stub_request(:get, "http://localhost/api/sources/v1.0/application_types/1/sources")
+    stub_request(:get, sources_url("application_types/1/sources"))
       .to_return(:status => 200, :body => response.to_json, :headers => response_headers)
   end
 

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -12,7 +12,7 @@ describe ServiceOffering::AddToPortfolioItem, :type => [:service, :topology] do
 
   around do |example|
     Insights::API::Common::Request.with_request(default_request) do
-      with_modified_env(:SOURCES_URL => "http://localhost") do
+      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com", :SOURCES_URL => "http://source.example.com") do
         example.call
       end
     end
@@ -29,9 +29,9 @@ describe ServiceOffering::AddToPortfolioItem, :type => [:service, :topology] do
       stub_request(:get, topological_url("service_offering_icons/998"))
         .to_return(:status => 200, :body => service_offering_icon.to_json, :headers => default_headers)
 
-      stub_request(:get, "http://localhost/api/sources/v1.0/application_types")
+      stub_request(:get, sources_url("application_types"))
         .to_return(:status => 200, :body => catalog_application_type.to_json, :headers => default_headers)
-      stub_request(:get, "http://localhost/api/sources/v1.0/application_types/1/sources")
+      stub_request(:get, sources_url("application_types/1/sources"))
         .to_return(:status => 200, :body => sources_response.to_json, :headers => default_headers)
     end
 

--- a/spec/services/tags/topology/remote_inventory_spec.rb
+++ b/spec/services/tags/topology/remote_inventory_spec.rb
@@ -6,7 +6,7 @@ describe Tags::Topology::RemoteInventory, :type => :service do
   end
 
   around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com") do
       example.call
     end
   end

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -32,15 +32,15 @@ module ServiceSpecHelper
   end
 
   def topological_url(partial_path, api_version = "v2.0")
-    "http://topology/api/topological-inventory/#{api_version}/#{partial_path}"
+    "http://topology.example.com/api/topological-inventory/#{api_version}/#{partial_path}"
   end
 
   def approval_url(partial_path, api_version = "v1.0")
-    "http://approval/api/approval/#{api_version}/#{partial_path}"
+    "http://approval.example.com/api/approval/#{api_version}/#{partial_path}"
   end
 
   def sources_url(partial_path, api_version = "v1.0")
-    "http://source/api/sources/#{api_version}/#{partial_path}"
+    "http://source.example.com/api/sources/#{api_version}/#{partial_path}"
   end
 
   def default_request

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -32,15 +32,21 @@ module ServiceSpecHelper
   end
 
   def topological_url(partial_path, api_version = "v2.0")
-    "http://topology.example.com/api/topological-inventory/#{api_version}/#{partial_path}"
+    url_string = "http://topology.example.com"
+    url = URI.join(url_string, "api/", "topological-inventory/", "#{api_version}/", "#{partial_path}")
+    url.to_s
   end
 
   def approval_url(partial_path, api_version = "v1.0")
-    "http://approval.example.com/api/approval/#{api_version}/#{partial_path}"
+    url_string = "http://approval.example.com"
+    url = URI.join(url_string, "api/", "approval/", "#{api_version}/", "#{partial_path}")
+    url.to_s
   end
 
   def sources_url(partial_path, api_version = "v1.0")
-    "http://source.example.com/api/sources/#{api_version}/#{partial_path}"
+    url_string = "http://source.example.com"
+    url = URI.join(url_string, "api/", "sources/", "#{api_version}/", "#{partial_path}")
+    url.to_s
   end
 
   def default_request

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -35,6 +35,14 @@ module ServiceSpecHelper
     "http://topology/api/topological-inventory/#{api_version}/#{partial_path}"
   end
 
+  def approval_url(partial_path, api_version = "v1.0")
+    "http://approval/api/approval/#{api_version}/#{partial_path}"
+  end
+
+  def sources_url(partial_path, api_version = "v1.0")
+    "http://source/api/sources/#{api_version}/#{partial_path}"
+  end
+
   def default_request
     { :headers => default_headers, :original_url => original_url }
   end

--- a/spec/support/topology_spec_helper.rb
+++ b/spec/support/topology_spec_helper.rb
@@ -1,7 +1,7 @@
 module TopologySpecHelper
   RSpec.configure do |config|
     config.around(:example, :type => :topology) do |example|
-      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology") do
+      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com") do
         example.call
       end
     end


### PR DESCRIPTION
This is a followup PR to https://github.com/RedHatInsights/catalog-api/pull/518

It adds additional spec helper methods `approval_url` and `sources_url` to assist in no longer manurally building urls in our specs when calling `stub_request`.

Following up on @mkanoor's comment: https://github.com/RedHatInsights/catalog-api/pull/549#discussion_r366063963

I ended up using http://topology.example.com, http://approval.example.com, http://source.example.com 

I could have used http://localhost... but our original conversations around this change was to also make it easy to know what service we were testing against.

Adding in `example.com` simultaneously allows us to use a testable domain while allowing us to maintain the separate integrity of each accessed microservice api url.