### PR TITLE
Allow for force reimporting of service_plans on reset

### DIFF
--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -2,7 +2,7 @@ module Catalog
   class ImportServicePlans
     attr_reader :json
 
-    def initialize(portfolio_item_id, force_reset=false)
+    def initialize(portfolio_item_id, force_reset: false)
       @portfolio_item = PortfolioItem.find(portfolio_item_id)
       force_reset ? clear_service_plans : check_conflict
     end

--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -2,10 +2,9 @@ module Catalog
   class ImportServicePlans
     attr_reader :json
 
-    def initialize(portfolio_item_id)
+    def initialize(portfolio_item_id, force_reset=false)
       @portfolio_item = PortfolioItem.find(portfolio_item_id)
-
-      raise Catalog::ConflictError, "Service Plan already exists for PortfolioItem: #{portfolio_item_id}" if @portfolio_item.service_plans.any?
+      force_reset ? clear_service_plans : check_conflict
     end
 
     def process
@@ -21,6 +20,16 @@ module Catalog
       @json = Catalog::ServicePlanJson.new(:portfolio_item_id => @portfolio_item.id, :collection => true).process.json
 
       self
+    end
+
+    private
+
+    def check_conflict
+      raise Catalog::ConflictError, "Service Plan already exists for PortfolioItem: #{@portfolio_item.id}" if @portfolio_item.service_plans.any?
+    end
+
+    def clear_service_plans
+      @portfolio_item.service_plans.destroy_all
     end
 
     def service_plan_schemas

--- a/app/services/catalog/service_plan_reset.rb
+++ b/app/services/catalog/service_plan_reset.rb
@@ -23,7 +23,7 @@ module Catalog
     private
 
     def reimport_from_topo
-      Catalog::ImportServicePlans.new(@plan.portfolio_item_id, true).process
+      Catalog::ImportServicePlans.new(@plan.portfolio_item_id, :force_reset => true).process
     end
   end
 end

--- a/spec/lib/catalog/rbac/access_control_entries_spec.rb
+++ b/spec/lib/catalog/rbac/access_control_entries_spec.rb
@@ -34,7 +34,7 @@ describe Catalog::RBAC::AccessControlEntries, :type => [:current_forwardable] do
       end
 
       it "returns a list of the permitted object ids" do
-        expect(subject.ace_ids('read', Portfolio)).to eq(["123", "456"])
+        expect(subject.ace_ids('read', Portfolio)).to match_array(["123", "456"])
       end
     end
 

--- a/spec/services/catalog/import_service_plans_spec.rb
+++ b/spec/services/catalog/import_service_plans_spec.rb
@@ -30,6 +30,24 @@ describe Catalog::ImportServicePlans, :type => [:service, :topology, :current_fo
       end
     end
 
+    context "when force_reset is set" do
+      let!(:service_plan_current) { create(:service_plan, :portfolio_item => portfolio_item) }
+      let(:data) { [service_plan] }
+
+      before do
+        described_class.new(portfolio_item.id, true).process
+      end
+
+      it "destroys the current service_plans" do
+        expect{ServicePlan.find(service_plan_current.id)}.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+
+      it "reimports the service plan" do
+        portfolio_item.service_plans.reload
+        expect(portfolio_item.service_plans.any?).to be_truthy
+      end
+    end
+
     context "when there is one plan" do
       let(:data) { [service_plan] }
 

--- a/spec/services/catalog/import_service_plans_spec.rb
+++ b/spec/services/catalog/import_service_plans_spec.rb
@@ -35,7 +35,7 @@ describe Catalog::ImportServicePlans, :type => [:service, :topology, :current_fo
       let(:data) { [service_plan] }
 
       before do
-        described_class.new(portfolio_item.id, true).process
+        described_class.new(portfolio_item.id, :force_reset => true).process
       end
 
       it "destroys the current service_plans" do

--- a/spec/services/catalog/service_plan_reset_spec.rb
+++ b/spec/services/catalog/service_plan_reset_spec.rb
@@ -1,7 +1,29 @@
-describe Catalog::ServicePlanReset do
+describe Catalog::ServicePlanReset, :type => [:current_forwardable, :topology] do
   let(:subject) { described_class.new(service_plan.id) }
+  let(:service_plan_orig) do
+    TopologicalInventoryApiClient::ServicePlan.new(
+      :name               => "The Plan",
+      :id                 => "1",
+      :description        => "A Service Plan",
+      :create_json_schema => { :schema => {} }
+    )
+  end
+  let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => data) }
+  let(:service_offering_response) do
+    TopologicalInventoryApiClient::ServiceOffering.new(:extra => {"survey_enabled" => true})
+  end
+
+  before do
+    stub_request(:get, topological_url("service_offerings/#{service_plan.portfolio_item.service_offering_ref}"))
+      .to_return(:status => 200, :body => service_offering_response.to_json, :headers => default_headers)
+    stub_request(:get, topological_url("service_offerings/#{service_plan.portfolio_item.service_offering_ref}/service_plans"))
+      .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)
+  end
 
   describe "#process" do
+    let(:data) { [service_plan_orig] }
+    let!(:portfolio_item) { service_plan.portfolio_item }
+    let!(:service_plan_id) { service_plan.id }
     let!(:service_plan) { create(:service_plan, :modified => modified) }
 
     context "when the modified attribute is nil" do
@@ -17,8 +39,7 @@ describe Catalog::ServicePlanReset do
 
       it "updates the plan to have a nil modified attribute" do
         subject.process
-        service_plan.reload
-        expect(service_plan.modified).to be_nil
+        expect(portfolio_item.service_plans.map(&:id)).not_to include(service_plan_id)
       end
 
       it "sets the status to a 200" do


### PR DESCRIPTION
JIRA: https://projects.engineering.redhat.com/browse/SSP-1217

The `/reset` endpoint was not re pulling from Topo. This fix fully resets any modified survey in existance and resets the base off of Topo as expected.

Thanks @lindgrenj6 for the pairing on this one.