### PR TITLE
Store API accessible service parameters with protected fields masked

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -16,7 +16,9 @@ class OrderItem < ApplicationRecord
   belongs_to :portfolio_item
   has_many :progress_messages, :dependent => :destroy
   has_many :approval_requests, :dependent => :destroy
+
   before_create :set_defaults
+  before_save :sanitize_parameters, :if => :will_save_change_to_service_parameters?
 
   def set_defaults
     self.state = "Created"
@@ -30,5 +32,24 @@ class OrderItem < ApplicationRecord
   def update_message(level, message)
     progress_messages << ProgressMessage.new(:level => level, :message => message, :tenant_id => self.tenant_id)
     touch
+  end
+
+  private
+
+  def sanitize_parameters
+    # Store the API accessible parameters with protected field values masked
+    self.service_parameters_raw = self[:service_parameters]
+
+    self[:service_parameters] = Catalog::OrderItemSanitizedParameters.new(:order_item => self).process.sanitized_parameters
+  end
+
+  def service_parameters_raw=(val)
+    raise Catalog::InvalidParameter, "Error: Masked parameters being saved to service_parameters_raw" if parameters_contain_sanitized_values?(val)
+
+    self[:service_parameters_raw] = val
+  end
+
+  def parameters_contain_sanitized_values?(val)
+    val.to_s.include?("\"#{Catalog::OrderItemSanitizedParameters::MASKED_VALUE}\"")
   end
 end

--- a/app/services/catalog/create_request_body_from.rb
+++ b/app/services/catalog/create_request_body_from.rb
@@ -9,15 +9,13 @@ module Catalog
     end
 
     def process
-      svc_params_sanitized = Catalog::OrderItemSanitizedParameters.new(:order_item_id => @order_item.id).process.sanitized_parameters
-
       @result = ApprovalApiClient::RequestIn.new.tap do |request|
         request.name      = @order_item.portfolio_item.name
         request.content   = {
           :product   => @order_item.portfolio_item.name,
           :portfolio => @order_item.portfolio_item.portfolio.name,
           :order_id  => @order_item.order_id.to_s,
-          :params    => svc_params_sanitized
+          :params    => @order_item.service_parameters
         }
         request.tag_resources = all_tag_resources
       end

--- a/app/services/catalog/order_item_sanitized_parameters.rb
+++ b/app/services/catalog/order_item_sanitized_parameters.rb
@@ -29,12 +29,12 @@ module Catalog
       order_item.service_plan_ref
     end
 
-    def service_parameters
-      order_item.service_parameters
+    def service_parameters_raw
+      order_item.service_parameters_raw
     end
 
     def filtered_parameters
-      service_parameters.slice(*fields.collect { |field| field.with_indifferent_access["name"] })
+      service_parameters_raw.slice(*fields.collect { |field| field.with_indifferent_access["name"] })
     end
 
     def service_plan_schema
@@ -51,7 +51,7 @@ module Catalog
       return {} if service_plan_does_not_exist?
       return filtered_parameters if @params[:do_not_mask_values]
 
-      svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters)
+      svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters_raw)
       fields.each_with_object({}) do |field, result|
         value = mask_value?(field) ? MASKED_VALUE : svc_params[field[:name]]
         result[field[:name]] = value

--- a/app/services/catalog/order_item_sanitized_parameters.rb
+++ b/app/services/catalog/order_item_sanitized_parameters.rb
@@ -2,7 +2,7 @@ module Catalog
   class OrderItemSanitizedParameters
     attr_reader :sanitized_parameters
 
-    MASKED_VALUE = "********".freeze
+    MASKED_VALUE = "$protected$".freeze
     FILTERED_PARAMS = %w[password token secret].freeze
 
     def initialize(params)

--- a/db/migrate/20200212122000_add_service_parameters_raw.rb
+++ b/db/migrate/20200212122000_add_service_parameters_raw.rb
@@ -1,0 +1,7 @@
+class AddServiceParametersRaw < ActiveRecord::Migration[5.1]
+  def change
+    add_column :order_items, :service_parameters_raw, :jsonb
+
+    OrderItem.update_all("service_parameters_raw=service_parameters")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_14_164456) do
+ActiveRecord::Schema.define(version: 2020_02_12_122000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2020_01_14_164456) do
     t.string "external_url"
     t.string "insights_request_id"
     t.datetime "discarded_at"
