### PR TITLE
Add a regex to validate tag values

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -679,7 +679,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TagItem"
+                    "$ref": "#/components/schemas/Tag"
                   }
                 }
               }
@@ -704,7 +704,7 @@
               "schema": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/TagItem"
+                  "$ref": "#/components/schemas/Tag"
                 }
               }
             }
@@ -746,7 +746,7 @@
               "schema": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/TagItem"
+                  "$ref": "#/components/schemas/Tag"
                 }
               }
             }
@@ -1238,7 +1238,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TagItem"
+                    "$ref": "#/components/schemas/Tag"
                   }
                 }
               }
@@ -1263,7 +1263,7 @@
               "schema": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/TagItem"
+                  "$ref": "#/components/schemas/Tag"
                 }
               }
             }
@@ -1305,7 +1305,7 @@
               "schema": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/TagItem"
+                  "$ref": "#/components/schemas/Tag"
                 }
               }
             }
@@ -3827,35 +3827,13 @@
       "Tag": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string",
-            "readOnly": true
-          },
-          "created_at": {
-            "format": "date-time",
-            "readOnly": true,
-            "type": "string"
-          },
-          "description": {
-            "example": "Instruction set architecture",
-            "readOnly": true,
-            "type": "string"
-          },
           "tag": {
             "example": "/namespace/architecture=x86_64",
-            "type": "string"
+            "type": "string",
+            "pattern": "\\/.*\\/.+(=.+|[^=]$)"
           }
         },
         "additionalProperties": false
-      },
-      "TagItem": {
-        "type": "object",
-        "properties": {
-          "tag": {
-            "example": "/namespace/architecture=x86_64",
-            "type": "string"
-          }
-        }
       },
       "TagsCollection": {
         "type": "object",

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -1,4 +1,5 @@
 describe "OpenAPI stuff" do
+  include RandomWordsSpecHelper
   SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags tags images icons service_plans access_control_entries].freeze
   let(:rails_routes) do
     Rails.application.routes.routes.each_with_object([]) do |route, array|
@@ -75,18 +76,6 @@ describe "OpenAPI stuff" do
         expect(ENV["APP_NAME"]).not_to be_nil
         expect(api_v1x0_orders_url(:only_path => true)).to eq("/api/v1.0/orders")
       end
-    end
-
-    def words
-      @words ||= File.readlines("/usr/share/dict/words").collect(&:strip)
-    end
-
-    def random_path_part
-      rand(1..5).times.collect { words.sample }.join("_")
-    end
-
-    def random_path
-      rand(1..10).times.collect { random_path_part }.join("/")
     end
   end
 

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -422,6 +422,31 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
       end
     end
 
+    shared_examples_for "bad_tags" do
+      let(:bad_tags) { %w[/ /approval /approval/workflows=] }
+
+      it "throws a 400" do
+        bad_tags.each do |tag|
+          post "#{api_version}/portfolios/#{portfolio.id}/#{endpoint}", :headers => default_headers, :params => [:tag => tag]
+
+          expect(response).to have_http_status(400)
+        end
+      end
+    end
+
+    shared_examples_for "good_tags" do
+      include RandomWordsSpecHelper
+      let(:good_tags) { Array.new(10) { random_tag } }
+
+      it "adds the tag successfully" do
+        good_tags.each do |tag|
+          post "#{api_version}/portfolios/#{portfolio.id}/tag", :headers => default_headers, :params => [:tag => tag]
+          expect(response).to have_http_status(201)
+          expect(json.first["tag"]).to eq tag
+        end
+      end
+    end
+
     context "GET /portfolios/{id}/tags" do
       let(:params) { {:name => tag_name, :namespace => tag_ns} }
 
@@ -465,6 +490,10 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
           expect(response).to have_http_status(304)
         end
       end
+
+      let(:endpoint) { "tag" }
+      it_behaves_like "bad_tags"
+      it_behaves_like "good_tags"
     end
 
     context "POST /portfolios/{id}/untag" do
@@ -481,6 +510,10 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
         expect(response).to have_http_status(204)
         expect(portfolio.tags).to be_empty
       end
+
+      let(:endpoint) { "tag" }
+      it_behaves_like "bad_tags"
+      it_behaves_like "good_tags"
     end
   end
 end

--- a/spec/support/random_words_spec_helper.rb
+++ b/spec/support/random_words_spec_helper.rb
@@ -1,0 +1,17 @@
+module RandomWordsSpecHelper
+  def words
+    @words ||= File.readlines("/usr/share/dict/words").collect(&:strip)
+  end
+
+  def random_path_part
+    Array.new(rand(1..5)) { words.sample }.join("_")
+  end
+
+  def random_path
+    Array.new(rand(1..10)) { random_path_part }.join("/")
+  end
+
+  def random_tag
+    "/#{words.sample}/#{words.sample}".tap { |tag| tag << "=#{words.sample}" if (rand(10) % 2).even? }
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1126

Fixes this bug by adding a regex to validate tag strings.

\# TODO:
- [x] specs