### PR TITLE
Normalize rbac ace table and added readonly permissions table

### DIFF
--- a/app/controllers/api/v1/mixins/ace_mixin.rb
+++ b/app/controllers/api/v1/mixins/ace_mixin.rb
@@ -2,9 +2,12 @@ module Api
   module V1
     module Mixins
       module ACEMixin
-        def ace_ids(verb, klass)
-          params = { :group_uuid => my_group_uuids, :permission => verb, :aceable_type => klass.to_s }
-          AccessControlEntry.where(params).collect { |ace| ace.aceable_id.to_s }
+        def ace_ids(permission, klass)
+          AccessControlEntry.joins(:permissions).where(
+            :permissions            => {:name => permission},
+            :access_control_entries => {:group_uuid => my_group_uuids,
+                                        :aceable_type => klass.to_s}
+          ).collect { |ace| ace.aceable_id.to_s }
         end
 
         def my_group_uuids

--- a/app/controllers/api/v1/mixins/ace_mixin.rb
+++ b/app/controllers/api/v1/mixins/ace_mixin.rb
@@ -4,9 +4,13 @@ module Api
       module ACEMixin
         def ace_ids(permission, klass)
           AccessControlEntry.joins(:permissions).where(
-            :permissions            => {:name => permission},
-            :access_control_entries => {:group_uuid => my_group_uuids,
-                                        :aceable_type => klass.to_s}
+            :permissions            => {
+              :name => permission
+            },
+            :access_control_entries => {
+              :group_uuid   => my_group_uuids,
+              :aceable_type => klass.to_s
+            }
           ).collect { |ace| ace.aceable_id.to_s }
         end
 

--- a/app/models/access_control_entry.rb
+++ b/app/models/access_control_entry.rb
@@ -4,7 +4,8 @@ class AccessControlEntry < ApplicationRecord
   has_many :access_control_permissions, :dependent => :destroy
   has_many :permissions, :through => :access_control_permissions
 
-  def add_permissions(permissions)
-    permissions.each { |name| self.permissions << Permission.find_by!(:name => name) }
+  def add_new_permissions(permissions)
+    new_permissions = permissions - self.permissions.map(&:name)
+    new_permissions.each { |name| self.permissions << Permission.find_by!(:name => name) }
   end
 end

--- a/app/models/access_control_entry.rb
+++ b/app/models/access_control_entry.rb
@@ -2,4 +2,8 @@ class AccessControlEntry < ApplicationRecord
   acts_as_tenant(:tenant)
   belongs_to :aceable, :polymorphic => true
   has_and_belongs_to_many :permissions
+
+  def add_permissions(permissions)
+    permissions.each { |name| self.permissions << Permission.find_by!(:name => name) }
+  end
 end

--- a/app/models/access_control_entry.rb
+++ b/app/models/access_control_entry.rb
@@ -1,4 +1,5 @@
 class AccessControlEntry < ApplicationRecord
   acts_as_tenant(:tenant)
   belongs_to :aceable, :polymorphic => true
+  has_and_belongs_to_many :permissions
 end

--- a/app/models/access_control_entry.rb
+++ b/app/models/access_control_entry.rb
@@ -1,7 +1,8 @@
 class AccessControlEntry < ApplicationRecord
   acts_as_tenant(:tenant)
   belongs_to :aceable, :polymorphic => true
-  has_and_belongs_to_many :permissions
+  has_many :access_control_permissions, :dependent => :destroy
+  has_many :permissions, :through => :access_control_permissions
 
   def add_permissions(permissions)
     permissions.each { |name| self.permissions << Permission.find_by!(:name => name) }

--- a/app/models/access_control_permission.rb
+++ b/app/models/access_control_permission.rb
@@ -1,0 +1,5 @@
+class AccessControlPermission < ApplicationRecord
+  acts_as_tenant(:tenant)
+  belongs_to :permission
+  belongs_to :access_control_entry
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,5 +1,5 @@
 class Permission < ApplicationRecord
-  enum :name => [:read, :update, :delete, :order], :_suffix => true
+  enum :name => { :read => "read", :delete => "delete", :order => "order", :update => "update" }, :_suffix => true
 
   def readonly?
     !new_record?

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,8 +1,7 @@
 class Permission < ApplicationRecord
-  enum :name => { :read => "read", :delete => "delete", :order => "order", :update => "update" }, :_suffix => true
+  enum :name => {:read => "read", :delete => "delete", :order => "order", :update => "update"}, :_suffix => true
 
   def readonly?
     !new_record?
   end
-
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,4 @@
+class Permission < ApplicationRecord
+  enum :name => [:read, :update, :delete, :order], :_suffix => true
+  has_and_belongs_to_many :access_control_entries
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,4 +1,8 @@
 class Permission < ApplicationRecord
   enum :name => [:read, :update, :delete, :order], :_suffix => true
-  has_and_belongs_to_many :access_control_entries
+
+  def readonly?
+    !new_record?
+  end
+
 end

--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -11,7 +11,7 @@ module Catalog
     def process
       group_permissions = {}
       @object.access_control_entries.each do |ace|
