### PR TITLE
Remove 404 response when un-tagging resources

### DIFF
--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -40,8 +40,8 @@ module Api
         primary_instance = primary_collection_model.find(request_path_parts["primary_collection_id"])
 
         parsed_body.each do |i|
-          tag = Tag.find_by!(Tag.parse(i["tag"]))
-          primary_instance.tags.destroy(tag)
+          tag = Tag.find_by(Tag.parse(i["tag"]))
+          primary_instance.tags.destroy(tag) if tag
         end
 
         head :no_content, :location => "#{instance_link(primary_instance)}/tags"

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -735,9 +735,6 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "description": "Portfolio Not Found."
           }
         },
         "requestBody": {
@@ -1294,9 +1291,6 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "description": "Portfolio Item Not Found."
           }
         },
         "requestBody": {

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -436,6 +436,13 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
       expect(portfolio_item.tags).to be_empty
     end
 
+    it "silences not found errors" do
+      portfolio_item.tags.destroy_all
+      post "#{api_version}/portfolio_items/#{portfolio_item.id}/untag", :headers => default_headers, :params => params
+
+      expect(response).to have_http_status(204)
+    end
+
     let(:endpoint) { "untag" }
     it_behaves_like "bad_tags"
     it_behaves_like "good_tags"

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -512,7 +512,14 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
         expect(portfolio.tags).to be_empty
       end
 
-      let(:endpoint) { "tag" }
+      it "silences not found errors" do
+        portfolio.tags.destroy_all
+        post "#{api_version}/portfolios/#{portfolio.id}/untag", :headers => default_headers, :params => params
+
+        expect(response).to have_http_status(204)
+      end
+
+      let(:endpoint) { "untag" }
       it_behaves_like "bad_tags"
       it_behaves_like "good_tags"
     end


### PR DESCRIPTION
This updates the behavior to be the same as tagging when we ignore `ActiveRecord::RecordNotUnique` errors.

cc @bdunne @Fryguy 