### PR TITLE
Update CMD script to only start the rails application if the db migrations succeed

### DIFF
--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -24,5 +24,4 @@ function check_svc_status() {
 # Wait for postgres to be ready
 check_svc_status $DATABASE_HOST $DATABASE_PORT
 
-bundle exec rake db:migrate
-bundle exec rails server
+bundle exec rake db:migrate && bundle exec rails server


### PR DESCRIPTION
As discussed in https://github.com/RedHatInsights/insights-api-common-rails/pull/143 and https://github.com/RedHatInsights/insights-api-common-rails/issues/146 we think it is a good idea to change the startup behavior of our applications.

We shouldn't start the application if database migrations fail, which would leave the application running but in a not-100% state. 