### PR TITLE
Remove Icons#show and Icons#icon_data since they are not used by the UI

### DIFF
--- a/app/controllers/api/v1/icons_controller.rb
+++ b/app/controllers/api/v1/icons_controller.rb
@@ -6,10 +6,6 @@ module Api
       # Due to the fact form-data is getting uploaded and isn't supported by openapi_parser
       skip_before_action :validate_request, :only => %i[create update]
 
-      def show
-        render :json => Icon.find(params.require(:id))
-      end
-
       def create
         icon = Catalog::CreateIcon.new(icon_params).process.icon
         render :json => icon
@@ -47,9 +43,7 @@ module Api
       end
 
       def find_icon(ids)
-        if ids[:icon_id].present?
-          Icon.find(ids[:icon_id])
-        elsif ids[:portfolio_item_id].present?
+        if ids[:portfolio_item_id].present?
           Icon.find_by!(:restore_to => PortfolioItem.find(ids[:portfolio_item_id]))
         elsif ids[:portfolio_id].present?
           Icon.find_by!(:restore_to => Portfolio.find(ids[:portfolio_id]))

--- a/app/controllers/api/v1/icons_controller.rb
+++ b/app/controllers/api/v1/icons_controller.rb
@@ -7,8 +7,8 @@ module Api
       skip_before_action :validate_request, :only => %i[create update]
 
       def create
-        icon = Catalog::CreateIcon.new(icon_params).process.icon
-        render :json => icon
+        Catalog::CreateIcon.new(icon_params).process
+        head :ok
       end
 
       def destroy
@@ -17,8 +17,8 @@ module Api
       end
 
       def update
-        icon = Catalog::UpdateIcon.new(params.require(:id), icon_patch_params).process.icon
-        render :json => icon
+        Catalog::UpdateIcon.new(params.require(:id), icon_patch_params).process
+        head :ok
       end
 
       def raw_icon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,9 +62,7 @@ Rails.application.routes.draw do
         post :copy, :action => 'copy', :controller => 'portfolio_items'
         post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
       end
-      resources :icons, :only => [:create, :destroy, :show, :update] do
-        get :icon_data, :to => 'icons#raw_icon'
-      end
+      resources :icons, :only => [:create, :update, :destroy]
       resources :settings
       resources :tags, :only => [:index]
       resources :tenants, :only => [:index, :show] do

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2030,40 +2030,6 @@
       }
     },
     "/icons/{id}": {
-      "get": {
-        "tags": [
-          "Icon"
-        ],
-        "summary": "Fetch an Icon by ID",
-        "operationId": "getIcon",
-        "description": "Fetch an Icon by ID",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The Icon matching the Icon ID",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Icon"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "description": "Icon not found"
-          }
-        }
-      },
       "patch": {
         "tags": [
           "Icon"
@@ -2127,55 +2093,6 @@
           },
           "404": {
             "description": "Icon not found."
-          }
-        }
-      }
-    },
-    "/icons/{id}/icon_data": {
-      "get": {
-        "tags": [
-          "Icon"
-        ],
-        "summary": "Fetches the specified icon's image",
-        "operationId": "showIconData",
-        "description": "Fetch the specified portfolio item's icon image.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Portfolio Item Icon",
-            "content": {
-              "image/svg+xml": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "image/png": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "image/jpeg": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "204": {
-            "description": "No icon data present."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
           }
         }
       }

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2011,14 +2011,7 @@
         },
         "responses": {
           "200": {
-            "description": "The newly created Icon",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Icon"
-                }
-              }
-            }
+            "description": "Icon Created"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -2055,14 +2048,7 @@
         "operationId": "updateIcon",
         "responses": {
           "200": {
-            "description": "Return the updated Icon object",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Icon"
-                }
-              }
-            }
+            "description": "Icon Updated Successfully"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -3203,47 +3189,6 @@
               "canceled"
             ],
             "description": "The state of the approval request (approved, denied, undecided, canceled)",
-            "readOnly": true
-          }
-        }
-      },
-      "Icon": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "ID",
-            "description": "The unique identifier for this Service Offering Icon",
-            "readOnly": true
-          },
-          "image_id": {
-            "type": "string",
-            "title": "Image ID",
-            "description": "The Image reference containing the binary image data for this icon",
-            "readOnly": false
-          },
-          "source_ref": {
-            "type": "string",
-            "title": "Source Ref",
-            "description": "Stores the Source Ref for this icon",
-            "readOnly": true
-          },
-          "source_id": {
-            "type": "string",
-            "title": "Source ID",
-            "description": "The source ID for this icon",
-            "readOnly": true
-          },
-          "portfolio_id": {
-            "type": "string",
-            "title": "Portfolio ID",
-            "description": "The portfolio this icon belongs to.",
-            "readOnly": true
-          },
-          "portfolio_item_id": {
-            "type": "string",
-            "title": "Portfolio Item ID",
-            "description": "The portfolio_item this icon belongs to.",
             "readOnly": true
           }
         }