-        group_permissions[ace.group_uuid] = group_permissions.fetch(ace.group_uuid, []) << ace.permission
+        group_permissions[ace.group_uuid] = ace.permissions.map(&:name)
       end
 
       @result = group_permissions.each_with_object([]) do |(uuid, permissions), memo|

--- a/app/services/catalog/share_resource.rb
+++ b/app/services/catalog/share_resource.rb
@@ -14,7 +14,7 @@ module Catalog
       @group_uuids.each do |group_uuid|
         ace = AccessControlEntry.find_or_create_by(:group_uuid => group_uuid,
                                                    :aceable    => @object)
-        ace.add_permissions(@permissions)
+        ace.add_new_permissions(@permissions)
       end
       self
     end

--- a/app/services/catalog/share_resource.rb
+++ b/app/services/catalog/share_resource.rb
@@ -12,10 +12,10 @@ module Catalog
     def process
       validate_groups
       @group_uuids.each do |group_uuid|
+        ace = AccessControlEntry.find_or_create_by(:group_uuid => group_uuid,
+                                                   :aceable    => @object)
         @permissions.each do |permission|
-          AccessControlEntry.find_or_create_by(:group_uuid => group_uuid,
-                                               :permission => permission,
-                                               :aceable    => @object)
+          ace.permissions << Permission.find_by(:name => permission)
         end
       end
       self

--- a/app/services/catalog/share_resource.rb
+++ b/app/services/catalog/share_resource.rb
@@ -14,9 +14,7 @@ module Catalog
       @group_uuids.each do |group_uuid|
         ace = AccessControlEntry.find_or_create_by(:group_uuid => group_uuid,
                                                    :aceable    => @object)
-        @permissions.each do |permission|
-          ace.permissions << Permission.find_by(:name => permission)
-        end
+        ace.add_permissions(@permissions)
       end
       self
     end

--- a/app/services/catalog/unshare_resource.rb
+++ b/app/services/catalog/unshare_resource.rb
@@ -11,13 +11,12 @@ module Catalog
 
     def process
       validate_groups
-      @group_uuids.each do |group_uuid|
-        @permissions.each do |permission|
-          AccessControlEntry.where(:group_uuid => group_uuid,
-                                   :permission => permission,
-                                   :aceable    => @object).destroy_all
-        end
-      end
+      AccessControlEntry.
+        joins(:permissions).
+        where(:group_uuid => @group_uuids,
+              :aceable    => @object,
+              :permissions => {:name => @permissions}).
+        destroy_all
       self
     end
   end

--- a/app/services/catalog/unshare_resource.rb
+++ b/app/services/catalog/unshare_resource.rb
@@ -11,12 +11,12 @@ module Catalog
 
     def process
       validate_groups
-      AccessControlEntry.
-        joins(:permissions).
-        where(:group_uuid => @group_uuids,
-              :aceable    => @object,
-              :permissions => {:name => @permissions}).
-        destroy_all
+      AccessControlEntry
+        .joins(:permissions)
+        .where(:group_uuid  => @group_uuids,
+               :aceable     => @object,
+               :permissions => {:name => @permissions})
+        .destroy_all
       self
     end
   end

--- a/db/migrate/20200114164456_normalize_ace_table.rb
+++ b/db/migrate/20200114164456_normalize_ace_table.rb
@@ -1,17 +1,21 @@
 class NormalizeAceTable < ActiveRecord::Migration[5.2]
   def up
     create_table :permissions do |t|
-      t.integer :name
-
       t.timestamps
+    end
+
+    execute <<-SQL
+      CREATE TYPE permissions_name AS ENUM ('read', 'delete', 'order', 'update');
+    SQL
+    add_column :permissions, :name, :permissions_name
+    add_index :permissions, :name
+
+    %w[read delete order update].each do |perm|
+      Permission.create!(:name => perm)
     end
 
     create_join_table :access_control_entries, :permissions do |t|
       t.index [:access_control_entry_id, :permission_id], :name => "index_ace_permissions_on_ace_id_and_permission_id"
-    end
-
-    (0..3).each do |permission|
-      Permission.create!(:name => permission)
     end
 
     AccessControlEntry.all.each do |entry|
@@ -27,7 +31,19 @@ class NormalizeAceTable < ActiveRecord::Migration[5.2]
   def down
     add_column :access_control_entries, :permission, :string
     add_index(:access_control_entries, [:group_uuid, :aceable_type, :permission], :name => "index_on_group_uuid_aceable_type_permission")
+
+    AccessControlEntry.all.each do |entry|
+      entry.permissions.each do |perm|
+        entry.permission = perm.name
+        entry.save!
+      end
+    end
+
     drop_table :permissions
+    remove_index :access_control_entries, :name => :index_on_group_uuid_aceable_type
+    execute <<-SQL
+      DROP TYPE permissions_name;
+    SQL
     drop_join_table :access_control_entries, :permissions
   end
 end

--- a/db/migrate/20200114164456_normalize_ace_table.rb
+++ b/db/migrate/20200114164456_normalize_ace_table.rb
@@ -1,8 +1,6 @@
 class NormalizeAceTable < ActiveRecord::Migration[5.2]
   def up
