### PR TITLE
Add the approval request external reference to progress message

### DIFF
--- a/app/models/approval_request.rb
+++ b/app/models/approval_request.rb
@@ -4,6 +4,10 @@ class ApprovalRequest < ApplicationRecord
 
   belongs_to :order_item
 
+  after_create do
+    order_item.update_message("info", "Created Approval Request ref: #{approval_request_ref}.  catalog approval request id: #{id}")
+  end
+
   scope :by_owner, lambda {
     joins("INNER JOIN order_items ON (order_items.id = approval_requests.order_item_id::int)")
       .joins("INNER JOIN orders ON (orders.id = order_items.order_id::int)")

--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -32,8 +32,6 @@ module Catalog
         :state                => response.decision.to_sym,
         :tenant_id            => order_item.tenant_id
       )
-
-      order_item.update_message("info", "Approval Request Submitted for ID: #{order_item.approval_requests.last.id}")
     end
 
     def fail_order

--- a/spec/models/approval_request_spec.rb
+++ b/spec/models/approval_request_spec.rb
@@ -25,4 +25,11 @@ describe ApprovalRequest, :type => :model do
       expect(results.first.id).to eq approval_request1.id
     end
   end
+
+  describe ".create" do
+    it "generates a progress_message on the associated order_item" do
+      progress_message = approval_request1.order_item.progress_messages.first
+      expect(progress_message.message).to match(/Created Approval Request ref: \d*\.  catalog approval request id: #{approval_request1.id}/)
+    end
+  end
 end


### PR DESCRIPTION
Addressing feedback from https://projects.engineering.redhat.com/browse/SSP-1105

Changed to log the external reference to the approval request in the progress message.  Keep local request ID, but not sure if that is of much use.

Also looking for feedback on moving this to a callback on the ApprovalRequest class.  Easy enough to move it back if we don't like this approach.