### PR TITLE
[WIP] Revert "When calling list_groups from RBAC service use a higher limit"

### DIFF
--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -2,7 +2,6 @@ module Catalog
   class ShareInfo
     require 'rbac-api-client'
     attr_reader :result
-    MAX_GROUPS_LIMIT = 500
 
     def initialize(options)
       @object = options[:object]
@@ -28,7 +27,7 @@ module Catalog
 
     def group_names
       @group_names ||= Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
-        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :limit => MAX_GROUPS_LIMIT).each_with_object({}) do |group, memo|
+        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, {}).each_with_object({}) do |group, memo|
           memo[group.uuid] = group.name
         end
       end

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -353,11 +353,10 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
 
     context 'share_info' do
       include_context "sharing_objects"
-      let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT} }
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-          allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, pagination_options).and_return(groups)
+          allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
           ace1
           ace2
           ace3

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -5,14 +5,12 @@ describe Catalog::ShareInfo, :type => :service do
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
-  let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT} }
-
   let(:params) { { :object => portfolio } }
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
     allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, pagination_options).and_return([group1])
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([group1])
     create(:access_control_entry, :has_read_and_update_permission, :group_uuid => group1.uuid, :aceable => portfolio)
   end
 


### PR DESCRIPTION
This reverts commit 5ee70db4ce298047dd97999e0d24e80234b9f1aa. (PR https://github.com/RedHatInsights/catalog-api/pull/570)

Based on the following change in the RBAC service
https://github.com/RedHatInsights/insights-rbac/pull/195

@mkanoor @syncrou 
**Need to discuss if we want to drop the limit option and use the newer RBAC mode of returning all data.**