-    create_table :permissions do |t|
-      t.timestamps
-    end
+    create_table(:permissions, &:timestamps)
 
     execute <<-SQL
       CREATE TYPE permissions_name AS ENUM ('read', 'delete', 'order', 'update');
@@ -14,15 +12,41 @@ class NormalizeAceTable < ActiveRecord::Migration[5.2]
       Permission.create!(:name => perm)
     end
 
-    create_join_table :access_control_entries, :permissions do |t|
-      t.index [:access_control_entry_id, :permission_id], :name => "index_ace_permissions_on_ace_id_and_permission_id"
+    create_table :access_control_permissions do |t|
+      t.bigint :tenant_id
+      t.bigint :access_control_entry_id
+      t.bigint :permission_id
+
+      t.timestamps
+
+      t.index [:tenant_id, :access_control_entry_id, :permission_id], :name => "index_tenant_ace_permissions_on_ace_id_and_permission_id"
     end
 
-    AccessControlEntry.all.each do |entry|
-      perm = entry.send(:permission)
-      permission = Permission.find_by(:name => perm)
-      entry.permissions << permission
+    ###### -------Database Operations before table modification--------- ######
+
+    # Lookup all distinct group, aceable entries
+    ace_distinct = AccessControlEntry.distinct.pluck(:group_uuid, :aceable_type, :aceable_id)
+    ace_distinct.each do |ace|
+      # pull a group of all known group_uuid, aceable entries to grab the accumulated permissions
+      aces = AccessControlEntry.where(:group_uuid => ace[0], :aceable_type => ace[1], :aceable_id => ace[2])
+      perms = aces.map(&:permission)
+      current_ace = nil
+      # Loop through the permissions and apply them to the current distinct ace record
+      perms.each do |perm|
+        permission = Permission.find_by(:name => perm)
+        # Set the current record that we are going to deem the savable record
+        current_ace = aces.first
+        current_ace.access_control_permissions.build(:permission_id => permission.id, :tenant_id => current_ace.tenant_id)
+      end
+      # When finished with this ACE record, set the soon to be deleted permission record to 'distinct_group'
+      current_ace.permission = 'distinct_group'
+      current_ace.save!
     end
+
+    # Destroy all ACE records that do not have a permission of 'distinct_group'
+    AccessControlEntry.where.not(:permission => 'distinct_group').delete_all
+
+    ###### ------------------------------------------------------------- ######
 
     remove_column :access_control_entries, :permission
     add_index(:access_control_entries, [:group_uuid, :aceable_type], :name => "index_on_group_uuid_aceable_type")
@@ -32,18 +56,31 @@ class NormalizeAceTable < ActiveRecord::Migration[5.2]
     add_column :access_control_entries, :permission, :string
     add_index(:access_control_entries, [:group_uuid, :aceable_type, :permission], :name => "index_on_group_uuid_aceable_type_permission")
 
+    ###### -------Database Operations before table modification--------- ######
+
+    # Lookup all Access Control Entries
     AccessControlEntry.all.each do |entry|
-      entry.permissions.each do |perm|
-        entry.permission = perm.name
-        entry.save!
+      # Grab all current permissions for this group_uuid and aceable entity
+      all_permissions = entry.permissions.map(&:name)
+      # Apply each permission, starting with the current record, then create an identical record
+      #  for the rest of the permissions
+      all_permissions.each do |perm|
+        if entry.permission.nil?
+          entry.permission = perm
+          entry.save!
+        else
+          AccessControlEntry.create!(:group_uuid => entry.group_uuid, :permission => perm, :aceable_type => entry.aceable_type, :aceable_id => entry.aceable_id)
+        end
       end
     end
+
+    ###### ------------------------------------------------------------- ######
 
     drop_table :permissions
     remove_index :access_control_entries, :name => :index_on_group_uuid_aceable_type
     execute <<-SQL
       DROP TYPE permissions_name;
     SQL
-    drop_join_table :access_control_entries, :permissions
+    drop_table :access_control_permissions
   end
 end

--- a/db/migrate/20200114164456_normalize_ace_table.rb
+++ b/db/migrate/20200114164456_normalize_ace_table.rb
@@ -1,0 +1,33 @@
+class NormalizeAceTable < ActiveRecord::Migration[5.2]
+  def up
+    create_table :permissions do |t|
+      t.integer :name
+
+      t.timestamps
+    end
+
+    create_join_table :access_control_entries, :permissions do |t|
+      t.index [:access_control_entry_id, :permission_id], :name => "index_ace_permissions_on_ace_id_and_permission_id"
+    end
+
+    (0..3).each do |permission|
+      Permission.create!(:name => permission)
+    end
+
+    AccessControlEntry.all.each do |entry|
+      perm = entry.send(:permission)
+      permission = Permission.find_by(:name => perm)
+      entry.permissions << permission
+    end
+
+    remove_column :access_control_entries, :permission
+    add_index(:access_control_entries, [:group_uuid, :aceable_type], :name => "index_on_group_uuid_aceable_type")
+  end
+
+  def down
+    add_column :access_control_entries, :permission, :string
+    add_index(:access_control_entries, [:group_uuid, :aceable_type, :permission], :name => "index_on_group_uuid_aceable_type_permission")
+    drop_table :permissions
+    drop_join_table :access_control_entries, :permissions
+  end
+end

