### PR TITLE
Remove rescue logging introduced in #510

### DIFF
--- a/app/controllers/api/v1/mixins/service_offering_mixin.rb
+++ b/app/controllers/api/v1/mixins/service_offering_mixin.rb
@@ -8,7 +8,6 @@ module Api
           order_id = params.require(:order_id)
           service_offering_service = Catalog::ServiceOffering.new(order_id).process
           if service_offering_service.archived
-            Rails.logger.error("Service offering for order #{order_id} has been archived and can no longer be ordered")
             raise Catalog::ServiceOfferingArchived, "Service offering for order #{order_id} has been archived and can no longer be ordered"
           else
             @order = service_offering_service.order

--- a/app/services/catalog/add_to_order.rb
+++ b/app/services/catalog/add_to_order.rb
@@ -11,9 +11,6 @@ module Catalog
       @order_item = order.order_items.create!(order_item_params.merge!(:service_plan_ref => service_plan_ref))
 
       self
-    rescue ActiveRecord::RecordInvalid => e
-      Rails.logger.error("Error creating order item for order_id #{order.id}: #{e.message}")
-      raise
     end
 
     private

--- a/app/services/catalog/create_icon.rb
+++ b/app/services/catalog/create_icon.rb
@@ -23,9 +23,6 @@ module Catalog
       @destination.update!(:icon_id => @icon.id)
 
       self
-    rescue ActiveRecord::RecordInvalid => e
-      Rails.logger.error("Error creating Icon object for #{@destination.class} #{@destination.id}: #{e.message}")
-      raise
     end
   end
 end

--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -21,9 +21,6 @@ module Catalog
       @service_plans = @portfolio_item.service_plans
 
       self
-    rescue ActiveRecord::RecordInvalid => e
-      Rails.logger.error("Error creating service plan with schemas: #{service_plan_schemas}, #{e.message}")
-      raise
     end
 
     def service_plan_schemas

--- a/spec/services/catalog/add_to_order_spec.rb
+++ b/spec/services/catalog/add_to_order_spec.rb
@@ -37,19 +37,6 @@ describe Catalog::AddToOrder, :type => :service do
     end
   end
 
-  context "when the parameters are invalid" do
-    let(:invalid_params) do
-      ActionController::Parameters.new('order_id'          => order.id,
-                                       'portfolio_item_id' => portfolio_item.id,
-                                       'count'             => 1)
-    end
-
-    it "raises an ActiveRecord::RecordInvalid exception and logs a message" do
-      expect(Rails.logger).to receive(:error).with(/Error creating order item for order_id #{order_id}/)
-      expect { described_class.new(invalid_params).process }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-  end
-
   context "invalid order" do
     let(:order_id) { "999" }
     it "invalid order" do

--- a/spec/services/catalog/create_icon_spec.rb
+++ b/spec/services/catalog/create_icon_spec.rb
@@ -77,20 +77,5 @@ describe Catalog::CreateIcon, :type => :service do
 
       it_behaves_like "#process handling generic object"
     end
-
-    context "when there is an error creating the image" do
-      let(:destination) { create(:portfolio) }
-      let(:destination_params) { {:portfolio_id => destination.id} }
-      let(:image_params) { {:content => form_upload_test_image("ocp_logo.jpg")} }
-
-      before do
-        allow(Icon).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
-      end
-
-      it "logs an error and raises" do
-        expect(Rails.logger).to receive(:error).with(/Error creating Icon object/)
-        expect { subject.process }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
   end
 end

--- a/spec/services/catalog/import_service_plans_spec.rb
+++ b/spec/services/catalog/import_service_plans_spec.rb
@@ -54,18 +54,5 @@ describe Catalog::ImportServicePlans, :type => [:service, :topology, :current_fo
         expect(portfolio_item.service_plans.count).to eq 2
       end
     end
-
-    context "if create somehow fails" do
-      let(:data) { [] }
-
-      before do
-        allow(ServicePlan).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
-      end
-
-      it "raises an error and logs a message" do
-        expect(Rails.logger).to receive(:error).with(/Error creating service plan/)
-        expect { subject.process }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
   end
 end


### PR DESCRIPTION
After the insights common gem gets updated with https://github.com/RedHatInsights/insights-api-common-rails/pull/147, these log statements will be redundant.

Travis will fail until the gem gets updated, so for now this is WIP.

@mkanoor @syncrou @lindgrenj6 👀 