### PR TITLE
Validate OrderItem `service_parameters` when ordering 

### DIFF
--- a/app/services/catalog/order_item_sanitized_parameters.rb
+++ b/app/services/catalog/order_item_sanitized_parameters.rb
@@ -7,6 +7,7 @@ module Catalog
 
     def initialize(params)
       @params = params
+      @order_item = params[:order_item]
     end
 
     def process
@@ -32,6 +33,10 @@ module Catalog
       order_item.service_parameters
     end
 
+    def filtered_parameters
+      service_parameters.slice(*fields.collect { |field| field.with_indifferent_access["name"] })
+    end
+
     def service_plan_schema
       TopologicalInventory.call do |api|
         @plan = api.show_service_plan(service_plan_ref.to_s)
@@ -44,6 +49,7 @@ module Catalog
 
     def compute_sanitized_parameters
       return {} if service_plan_does_not_exist?
+      return filtered_parameters if @params[:do_not_mask_values]
 
       svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters)
       fields.each_with_object({}) do |field, result|

--- a/app/services/catalog/submit_order.rb
+++ b/app/services/catalog/submit_order.rb
@@ -36,7 +36,7 @@ module Catalog
 
     def parameters(item)
       TopologicalInventoryApiClient::OrderParametersServiceOffering.new.tap do |obj|
-        obj.service_parameters = item.service_parameters
+        obj.service_parameters = sanitized_parameters(item)
         obj.provider_control_parameters = item.provider_control_parameters
         obj.service_plan_id = item.service_plan_ref
       end
@@ -48,6 +48,13 @@ module Catalog
       item.order_request_sent_at = Time.now.utc
       item.update_message('info', 'Ordered')
       item.save!
+    end
+
+    def sanitized_parameters(item)
+      Catalog::OrderItemSanitizedParameters.new(
+        :order_item         => item,
+        :do_not_mask_values => true
+      ).process.sanitized_parameters
     end
   end
 end

--- a/spec/services/catalog/submit_order_spec.rb
+++ b/spec/services/catalog/submit_order_spec.rb
@@ -2,8 +2,8 @@ describe Catalog::SubmitOrder, :type => [:service, :topology, :current_forwardab
   let(:service_offering_ref) { "998" }
   let(:service_plan_ref) { "991" }
   let(:order) { create(:order) }
-  let(:service_parameters) { { 'var1' => 'Fred', 'var2' => 'Wilma' } }
-  let(:provider_control_parameters) { { 'namespace' => 'Bedrock' } }
+  let(:service_parameters) { {'var1' => 'Fred', 'var2' => 'Wilma'} }
+  let(:provider_control_parameters) { {'namespace' => 'Bedrock'} }
   let!(:order_item) do
     create(:order_item, :portfolio_item              => portfolio_item,
                         :service_parameters          => service_parameters,
@@ -31,6 +31,15 @@ describe Catalog::SubmitOrder, :type => [:service, :topology, :current_forwardab
     )
   end
 
+  let(:service_plan_show_response) do
+    TopologicalInventoryApiClient::ServicePlan.new(
+      :name               => "Plan A",
+      :id                 => "1",
+      :description        => "Plan A",
+      :create_json_schema => {:schema => {:fields => [{:name => "var1"}, {:name => "var2"}]}}
+    )
+  end
+
   let(:topo_service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => [topo_service_plan]) }
   let(:service_plan_response) { topo_service_plan_response }
 
@@ -41,29 +50,41 @@ describe Catalog::SubmitOrder, :type => [:service, :topology, :current_forwardab
 
     stub_request(:get, topological_url("service_offerings/#{service_offering_ref}/service_plans"))
       .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)
+    stub_request(:get, topological_url("service_plans/#{service_plan_ref}"))
+      .to_return(:status => 200, :body => service_plan_show_response.to_json, :headers => default_headers)
   end
 
   context "when the order ID is valid" do
     let(:params) { order.id.to_s }
     let(:order_response) { TopologicalInventoryApiClient::InlineResponse200.new(:task_id => "100") }
 
-    context "when the source is valid" do
-      before do
-        request_stubs = {
+    before do
+      stub_request(:post, topological_url("service_offerings/998/order"))
+        .with(
           :body    => {
             :service_parameters          => service_parameters,
             :provider_control_parameters => provider_control_parameters,
             :service_plan_id             => service_plan_ref,
           }.to_json,
           :headers => default_headers
-        }
-        stub_request(:post, topological_url("service_offerings/998/order"))
-          .with(request_stubs)
-          .to_return(:status => 200, :body => order_response.to_json, :headers => {"Content-type" => "application/json"})
-      end
+        )
+        .to_return(:status => 200, :body => order_response.to_json, :headers => {"Content-type" => "application/json"})
+    end
 
+    context "when the source is valid" do
       it "updates the order item with the task id" do
         expect(submit_order.process.order.order_items.first.topology_task_ref).to eq("100")
+      end
+    end
+
+    context "when sending extra parameters" do
+      before do
+        order_item.update!(:service_parameters => service_parameters.merge(:extra_param => "extra! extra!"))
+        submit_order.process
+      end
+
+      it "only sends the parameters specified in the schema" do
+        expect(a_request(:post, topological_url("service_offerings/998/order")).with { |req| req.body.exclude?("extra_param") }).to have_been_made
       end
     end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1048

Currently we pass any and all `service_parameters` that get passed in on order to topology, even though the keys might not exist in the survey on the tower. 

This could cause issues in the future, so we pull the survey and only allow the fields present on the survey to be passed through. This mainly effects ordering form the API as far as I know since the frontend will only pass in the values present on the survey - but it is still a hole we need to consider. 