--- a/db/migrate/20200114164456_normalize_ace_table.rb
+++ b/db/migrate/20200114164456_normalize_ace_table.rb
@@ -30,12 +30,11 @@ class NormalizeAceTable < ActiveRecord::Migration[5.2]
       # pull a group of all known group_uuid, aceable entries to grab the accumulated permissions
       aces = AccessControlEntry.where(:group_uuid => ace[0], :aceable_type => ace[1], :aceable_id => ace[2])
       perms = aces.map(&:permission)
-      current_ace = nil
+      # Set the current record that we are going to deem the savable record
+      current_ace = aces.first
       # Loop through the permissions and apply them to the current distinct ace record
       perms.each do |perm|
         permission = Permission.find_by(:name => perm)
-        # Set the current record that we are going to deem the savable record
-        current_ace = aces.first
         current_ace.access_control_permissions.build(:permission_id => permission.id, :tenant_id => current_ace.tenant_id)
       end
       # When finished with this ACE record, set the soon to be deleted permission record to 'distinct_group'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,11 +106,8 @@ ActiveRecord::Schema.define(version: 2020_01_14_164456) do
     t.index ["tenant_id"], name: "index_orders_on_tenant_id"
   end
 
-  create_table "permissions", force: :cascade do |t|
-    t.integer "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
+# Could not dump table "permissions" because of following StandardError
+#   Unknown type 'permissions_name' for column 'name'
 
   create_table "portfolio_item_tags", id: :serial, force: :cascade do |t|
     t.bigint "tag_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,8 +37,8 @@ ActiveRecord::Schema.define(version: 2020_01_14_164456) do
     t.integer "order_item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "state", default: 0
     t.string "reason"
+    t.integer "state", default: 0
     t.bigint "tenant_id"
     t.datetime "request_completed_at"
     t.index ["tenant_id"], name: "index_approval_requests_on_tenant_id"
@@ -83,8 +83,8 @@ ActiveRecord::Schema.define(version: 2020_01_14_164456) do
     t.bigint "portfolio_item_id"
     t.jsonb "service_parameters"
     t.jsonb "provider_control_parameters"
-    t.jsonb "context"
     t.string "owner"
+    t.jsonb "context"
     t.string "external_url"
     t.string "insights_request_id"
     t.datetime "discarded_at"
@@ -138,6 +138,7 @@ ActiveRecord::Schema.define(version: 2020_01_14_164456) do
     t.string "distributor"
     t.string "documentation_url"
     t.string "support_url"
+    t.string "service_offering_icon_ref"
     t.datetime "discarded_at"
     t.string "owner"
     t.string "service_offering_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,10 +26,11 @@ ActiveRecord::Schema.define(version: 2020_01_14_164456) do
     t.index ["group_uuid", "aceable_type"], name: "index_on_group_uuid_aceable_type"
   end
 
-  create_table "access_control_entries_permissions", id: false, force: :cascade do |t|
-    t.bigint "access_control_entry_id", null: false
-    t.bigint "permission_id", null: false
-    t.index ["access_control_entry_id", "permission_id"], name: "index_ace_permissions_on_ace_id_and_permission_id"
+  create_table "access_control_permissions", force: :cascade do |t|
+    t.bigint "tenant_id"
+    t.bigint "access_control_entry_id"
+    t.bigint "permission_id"
+    t.index ["tenant_id", "access_control_entry_id", "permission_id"], name: "index_tenant_ace_permissions_on_ace_id_and_permission_id"
   end
 
   create_table "approval_requests", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_06_182459) do
+ActiveRecord::Schema.define(version: 2020_01_14_164456) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,13 +18,18 @@ ActiveRecord::Schema.define(version: 2019_12_06_182459) do
   create_table "access_control_entries", force: :cascade do |t|
     t.string "group_uuid"
     t.bigint "tenant_id"
-    t.string "permission"
     t.string "aceable_type"
     t.bigint "aceable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["aceable_type", "aceable_id"], name: "index_access_control_entries_on_aceable_type_and_aceable_id"
-    t.index ["group_uuid", "aceable_type", "permission"], name: "index_on_group_uuid_aceable_type_permission"
+    t.index ["group_uuid", "aceable_type"], name: "index_on_group_uuid_aceable_type"
+  end
+
+  create_table "access_control_entries_permissions", id: false, force: :cascade do |t|
+    t.bigint "access_control_entry_id", null: false
+    t.bigint "permission_id", null: false
+    t.index ["access_control_entry_id", "permission_id"], name: "index_ace_permissions_on_ace_id_and_permission_id"
   end
 
   create_table "approval_requests", force: :cascade do |t|
@@ -32,8 +37,8 @@ ActiveRecord::Schema.define(version: 2019_12_06_182459) do
     t.integer "order_item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "reason"
     t.integer "state", default: 0
