### PR TITLE
Add max image size to description of CreateIcon object in openapi.json

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -37,7 +37,7 @@ class Image < ApplicationRecord
 
   def image_size
     if decoded_image.bytes.count > MAX_IMAGE_SIZE
-      raise Catalog::InvalidParameter, "Image size exceeds max limit of #{MAX_IMAGE_SIZE.to_s(:human_size)}"
+      errors.add(:content, "Image size exceeds max limit of #{MAX_IMAGE_SIZE.to_s(:human_size)}")
     end
   end
 end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -3040,7 +3040,7 @@
           "content": {
             "type": "string",
             "title": "Content",
-            "description": "The binary image contents",
+            "description": "The binary image contents, maximum size is 250KB",
             "format": "binary"
           },
           "portfolio_id": {

--- a/spec/requests/api/v1.0/icons_spec.rb
+++ b/spec/requests/api/v1.0/icons_spec.rb
@@ -156,6 +156,10 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
       it "returns bad request" do
         expect(response).to have_http_status(:bad_request)
       end
+
+      it "throws ActiveRecord::RecordInvalid" do
+        expect(first_error_detail).to match(/ActiveRecord::RecordInvalid/)
+      end
     end
   end
 


### PR DESCRIPTION
~~Instead of just using a `validate` call which appears to not have been firing the way it is expected to in real life usage.~~
Found out the only way this was possible is that @Hyperkid123 was using an image that was already in the system. 

Also added the max image size to the description of the openapi json.

@miq-bot add_label bug