### PR TITLE
Use Pundit for portfolio_item collection scoping on portfolios

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'more_core_extensions', '~>3.5'
 gem 'pg', '~> 1.0', :require => false
 gem 'prometheus-client', '~> 0.8.0'
 gem 'puma', '~> 3.12.2'
+gem 'pundit'
 gem 'rack-cors', '>= 1.0.4'
 gem 'rest-client', '>= 1.8.0'
 

--- a/app/controllers/api/v1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1/portfolio_items_controller.rb
@@ -19,7 +19,7 @@ module Api
         elsif params[:tag_id]
           collection(Tag.find(params.require(:tag_id)).portfolio_items)
         else
-          collection(PortfolioItem.all)
+          collection(policy_scope(PortfolioItem.all))
         end
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::API
   include Insights::API::Common::ApplicationControllerMixins::RequestBodyValidation
   include Insights::API::Common::ApplicationControllerMixins::RequestPath
   include Insights::API::Common::ApplicationControllerMixins::Parameters
+  include Pundit
 
   around_action :with_current_request
 
@@ -37,5 +38,9 @@ class ApplicationController < ActionController::API
     required_entitlements = %i[ansible?]
 
     required_entitlements.map { |e| entitlement.send(e) }.all?
+  end
+
+  def pundit_user
+    Insights::API::Common::Request.current!
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,48 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  alias new? create?
+
+  def update?
+    false
+  end
+
+  alias edit? update?
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    include Api::V1::Mixins::ACEMixin
+    include Api::V1::Mixins::RBACMixin
+
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all # Override in sub-policy scope for now
+    end
+  end
+end

--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -1,0 +1,21 @@
+class PortfolioItemPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if catalog_administrator?
+        scope.all
+      else
+        check_access
+
+        ids = ace_ids('read', Portfolio)
+        scope.where(:portfolio_id => ids)
+      end
+    end
+
+    private
+
+    def check_access
+      access_obj = Insights::API::Common::RBAC::Access.new('portfolios', 'read').process
+      raise Catalog::NotAuthorized, "Not Authorized for portfolios" unless access_obj.accessible?
+    end
+  end
+end

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -18,5 +18,6 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "Catalog::ServiceOfferingArchived"   => :bad_request,
   "Catalog::SourcesError"              => :service_unavailable,
   "Catalog::TopologyError"             => :service_unavailable,
-  "Discard::DiscardError"              => :bad_request
+  "Discard::DiscardError"              => :bad_request,
+  "Pundit::NotAuthorizedError"         => :forbidden
 )

--- a/spec/policies/portfolio_item_policy_scope_spec.rb
+++ b/spec/policies/portfolio_item_policy_scope_spec.rb
@@ -1,0 +1,81 @@
+describe PortfolioItemPolicy::Scope, :type => [:service] do
+  let(:user) { nil }
+  let(:scope) { PortfolioItem }
+  let(:subject) { described_class.new(user, scope) }
+
+  describe "#resolve" do
+    let(:portfolio) { create(:portfolio) }
+    let!(:portfolio_item1) { create(:portfolio_item, :portfolio => portfolio) }
+    let!(:portfolio_item2) { create(:portfolio_item) }
+
+    around do |example|
+      with_modified_env(:RBAC_URL => "http://rbac") do
+        Insights::API::Common::Request.with_request(default_request) { example.call }
+      end
+    end
+
+    before do
+      allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with("Catalog Administrator").and_return(admin?)
+    end
+
+    context "when the user is a catalog administrator" do
+      let(:admin?) { true }
+
+      it "returns all of the portfolio items" do
+        expect(subject.resolve).to contain_exactly(portfolio_item1, portfolio_item2)
+      end
+    end
+
+    context "when the user is not a catalog administrator" do
+      let(:admin?) { false }
+      let(:access_object) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => accessible?) }
+
+      before do
+        allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_object)
+        allow(access_object).to receive(:process).and_return(access_object)
+      end
+
+      context "when the user does not have permission to read portfolios" do
+        let(:accessible?) { false }
+
+        it "raises a Catalog::NotAuthorized error" do
+          expect { subject.resolve }.to raise_error(Catalog::NotAuthorized, "Not Authorized for portfolios")
+        end
+      end
+
+      context "when the user has permission to read portfolios" do
+        let(:accessible?) { true }
+        let(:rbac_paginated_response) do
+          RBACApiClient::GroupPagination.new(
+            :meta => RBACApiClient::PaginationMeta.new(:count => 1),
+            :data => [RBACApiClient::GroupOut.new(:uuid => "123-456")]
+          )
+        end
+
+        before do
+          stub_request(:get, "http://rbac/api/rbac/v1/groups/?limit=10&offset=0&scope=principal").to_return(
+            :status  => 200,
+            :body    => rbac_paginated_response.to_json,
+            :headers => default_headers
+          )
+        end
+
+        context "when the access control entries exist" do
+          before do
+            create(:access_control_entry, :has_read_permission, :aceable_id => portfolio.id)
+          end
+
+          it "returns the set limited by the correct portfolio ids" do
+            expect(subject.resolve).to eq([portfolio_item1])
+          end
+        end
+
+        context "when access control entries do not exist" do
+          it "returns an empty set" do
+            expect(subject.resolve).to eq([])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
@@ -6,7 +6,7 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
   let(:double_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => true) }
 
   let(:block_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => false) }
