### PR TITLE
Ensure task update message happens before any error messages

### DIFF
--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -13,12 +13,12 @@ module Catalog
           :context => @topic.payload["context"].try(&:with_indifferent_access)
         )
 
-        @task.state == "completed" ? delegate_task : add_task_update_message
+        add_task_update_message
+        delegate_task if @task.state == "completed"
       end
 
       self
     rescue StandardError => exception
-      add_update_message(:error) unless @task.nil?
       Rails.logger.error(exception.inspect)
       raise
     end
@@ -31,8 +31,6 @@ module Catalog
       elsif @task.context.has_key_path?(:applied_inventories)
         Rails.logger.info("Creating approval request for task")
         Catalog::CreateApprovalRequest.new(@task).process
-      else
-        add_task_update_message
       end
     end
 
@@ -45,11 +43,11 @@ module Catalog
     end
 
     def add_task_update_message
-      @task.status == "error" ? add_update_message(:error) : add_update_message(:info)
+      message = "Task update. State: #{@task.state}. Status: #{@task.status}. Context: #{@task.context}"
+      @task.status == "error" ? add_update_message(:error, message) : add_update_message(:info, message)
     end
 
-    def add_update_message(state)
-      message = "Task update. State: #{@task.state}. Status: #{@task.status}. Context: #{@task.context}"
+    def add_update_message(state, message)
       order_item.update_message(state, message)
       Rails.logger.send(state, message)
     end

--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -31,6 +31,8 @@ module Catalog
       elsif @task.context.has_key_path?(:applied_inventories)
         Rails.logger.info("Creating approval request for task")
         Catalog::CreateApprovalRequest.new(@task).process
+      else
+        Rails.logger.info("Incoming task has no current relevent delegation")
       end
     end
 

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -157,10 +157,21 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
             )
             subject.process
           end
+
+          it "logs an info message" do
+            expect(Rails.logger).to receive(:info).with(
+              "Incoming task has no current relevent delegation"
+            )
+            subject.process
+          end
         end
 
         context "when the status is not 'error'" do
           let(:status) { "updated" }
+
+          before do
+            allow(Rails.logger).to receive(:info).with(anything)
+          end
 
           it "updates the item with a progress message" do
             subject.process
@@ -171,7 +182,13 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
           end
 
           it "logs an info message" do
-            allow(Rails.logger).to receive(:info).with(anything)
+            expect(Rails.logger).to receive(:info).with(
+              "Incoming task has no current relevent delegation"
+            )
+            subject.process
+          end
+
+          it "logs an info message" do
             expect(Rails.logger).to receive(:info).with(
               "Task update. State: completed. Status: updated. Context: #{payload_context}"
             )

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -72,6 +72,15 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
 
         before do
           allow(Catalog::UpdateOrderItem).to receive(:new).and_return(update_order_item)
+          allow(update_order_item).to receive(:process)
+        end
+
+        it "updates the item with a progress message" do
+          subject.process
+          progress_message = ProgressMessage.last
+          expect(progress_message.level).to eq("info")
+          expect(progress_message.message).to match(/Task update. State: completed/)
+          expect(progress_message.order_item_id).to eq(order_item.id.to_s)
         end
 
         it "delegates to updating the order item" do
@@ -94,6 +103,7 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
 
         before do
           allow(Catalog::CreateApprovalRequest).to receive(:new).with(task).and_return(create_approval_request)
+          allow(create_approval_request).to receive(:process)
         end
 
         it "creates a task with id, state, status and context" do
@@ -106,8 +116,23 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
           subject.process
         end
 
+        it "updates the item with a progress message" do
+          subject.process
+          progress_message = ProgressMessage.last
+          expect(progress_message.level).to eq("info")
+          expect(progress_message.message).to match(/Task update. State: completed/)
+          expect(progress_message.order_item_id).to eq(order_item.id.to_s)
+        end
+
         it "delegates to creating the approval request" do
           expect(create_approval_request).to receive(:process)
+          subject.process
+        end
+
+        it "updates the item with a task progress message before delgation" do
+          subject.instance_variable_set(:@order_item, order_item)
+          expect(order_item).to receive(:update_message).with(:info, /Task update. State: completed/).ordered
+          expect(create_approval_request).to receive(:process).ordered
           subject.process
         end
       end


### PR DESCRIPTION
While investigating https://projects.engineering.redhat.com/browse/SSP-913, I noticed that the order of the progress messages was a bit off, because we got the "task running" event message, and then the "approval request error" message, and then the last message was "task completed". It wasn't *actually* getting these events in this order, it was just the way the code was structured to handle the errors.

This PR reorganizes the update messages so that we will always see the task update first, and then if there are any errors in the underlying delegation, those will show up last.

@syncrou Please Review.