### PR TITLE
Add logic to handle the `create_json_schema` field when importing ServicePlans

### DIFF
--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -15,7 +15,7 @@ module Api
 
       def create
         svc = Catalog::ImportServicePlans.new(params.require(:portfolio_item_id))
-        render :json => svc.process.service_plans
+        render :json => svc.process.json
       end
 
       def show

--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -1,6 +1,6 @@
 module Catalog
   class ImportServicePlans
-    attr_reader :service_plans
+    attr_reader :json
 
     def initialize(portfolio_item_id)
       @portfolio_item = PortfolioItem.find(portfolio_item_id)
@@ -18,7 +18,7 @@ module Catalog
         )
       end
 
-      @service_plans = @portfolio_item.service_plans
+      @json = Catalog::ServicePlanJson.new(:portfolio_item_id => @portfolio_item.id, :collection => true).process.json
 
       self
     end

--- a/spec/requests/api/v1.0/service_plans_spec.rb
+++ b/spec/requests/api/v1.0/service_plans_spec.rb
@@ -100,6 +100,10 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
       it "returns the imported service plans" do
         expect(json.first["id"]).to eq portfolio_item_without_service_plan.service_plans.first.id.to_s
       end
+
+      it "returns the base schema in the :create_json_schema field" do
+        expect(json.first["create_json_schema"]).to eq JSON.parse(modified_schema)
+      end
     end
 
     context "when a service_plan already exists for the portfolio_item specified" do

--- a/spec/services/catalog/import_service_plans_spec.rb
+++ b/spec/services/catalog/import_service_plans_spec.rb
@@ -23,6 +23,13 @@ describe Catalog::ImportServicePlans, :type => [:service, :topology, :current_fo
   end
 
   describe "#process" do
+    shared_examples_for "returns_json" do
+      it "returns the json" do
+        schemas = subject.json.collect { |plan| plan["create_json_schema"] }
+        expect(schemas.all? { |schema| schema == service_plan.create_json_schema }).to be_truthy
+      end
+    end
+
     context "when there is one plan" do
       let(:data) { [service_plan] }
 
@@ -37,6 +44,8 @@ describe Catalog::ImportServicePlans, :type => [:service, :topology, :current_fo
       it "adds the ServicePlan to the portfolio_item" do
         expect(portfolio_item.service_plans.count).to eq 1
       end
+
+      it_behaves_like "returns_json"
     end
 
     context "when there are multiple plans" do
@@ -53,6 +62,8 @@ describe Catalog::ImportServicePlans, :type => [:service, :topology, :current_fo
       it "adds both the ServicePlans to the portfolio_item" do
         expect(portfolio_item.service_plans.count).to eq 2
       end
+
+      it_behaves_like "returns_json"
     end
   end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1169

There was no logic to return the right `create_json_schema` key when calling `ServicePlans#create`. This changes the logic around to use the `Catalog::ServicePlanJson` service class like we're doing everywhere else we return the json. 