+    t.string "reason"
     t.bigint "tenant_id"
     t.datetime "request_completed_at"
     t.index ["tenant_id"], name: "index_approval_requests_on_tenant_id"
@@ -78,8 +83,8 @@ ActiveRecord::Schema.define(version: 2019_12_06_182459) do
     t.bigint "portfolio_item_id"
     t.jsonb "service_parameters"
     t.jsonb "provider_control_parameters"
-    t.string "owner"
     t.jsonb "context"
+    t.string "owner"
     t.string "external_url"
     t.string "insights_request_id"
     t.datetime "discarded_at"
@@ -99,6 +104,12 @@ ActiveRecord::Schema.define(version: 2019_12_06_182459) do
     t.datetime "discarded_at"
     t.index ["discarded_at"], name: "index_orders_on_discarded_at"
     t.index ["tenant_id"], name: "index_orders_on_tenant_id"
+  end
+
+  create_table "permissions", force: :cascade do |t|
+    t.integer "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "portfolio_item_tags", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,8 @@ ActiveRecord::Schema.define(version: 2020_01_14_164456) do
     t.bigint "tenant_id"
     t.bigint "access_control_entry_id"
     t.bigint "permission_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["tenant_id", "access_control_entry_id", "permission_id"], name: "index_tenant_ace_permissions_on_ace_id_and_permission_id"
   end
 

--- a/spec/factories/access_control_entry.rb
+++ b/spec/factories/access_control_entry.rb
@@ -11,5 +11,13 @@ FactoryBot.define do
     trait :has_read_permission do
       permissions { [Permission.create!(:name => 'read')] }
     end
+
+    trait :has_delete_permission do
+      permissions { [Permission.create!(:name => 'delete')] }
+    end
+
+    trait :has_read_and_update_permission do
+      permissions { [Permission.create!(:name => 'read'), Permission.create!(:name => 'update')] }
+    end
   end
 end

--- a/spec/factories/access_control_entry.rb
+++ b/spec/factories/access_control_entry.rb
@@ -5,19 +5,24 @@ FactoryBot.define do
     aceable_type { "Portfolio" }
 
     trait :has_update_permission do
-      permissions { [Permission.create!(:name => 'update')] }
+      access_control_permissions { [create(:access_control_permission, :has_update_permission)] }
     end
 
     trait :has_read_permission do
-      permissions { [Permission.create!(:name => 'read')] }
+      access_control_permissions { [create(:access_control_permission, :has_read_permission)] }
     end
 
     trait :has_delete_permission do
-      permissions { [Permission.create!(:name => 'delete')] }
+      access_control_permissions { [create(:access_control_permission, :has_delete_permission)] }
     end
 
     trait :has_read_and_update_permission do
-      permissions { [Permission.create!(:name => 'read'), Permission.create!(:name => 'update')] }
+      access_control_permissions do
+        [
+          create(:access_control_permission, :has_read_permission),
+          create(:access_control_permission, :has_update_permission),
+        ]
+      end
     end
   end
 end

--- a/spec/factories/access_control_entry.rb
+++ b/spec/factories/access_control_entry.rb
@@ -2,7 +2,14 @@ FactoryBot.define do
   factory :access_control_entry, :traits => [:has_tenant] do
     group_uuid { "123-456" }
     aceable_id { "6756" }
-    permission { "read" }
     aceable_type { "Portfolio" }
+
+    trait :has_update_permission do
+      permissions { [Permission.create!(:name => 'update')] }
+    end
+
+    trait :has_read_permission do
+      permissions { [Permission.create!(:name => 'read')] }
+    end
   end
 end

--- a/spec/factories/access_control_permission.rb
+++ b/spec/factories/access_control_permission.rb
@@ -6,10 +6,10 @@ FactoryBot.define do
   end
 
   trait :has_update_permission do
-    permission { Permission.create!(:name => 'update') }
+    permission { Permission.find_or_create_by(:name => 'update') }
   end
 
   trait :has_delete_permission do
-    permission { Permission.create!(:name => 'delete') }
+    permission { Permission.find_or_create_by(:name => 'delete') }
   end
 end

--- a/spec/factories/access_control_permission.rb
+++ b/spec/factories/access_control_permission.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :access_control_permission, :traits => [:has_tenant]
+
+  trait :has_read_permission do
+    permission
+  end
+
+  trait :has_update_permission do
+    permission { Permission.create!(:name => 'update') }
+  end
+
+  trait :has_delete_permission do
+    permission { Permission.create!(:name => 'delete') }
+  end
+end

--- a/spec/factories/permission.rb
+++ b/spec/factories/permission.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :permission do
+    name { "read" }
+  end
+end

--- a/spec/models/access_control_entry_spec.rb
+++ b/spec/models/access_control_entry_spec.rb
@@ -3,4 +3,23 @@ RSpec.describe AccessControlEntry, :type => :model do
   it { is_expected.to have_db_column(:aceable_type).of_type(:string) }
 
   it { is_expected.to belong_to(:aceable) }
