### PR TITLE
Fixed a bug in the root controller spec

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,16 +14,12 @@ class ApplicationController < ActionController::API
   private
 
   def with_current_request
-    logger.info("Handling incoming request")
     Insights::API::Common::Request.with_request(request) do |current|
-      logger.info(Insights::API::Common::Request.current_forwardable.to_s)
       if current.required_auth?
-        logger.info("Running with tenant")
         raise Insights::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
 
         ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
       else
-        logger.info("Running without tenant")
         ActsAsTenant.without_tenant { yield }
       end
     end

--- a/spec/requests/api/v1.0/root_spec.rb
+++ b/spec/requests/api/v1.0/root_spec.rb
@@ -1,13 +1,13 @@
 describe "v1.0 - root", :type => [:request, :v1] do
   it "#openapi.json" do
-    get("/#{api_version}/openapi.json", :headers => default_headers)
+    get("#{api_version}/openapi.json")
 
     expect(response.content_type).to eq("application/json")
     expect(response).to have_http_status(:ok)
   end
 
   it "handles redirects correctly" do
-    get("/api/v1/openapi.json", :headers => default_headers)
+    get("/api/v1/openapi.json")
 
     expect(response.status).to eq(302)
     expect(response.headers["Location"]).to eq("#{api_version}/openapi.json")


### PR DESCRIPTION
There was a leading / causing the specs to fail for
fetching the openapi.json when no headers were provided
Also removed the log messages added during testing in
PR # https://github.com/RedHatInsights/catalog-api/pull/558