### PR TITLE
Require portfolio_id when creating a portfolio_item

### DIFF
--- a/app/controllers/api/v1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1/portfolio_items_controller.rb
@@ -24,7 +24,6 @@ module Api
       end
 
       def create
-        params.require(:portfolio_id)
         so = ServiceOffering::AddToPortfolioItem.new(params_for_create)
         render :json => so.process.item
       end

--- a/app/controllers/api/v1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1/portfolio_items_controller.rb
@@ -24,6 +24,7 @@ module Api
       end
 
       def create
+        params.require(:portfolio_id)
         so = ServiceOffering::AddToPortfolioItem.new(params_for_create)
         render :json => so.process.item
       end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -11,7 +11,7 @@ class PortfolioItem < ApplicationRecord
 
   belongs_to :icon, :optional => true
   has_many :service_plans, :dependent => :destroy
-  belongs_to :portfolio, :optional => true
+  belongs_to :portfolio
   validates :service_offering_ref, :name, :presence => true
   validates :favorite_before_type_cast, :format => { :with => /\A(true|false)\z/i }, :allow_blank => true
 end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -901,6 +901,7 @@
                 "schema": {
                   "$ref": "#/components/schemas/PortfolioItem",
                   "required": [
+                    "portfolio_id",
                     "name",
                     "service_offering_source_ref"
                   ]

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -901,7 +901,6 @@
                 "schema": {
                   "$ref": "#/components/schemas/PortfolioItem",
                   "required": [
-                    "portfolio_id",
                     "name",
                     "service_offering_source_ref"
                   ]
@@ -3026,7 +3025,14 @@
       },
       "CreatePortfolioItem": {
         "type": "object",
+        "required": ["portfolio_id"],
         "properties": {
+          "portfolio_id": {
+            "type": "string",
+            "title": "Portfolio ID",
+            "description": "The Portfolio this portfolio item should belong to",
+            "example": "1"
+          },
           "service_offering_ref": {
             "type": "string",
             "title": "Service Offering Ref",

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -180,7 +180,7 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
 
       it "returns a required parameter error in the body" do
         post "#{api_version}/portfolio_items", :params => params, :headers => default_headers
-        expect(json["errors"].first["detail"]).to match(/param is missing or the value is empty: portfolio_id/)
+        expect(first_error_detail).to match(/missing required parameters: portfolio_id/)
       end
     end
 

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -163,7 +163,7 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
 
   context "when adding portfolio items" do
     let(:add_to_portfolio_svc) { double(ServiceOffering::AddToPortfolioItem) }
-    let(:params) { {:service_offering_ref => service_offering_ref, :portfolio_id => portfolio.id} }
+    let(:params) { {:service_offering_ref => service_offering_ref, :portfolio_id => portfolio.id.to_s} }
     let(:permitted_params) { ActionController::Parameters.new(params).permit(:service_offering_ref, :portfolio_id) }
 
     before do


### PR DESCRIPTION
It appears there are currently two ways to create new portfolio items, one is to POST to  `/portfolios/:portfolio_id/portfolio_items` (which includes the portfolio_id by definition), and the other is to POST to `/portfolio_items` directly. The latter did not require a portfolio_id, and I have also removed the `optional: true` from the association since it doesn't make sense to not have a portfolio id on a portfolio item anymore.

https://projects.engineering.redhat.com/browse/SSP-1118

@syncrou @lindgrenj6 @mkanoor Please Review