+
+  context "Permissions" do
+    let(:ace) { create(:access_control_entry, :has_read_permission) }
+    describe "add_new_permissions" do
+      it "only adds new" do
+        new_perm = ["delete"]
+        expect(ace.permissions.map(&:name)).to eq ["read"]
+        ace.add_new_permissions(new_perm)
+        expect(ace.permissions.map(&:name)).to eq ["read", "delete"]
+      end
+
+      it "does not add existing" do
+        new_perm = ["read"]
+        expect(ace.permissions.map(&:name)).to eq ["read"]
+        ace.add_new_permissions(new_perm)
+        expect(ace.permissions.map(&:name)).to eq ["read"]
+      end
+    end
+  end
 end

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -1,6 +1,6 @@
 describe "OpenAPI stuff" do
   include RandomWordsSpecHelper
-  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags tags images icons service_plans access_control_entries].freeze
+  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags tags images icons service_plans access_control_entries access_control_entries_permissions permissions].freeze
   let(:rails_routes) do
     Rails.application.routes.routes.each_with_object([]) do |route, array|
       r = ActionDispatch::Routing::RouteWrapper.new(route)

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -1,6 +1,6 @@
 describe "OpenAPI stuff" do
   include RandomWordsSpecHelper
-  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags tags images icons service_plans access_control_entries access_control_entries_permissions permissions].freeze
+  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags tags images icons service_plans access_control_entries access_control_permissions permissions].freeze
   let(:rails_routes) do
     Rails.application.routes.routes.each_with_object([]) do |route, array|
       r = ActionDispatch::Routing::RouteWrapper.new(route)

--- a/spec/requests/api/v1.0/portfolios_rbac_delete_access_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_rbac_delete_access_spec.rb
@@ -20,7 +20,7 @@ describe 'Portfolios Delete Access RBAC API', :type => [:request, :v1] do
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', permission).and_return(access_obj)
         allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
         allow(access_obj).to receive(:process).and_return(access_obj)
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1)
+        create(:access_control_entry, :has_delete_permission, :group_uuid => group1.uuid, :aceable => portfolio1)
       end
 
       it 'only allows deleting a specific portfolio' do

--- a/spec/requests/api/v1.0/portfolios_rbac_read_access_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_rbac_read_access_spec.rb
@@ -19,7 +19,7 @@ describe "v1.0 - Portfolios Read Access RBAC API", :type => [:request, :v1] do
   describe "GET /portfolios" do
     context "no permission to read portfolios" do
       before do
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'read', :aceable => portfolio2)
+        create(:access_control_entry, :has_read_permission, :group_uuid => group1.uuid, :aceable => portfolio2)
       end
 
       it "no access" do
@@ -71,7 +71,7 @@ describe "v1.0 - Portfolios Read Access RBAC API", :type => [:request, :v1] do
         allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
         allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, list_group_options).and_return([group1])
         allow(access_obj).to receive(:process).and_return(access_obj)
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'read', :aceable => portfolio1)
+        create(:access_control_entry, :has_read_permission, :group_uuid => group1.uuid, :aceable => portfolio1)
       end
 
       it 'ok' do

--- a/spec/requests/api/v1.0/portfolios_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_rbac_spec.rb
@@ -38,7 +38,7 @@ describe "v1.0 - Portfolios RBAC API", :type => [:request, :v1] do
     end
 
     it 'returns status code 200' do
-      create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'read', :aceable => portfolio1)
+      create(:access_control_entry, :has_read_permission, :group_uuid => group1.uuid, :aceable => portfolio1)
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
       allow(access_obj).to receive(:process).and_return(access_obj)
       get "#{api_version}/portfolios", :headers => default_headers
@@ -59,8 +59,8 @@ describe "v1.0 - Portfolios RBAC API", :type => [:request, :v1] do
     context "with filtering" do
       before do
         permission = 'read'
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1)
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio2)
+        create(:access_control_entry, :has_read_permission, :group_uuid => group1.uuid, :aceable => portfolio1)
+        create(:access_control_entry, :has_read_permission, :group_uuid => group1.uuid, :aceable => portfolio2)
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', permission).and_return(access_obj)
         allow(access_obj).to receive(:process).and_return(access_obj)
         get "#{api_version}/portfolios?filter[name]=#{portfolio1.name}", :headers => default_headers
@@ -133,22 +133,21 @@ describe "v1.0 - Portfolios RBAC API", :type => [:request, :v1] do
   end
 
   context "when the permissions array is proper" do
+    let(:permissions) { ['update'] }
     describe "#share" do
       it "goes through validation" do
-        permissions = ["update"]
+        has_permissions(permissions)
         post "#{api_version}/portfolios/#{portfolio1.id}/share", :headers => default_headers, :params => {
           :permissions => permissions,
           :group_uuids => [group1.uuid]
         }
-
         expect(response).to have_http_status(:no_content)
       end
     end
 
     describe "#unshare" do
       it "goes through validation" do