--- a/spec/requests/api/v1.0/icons_spec.rb
+++ b/spec/requests/api/v1.0/icons_spec.rb
@@ -15,18 +15,6 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
 
   let(:image) { create(:image) }
 
-  describe "#show" do
-    before { get "#{api_version}/icons/#{icon.id}", :headers => default_headers }
-
-    it "returns a 200" do
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "returns the icon specified" do
-      expect(json["id"]).to eq icon.id.to_s
-    end
-  end
-
   describe "#destroy" do
     before { delete "#{api_version}/icons/#{icon.id}", :headers => default_headers }
 
@@ -199,12 +187,6 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to eq "image/svg+xml"
       end
-
-      it "/icons/{icon_id}/icon_data returns the icon" do
-        get "#{api_version}/icons/#{icon.id}/icon_data", :headers => default_headers
-        expect(response).to have_http_status(:ok)
-        expect(response.content_type).to eq "image/svg+xml"
-      end
     end
 
     context "when the icon does not exist" do
@@ -221,12 +203,6 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
 
       it "/portfolios/{id}/icon returns no content" do
         get "#{api_version}/portfolios/#{portfolio.id}/icon", :headers => default_headers
-
-        expect(response).to have_http_status(:no_content)
-      end
-
-      it "/icons/{id}/icon_data returns no content" do
-        get "#{api_version}/icons/0/icon_data", :headers => default_headers
 
         expect(response).to have_http_status(:no_content)
       end

--- a/spec/requests/api/v1.0/icons_spec.rb
+++ b/spec/requests/api/v1.0/icons_spec.rb
@@ -52,17 +52,14 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
       it "returns a 200" do
         expect(response).to have_http_status(:ok)
       end
-
-      it "returns the created icon" do
-        expect(json["image_id"]).to be_truthy
-      end
     end
 
     context "when uploading a duplicate svg icon" do
       let(:params) { {:content => form_upload_test_image("ocp_logo.svg"), :portfolio_item_id => portfolio_item.id} }
 
       it "uses the reference from the one that is already there" do
-        expect(json["image_id"]).to eq image.id.to_s
+        portfolio_item.reload
+        expect(portfolio_item.icon.image_id).to eq image.id
       end
     end
 
@@ -75,7 +72,8 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
       end
 
       it "uses the already-existing image" do
-        expect(json["image_id"]).to eq ocp_png_image.id.to_s
+        portfolio_item.reload
+        expect(portfolio_item.icon.image_id).to eq ocp_png_image.id
       end
     end
 
@@ -88,7 +86,8 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
       end
 
       it "uses the already-existing image" do
-        expect(json["image_id"]).to eq ocp_jpg_image.id.to_s
+        portfolio_item.reload
+        expect(portfolio_item.icon.image_id).to eq ocp_jpg_image.id
       end
     end
 
@@ -118,7 +117,8 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
 
       it "makes a new image and icon" do
         expect(response).to have_http_status 200
-        expect(json["image_id"]).to_not eq image.id
+        portfolio_item.reload
+        expect(portfolio_item.icon.image_id).not_to eq image.id
       end
     end
 
@@ -130,7 +130,8 @@ describe "v1.0 - IconsRequests", :type => [:request, :v1] do
 
       it "makes a new image and icon" do
         expect(response).to have_http_status 200
-        expect(json["image_id"]).to_not eq image.id
+        portfolio_item.reload
+        expect(portfolio_item.icon.image_id).not_to eq image.id
       end
     end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1212

The `Icons#show` endpoint does not really serve a purpose anymore since we added support for binary image formats, it only made sense when the image payload would come in as a field in SVG format. It also does not work the way it used to when it pertains to returning the portfolio/portfolio_item id since it is a polymorphic relationship and we would have to intercept the `as_json` method call in order to set the field. 

Also removing the `Icons#icon_data` endpoint since we only get the raw icon as a subresource off of show portfolio/portfolio_item and that makes much more sense than querying here. 

I talked to @Hyperkid123 and found we don't use this endpoint anyway - and the UI gets the id from the portfolio/portfolio_item show endpoints since they return `icon_id` now. They can use that to DELETE/PATCH as necessary. 

**EDIT: also changing the response of CREATE/UPDATE to return HEAD 200 since the response isn't necessary.**