-  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123-456") }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
@@ -20,8 +20,10 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
   describe "GET /portfolio_items" do
     it 'returns status code 200' do
       allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolio_items', 'read').and_return(access_obj)
+      allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
       allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
       allow(access_obj).to receive(:process).and_return(access_obj)
+      create(:access_control_entry, :has_read_permission, :aceable_id => portfolio.id)
       get "#{api_version}/portfolio_items", :headers => default_headers
 
       expect(response).to have_http_status(200)
@@ -30,7 +32,7 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
     end
 
     it 'returns status code 403' do
-      allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolio_items', 'read').and_return(block_access_obj)
+      allow(Insights::API::Common::RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(block_access_obj)
       allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with(catalog_admin_role).and_return(false)
       allow(block_access_obj).to receive(:process).and_return(block_access_obj)
       get "#{api_version}/portfolio_items", :headers => default_headers

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -52,6 +52,10 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
 
   describe "GET /portfolios/:portfolio_id/portfolio_items" do
     before do
+      portfolio_item_policy_scope = PortfolioItemPolicy::Scope.new(nil, PortfolioItem)
+      allow(PortfolioItemPolicy::Scope).to receive(:new).and_return(portfolio_item_policy_scope)
+      allow(portfolio_item_policy_scope).to receive(:resolve).and_return(PortfolioItem.all)
+
       get "#{api_version}/portfolios/#{portfolio_id}/portfolio_items", :headers => default_headers
     end
 
@@ -152,6 +156,12 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
 
   describe 'GET portfolio items' do
     context "v1.0" do
+      before do
+        portfolio_item_policy_scope = PortfolioItemPolicy::Scope.new(nil, PortfolioItem)
+        allow(PortfolioItemPolicy::Scope).to receive(:new).and_return(portfolio_item_policy_scope)
+        allow(portfolio_item_policy_scope).to receive(:resolve).and_return(PortfolioItem.all)
+      end
+
       it "success" do
         portfolio_item
         get "#{api_version}/portfolio_items", :headers => default_headers


### PR DESCRIPTION
Using #569 as a baseline, this is a specific solution for portfolio items. Another PR will be forthcoming to handle more base types with pundit's `policy_scope`s, but as it stands we can't simply use `:base_query => filtered(policy_scope(base_query.model))` without significant spec changes which I think fall outside of the scope of this PR.

Note that this PR doesn't deal with refactoring authorization (with the `before_action`s), I think that should probably be in a separate PR as well.

https://projects.engineering.redhat.com/browse/SSP-1116

@syncrou @mkanoor @lindgrenj6 Please Review.