-        permissions = ["update"]
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'update', :aceable => portfolio1)
+        create(:access_control_entry, :has_update_permission, :group_uuid => group1.uuid, :aceable => portfolio1)
         post "#{api_version}/portfolios/#{portfolio1.id}/unshare", :headers => default_headers, :params => {
           :permissions => permissions,
           :group_uuids => [group1.uuid]

--- a/spec/requests/api/v1.0/portfolios_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_rbac_spec.rb
@@ -136,7 +136,7 @@ describe "v1.0 - Portfolios RBAC API", :type => [:request, :v1] do
     let(:permissions) { ['update'] }
     describe "#share" do
       it "goes through validation" do
-        has_permissions(permissions)
+        permissions_exist?(permissions)
         post "#{api_version}/portfolios/#{portfolio1.id}/share", :headers => default_headers, :params => {
           :permissions => permissions,
           :group_uuids => [group1.uuid]

--- a/spec/requests/api/v1.0/portfolios_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_rbac_spec.rb
@@ -136,7 +136,6 @@ describe "v1.0 - Portfolios RBAC API", :type => [:request, :v1] do
     let(:permissions) { ['update'] }
     describe "#share" do
       it "goes through validation" do
-        permissions_exist?(permissions)
         post "#{api_version}/portfolios/#{portfolio1.id}/share", :headers => default_headers, :params => {
           :permissions => permissions,
           :group_uuids => [group1.uuid]

--- a/spec/requests/api/v1.0/portfolios_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_rbac_spec.rb
@@ -97,8 +97,8 @@ describe "v1.0 - Portfolios RBAC API", :type => [:request, :v1] do
     context "when user has RBAC update portfolios access" do
       let(:portfolio_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => true) }
       before do
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'read', :aceable => portfolio1)
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'update', :aceable => portfolio1)
+        create(:access_control_entry, :has_read_permission, :group_uuid => group1.uuid, :aceable => portfolio1)
+        create(:access_control_entry, :has_update_permission, :group_uuid => group1.uuid, :aceable => portfolio1)
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'create').and_return(access_obj)
         allow(access_obj).to receive(:process).and_return(access_obj)

--- a/spec/requests/api/v1.0/portfolios_rbac_update_access_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_rbac_update_access_spec.rb
@@ -45,7 +45,7 @@ describe "v1.0 - Portfolios Write Access RBAC API", :type => [:request, :v1] do
     context "user has update permission" do
       before do
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'update').and_return(access_obj)
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => permission, :aceable => portfolio1)
+        create(:access_control_entry, :has_update_permission, :group_uuid => group1.uuid, :aceable => portfolio1)
       end
 
       it 'only allows updating a specific portfolio' do
@@ -62,7 +62,7 @@ describe "v1.0 - Portfolios Write Access RBAC API", :type => [:request, :v1] do
     context "user has read only permission for a specific portfolio" do
       before do
         allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'update').and_return(access_obj)
-        create(:access_control_entry, :group_uuid => group1.uuid, :permission => 'read', :aceable => portfolio1)
+        create(:access_control_entry, :has_read_permission, :group_uuid => group1.uuid, :aceable => portfolio1)
       end
 
       it 'fails updating a portfolio' do

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -298,6 +298,7 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
     shared_examples_for "#shared_test" do
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
+          has_permissions(['read'])
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
           allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
           post "#{api_version}/portfolios/#{shared_portfolio.id}/share", :params => attributes, :headers => default_headers

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -298,7 +298,6 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
     shared_examples_for "#shared_test" do
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
-          permissions_exist?(['read'])
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
           allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
           post "#{api_version}/portfolios/#{shared_portfolio.id}/share", :params => attributes, :headers => default_headers

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -298,7 +298,7 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
     shared_examples_for "#shared_test" do
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
-          has_permissions(['read'])
+          permissions_exist?(['read'])
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
           allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
           post "#{api_version}/portfolios/#{shared_portfolio.id}/share", :params => attributes, :headers => default_headers

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -13,8 +13,7 @@ describe Catalog::ShareInfo, :type => :service do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, pagination_options).and_return([group1])
-    create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => portfolio)
-    create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[1], :aceable => portfolio)
+    create(:access_control_entry, :has_read_and_update_permission, :group_uuid => group1.uuid, :aceable => portfolio)
   end
 
   let(:subject) { described_class.new(params) }
@@ -35,7 +34,7 @@ describe Catalog::ShareInfo, :type => :service do
 
   context "when only some group uuids exist" do
     before do
-      create(:access_control_entry, :group_uuid => "non-existent", :permission => permissions[1], :aceable => portfolio)
+      create(:access_control_entry, :has_update_permission, :group_uuid => "non-existent", :aceable => portfolio)
     end
 
     it_behaves_like "#process"

--- a/spec/services/catalog/share_resource_spec.rb
+++ b/spec/services/catalog/share_resource_spec.rb
@@ -13,7 +13,7 @@ describe Catalog::ShareResource, :type => :service do
   end
 
   before do
-    has_permissions(permissions)
+    permissions_exist?(permissions)
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])

--- a/spec/services/catalog/share_resource_spec.rb
+++ b/spec/services/catalog/share_resource_spec.rb
@@ -13,7 +13,6 @@ describe Catalog::ShareResource, :type => :service do
   end
 
   before do
-    permissions_exist?(permissions)
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])

