### PR TITLE
When calling list_groups from RBAC service use a higher limit

### DIFF
--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -2,6 +2,7 @@ module Catalog
   class ShareInfo
     require 'rbac-api-client'
     attr_reader :result
+    MAX_GROUPS_LIMIT = 500
 
     def initialize(options)
       @object = options[:object]
@@ -27,7 +28,7 @@ module Catalog
 
     def group_names
       @group_names ||= Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
-        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, {}).each_with_object({}) do |group, memo|
+        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, {:limit => MAX_GROUPS_LIMIT}).each_with_object({}) do |group, memo|
           memo[group.uuid] = group.name
         end
       end

--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -28,7 +28,7 @@ module Catalog
 
     def group_names
       @group_names ||= Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
-        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, {:limit => MAX_GROUPS_LIMIT}).each_with_object({}) do |group, memo|
+        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :limit => MAX_GROUPS_LIMIT).each_with_object({}) do |group, memo|
           memo[group.uuid] = group.name
         end
       end

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -353,10 +353,11 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
 
     context 'share_info' do
       include_context "sharing_objects"
+      let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT} }
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-          allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+          allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, pagination_options).and_return(groups)
           ace1
           ace2
           ace3

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -5,13 +5,14 @@ describe Catalog::ShareInfo, :type => :service do
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
+  let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT} }
 
   let(:params) { { :object => portfolio } }
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, pagination_options).and_return([group1])
     create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[0], :aceable => portfolio)
     create(:access_control_entry, :group_uuid => group1.uuid, :permission => permissions[1], :aceable => portfolio)
   end


### PR DESCRIPTION
The default of 10 causes too many requests into the RBAC service
Using a default of 500.
This was causing a slow screen rendering when displaying the Current Share Information in the UI.