+    t.jsonb "service_parameters_raw"
     t.index ["discarded_at"], name: "index_order_items_on_discarded_at"
     t.index ["tenant_id"], name: "index_order_items_on_tenant_id"
   end

--- a/spec/factories/order_item.rb
+++ b/spec/factories/order_item.rb
@@ -6,6 +6,12 @@ FactoryBot.define do
     count { 1 }
     insights_request_id { "insights-request-id" }
 
+    after(:build) { |order_item| order_item.class.skip_callback(:save, :before, :sanitize_parameters, :raise => false) }
+
+    factory :order_item_with_callback do
+      after(:create) { |order_item| order_item.send(:sanitize_parameters); order_item.save! }
+    end
+
     order
     portfolio_item
   end

--- a/spec/services/catalog/create_request_body_from_spec.rb
+++ b/spec/services/catalog/create_request_body_from_spec.rb
@@ -1,7 +1,7 @@
 describe Catalog::CreateRequestBodyFrom, :type => :service do
   let(:subject) { described_class.new(order, order_item, task) }
   let(:order) { create(:order) }
-  let(:order_item) { create(:order_item) }
+  let(:order_item) { create(:order_item_with_callback) }
   let(:task) { TopologicalInventoryApiClient::Task.new }
 
   describe "#process" do

--- a/spec/services/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/services/catalog/order_item_sanitized_parameters_spec.rb
@@ -3,7 +3,7 @@ describe Catalog::OrderItemSanitizedParameters, :type => [:service, :topology, :
   let(:params) { ActionController::Parameters.new('order_item_id' => order_item.id) }
 
   describe "#process" do
-    let(:order_item) { create(:order_item, :service_plan_ref => service_plan_ref, :service_parameters => {"name" => "fred", "Totally not a pass" => "s3cret"}) }
+    let(:order_item) { create(:order_item_with_callback, :service_plan_ref => service_plan_ref, :service_parameters => {"name" => "fred", "Totally not a pass" => "s3cret"}) }
 
     context "when there is a valid service_plan_ref" do
       let(:service_plan_ref) { "777" }

--- a/spec/support/order_item_with_service_plan_helper.rb
+++ b/spec/support/order_item_with_service_plan_helper.rb
@@ -1,0 +1,24 @@
+RSpec.shared_context "uses an order item with raw service parameters set" do
+  let(:service_plan_show_response) do
+    TopologicalInventoryApiClient::ServicePlan.new(
+      :name               => "Plan A",
+      :id                 => "1",
+      :description        => "Plan A",
+      :create_json_schema => {:schema => {:fields => [{:name => "var1"}, {:name => "var2"}]}}
+    )
+  end
+
+  before do
+    stub_request(:get, topological_url("service_plans/#{service_plan_ref}"))
+      .to_return(:status => 200, :body => service_plan_show_response.to_json, :headers => default_headers)
+
+    @order_item =
+      create(:order_item_with_callback, :portfolio_item              => portfolio_item,
+                                        :service_parameters          => service_parameters,
+                                        :service_plan_ref            => service_plan_ref,
+                                        :provider_control_parameters => provider_control_parameters,
+                                        :order_id                    => order.id,
+                                        :count                       => 1,
+                                        :context                     => default_request)
+  end
+end


### PR DESCRIPTION
See https://projects.engineering.redhat.com/browse/SSP-1221

Protected dialogs field values are currently stored in the `service_parameters` column as clear text values.  This exposes them to API callers.

This change moves the raw values into a `service_parameters_raw` column and stores sanitized values in the original `service_parameters` column.  This allows API callers to retrieve the parameters without access to the protected fields while still retaining the original values to pass during ordering.

Tower follows a similar approach (Tower screenshots in the associated Jira story) in that it masks the protected fields in API calls.

**Would really like to get feedback on this approach before working on specs.**

**Before**
![image](https://user-images.githubusercontent.com/2591569/74394718-59eb7080-4ddb-11ea-86bd-7252c4f6714f.png)

![image](https://user-images.githubusercontent.com/2591569/74394743-6a9be680-4ddb-11ea-9173-4c2f9830f92c.png)

**After**
![image](https://user-images.githubusercontent.com/2591569/74688769-ae5d6a00-51a6-11ea-9bd1-9e94d37b4ca9.png)

![image](https://user-images.githubusercontent.com/2591569/74688851-e06ecc00-51a6-11ea-9f50-39e77481bfbf.png)