--- a/spec/services/catalog/share_resource_spec.rb
+++ b/spec/services/catalog/share_resource_spec.rb
@@ -13,6 +13,7 @@ describe Catalog::ShareResource, :type => :service do
   end
 
   before do
+    has_permissions(permissions)
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])
@@ -23,6 +24,6 @@ describe Catalog::ShareResource, :type => :service do
   it "#process" do
     subject.process
     portfolio.reload
-    expect(portfolio.access_control_entries.count).to eq(2)
+    expect(portfolio.access_control_entries.first.permissions.count).to eq(2)
   end
 end

--- a/spec/services/catalog/unshare_resource_spec.rb
+++ b/spec/services/catalog/unshare_resource_spec.rb
@@ -16,8 +16,8 @@ describe Catalog::UnshareResource, :type => :service do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])
-    create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => portfolio)
-    create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[1], :aceable => portfolio)
+    create(:access_control_entry, :has_read_permission, :group_uuid => group1.uuid, :aceable => portfolio)
+    create(:access_control_entry, :has_update_permission, :group_uuid => group1.uuid, :aceable => portfolio)
   end
 
   let(:subject) { described_class.new(params) }

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -11,10 +11,6 @@ module ServiceSpecHelper
     end
   end
 
-  def permissions_exist?(perms)
-    perms.each { |perm| Permission.create!(:name => perm) }
-  end
-
   def with_modified_env(options, &block)
     Thread.current[:api_instance] = nil
     ClimateControl.modify(options, &block)

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -11,6 +11,10 @@ module ServiceSpecHelper
     end
   end
 
+  def has_permissions(perms)
+    perms.each { |perm| Permission.create!(:name => perm) }
+  end
+
   def with_modified_env(options, &block)
     Thread.current[:api_instance] = nil
     ClimateControl.modify(options, &block)

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -11,7 +11,7 @@ module ServiceSpecHelper
     end
   end
 
-  def has_permissions(perms)
+  def permissions_exist?(perms)
     perms.each { |perm| Permission.create!(:name => perm) }
   end
 

--- a/spec/support/sharing_objects.rb
+++ b/spec/support/sharing_objects.rb
@@ -1,11 +1,12 @@
 RSpec.shared_context "sharing_objects" do
   let(:app_name) { 'catalog' }
   let!(:shared_portfolio) { create(:portfolio) }
+  let(:permissions) { %w[read] }
   let(:http_status) { '204' }
   let(:attributes) { {:group_uuids => group_uuids, :permissions => permissions} }
-  let(:ace1) { create(:access_control_entry, :group_uuid => group1.uuid, :aceable => shared_portfolio) }
-  let(:ace2) { create(:access_control_entry, :group_uuid => group2.uuid, :aceable => shared_portfolio) }
-  let(:ace3) { create(:access_control_entry, :group_uuid => group3.uuid, :aceable => shared_portfolio) }
+  let(:ace1) { create(:access_control_entry, :has_read_permission, :group_uuid => group1.uuid, :aceable => shared_portfolio) }
+  let(:ace2) { create(:access_control_entry, :has_read_permission, :group_uuid => group2.uuid, :aceable => shared_portfolio) }
+  let(:ace3) { create(:access_control_entry, :has_read_permission, :group_uuid => group3.uuid, :aceable => shared_portfolio) }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:group_uuids) { [group1.uuid, group2.uuid, group3.uuid] }

--- a/spec/support/sharing_objects.rb
+++ b/spec/support/sharing_objects.rb
@@ -1,12 +1,11 @@
 RSpec.shared_context "sharing_objects" do
   let(:app_name) { 'catalog' }
   let!(:shared_portfolio) { create(:portfolio) }
-  let(:permissions) { %w[read] }
   let(:http_status) { '204' }
   let(:attributes) { {:group_uuids => group_uuids, :permissions => permissions} }
-  let(:ace1) { create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => shared_portfolio) }
-  let(:ace2) { create(:access_control_entry, :group_uuid => group2.uuid, :permission => permissions[0], :aceable => shared_portfolio) }
-  let(:ace3) { create(:access_control_entry, :group_uuid => group3.uuid, :permission => permissions[0], :aceable => shared_portfolio) }
+  let(:ace1) { create(:access_control_entry, :group_uuid => group1.uuid, :aceable => shared_portfolio) }
+  let(:ace2) { create(:access_control_entry, :group_uuid => group2.uuid, :aceable => shared_portfolio) }
+  let(:ace3) { create(:access_control_entry, :group_uuid => group3.uuid, :aceable => shared_portfolio) }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:group_uuids) { [group1.uuid, group2.uuid, group3.uuid] }


### PR DESCRIPTION
This is a followup to https://github.com/RedHatInsights/catalog-api/pull/500 as discussed [here](https://github.com/RedHatInsights/catalog-api/pull/500#pullrequestreview-334112829).

1. Pull out `permissions` into its own table.
2. Set the permissions as enum and lock the model as read only.

Potential performance increases:

1. ACE table only stores guids and polymorphic objects removing permissions duplication
2. Permission table only needs to support reads
3. Allows for 1 ACE row to support multiple permissions rows.