### PR TITLE
Remove check-svc-status function from `run_rails_server`

### DIFF
--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -7,21 +7,4 @@ cat > $WORKDIR/v2_key << KEY
 :key: ${ENCRYPTION_KEY}
 KEY
 
-function check_svc_status() {
-  local SVC_NAME=$1 SVC_PORT=$2
-
-  [[ $# -lt 2 ]] && echo "Error something seems wrong, we need at least two parameters to check service status" && exit 1
-
-  echo "== Checking ${SVC_NAME}:$SVC_PORT status =="
-
-  while true; do
-    ncat ${SVC_NAME} ${SVC_PORT} < /dev/null && break
-    sleep 5
-  done
-  echo "${SVC_NAME}:${SVC_PORT} - accepting connections"
-}
-
-# Wait for postgres to be ready
-check_svc_status $DATABASE_HOST $DATABASE_PORT
-
 bundle exec rake db:migrate && bundle exec rails server


### PR DESCRIPTION
This is a leftover from the MiQ days when we had to wait for the db to
be up before trying to start, since this is a SaaS application we won't
run into this very often, and even then since this is a containerized
application we can just let it fail to start a time or 2 then it will
come up once the db is finally there.