### PR TITLE
Mark order as failed if task is an error status

### DIFF
--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -15,6 +15,7 @@ module Catalog
 
         add_task_update_message
         delegate_task if @task.state == "completed"
+        fail_order if @task.status == "error"
       end
 
       self
@@ -52,6 +53,11 @@ module Catalog
     def add_update_message(state, message)
       order_item.update_message(state, message)
       Rails.logger.send(state, message)
+    end
+
+    def fail_order
+      order_item.update!(:state => "Failed")
+      Catalog::OrderStateTransition.new(order_item.order_id).process
     end
   end
 end

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -12,6 +12,7 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
       create(:order_item, :topology_task_ref => "123")
     end
   end
+  let(:order_state_transition) { instance_double(Catalog::OrderStateTransition) }
 
   before do
     allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
@@ -143,6 +144,11 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
         context "when the status is 'error'" do
           let(:status) { "error" }
 
+          before do
+            allow(Catalog::OrderStateTransition).to receive(:new).with(order_item.order.id).and_return(order_state_transition)
+            allow(order_state_transition).to receive(:process)
+          end
+
           it "updates the item with a progress message" do
             subject.process
             progress_message = ProgressMessage.last
@@ -163,6 +169,13 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
               "Incoming task has no current relevent delegation"
             )
             subject.process
+          end
+
+          it "transitions the order state and marks the order item failed" do
+            expect(order_state_transition).to receive(:process)
+            subject.process
+            order_item.reload
+            expect(order_item.state).to eq("Failed")
           end
         end
 


### PR DESCRIPTION
When a task comes back with the status of "error", we were just logging it and not really doing anything else. Since we don't currently have a way to do something like a retry, there's really no reason to leave the order in the "ordering" state. This PR will mark the order item as failed and then transition the order, which will eventually transition to failed since one of the order items attached to it has failed.

https://projects.engineering.redhat.com/browse/SSP-1121

@syncrou @mkanoor @lindgrenj6 Please Review