### PR TITLE
Log insights_request_id to order_item progress messages

### DIFF
--- a/app/services/catalog/add_to_order.rb
+++ b/app/services/catalog/add_to_order.rb
@@ -9,6 +9,7 @@ module Catalog
     def process
       order = Order.find_by!(:id => @params[:order_id])
       @order_item = order.order_items.create!(order_item_params.merge!(:service_plan_ref => service_plan_ref))
+      @order_item.update_message("info", "Order item tracking ID (x-rh-insights-request-id): #{@order_item.insights_request_id}")
 
       self
     end

--- a/spec/services/catalog/add_to_order_spec.rb
+++ b/spec/services/catalog/add_to_order_spec.rb
@@ -52,16 +52,18 @@ describe Catalog::AddToOrder, :type => :service do
     end
 
     it 'can recreate the request from the context' do
-      item = nil
-      Insights::API::Common::Request.with_request(request) do
-        item = subject.order_item
-      end
+      item = Insights::API::Common::Request.with_request(request) { subject.order_item }
 
       new_request = item.context.transform_keys(&:to_sym)
       Insights::API::Common::Request.with_request(new_request) do
         expect(Insights::API::Common::Request.current.user.username).to eq "jdoe"
         expect(Insights::API::Common::Request.current.user.email).to eq "jdoe@acme.com"
       end
+    end
+
+    it "should create a process message with the x-rh-insights-request-id" do
+      progress_message = Insights::API::Common::Request.with_request(request) { subject.order_item.progress_messages.first }
+      expect(progress_message.message).to match('Order item tracking ID (x-rh-insights-request-id): gobbledygook')
     end
   end
 


### PR DESCRIPTION
The `insights_request_id` is added to the http header by 3Scale and Catalog sends the ID as part of internal calls to other micro-services.  This allows the order_item request to be tracked as it progresses through the system.

[Jira SSP-1207](https://projects.engineering.redhat.com/browse/SSP-1207)