### PR TITLE
Add check to make sure readOnly params are not allowed on POST

### DIFF
--- a/app/controllers/api/v1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1/portfolio_items_controller.rb
@@ -17,7 +17,7 @@ module Api
         portfolio = Portfolio.find(params.require(:portfolio_id))
         authorize(portfolio)
 
-        so = ServiceOffering::AddToPortfolioItem.new(params_for_create)
+        so = ServiceOffering::AddToPortfolioItem.new(writeable_params_for_create)
         render :json => so.process.item
       end
 

--- a/app/controllers/api/v1/portfolios_controller.rb
+++ b/app/controllers/api/v1/portfolios_controller.rb
@@ -14,7 +14,7 @@ module Api
       def create
         authorize(Portfolio)
 
-        portfolio = Portfolio.create!(params_for_create)
+        portfolio = Portfolio.create!(writeable_params_for_create)
         render :json => portfolio
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::API
   include Response
   include Api::V1::Mixins::ACEMixin
   include Api::V1::Mixins::RBACMixin
+  include Api::V1::Mixins::ValidationMixin
   include Insights::API::Common::ApplicationControllerMixins::ApiDoc
   include Insights::API::Common::ApplicationControllerMixins::Common
   include Insights::API::Common::ApplicationControllerMixins::ExceptionHandling

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -223,6 +223,20 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
     end
   end
 
+  context "when passing in read-only parameters" do
+    let(:params) { {:service_offering_ref => service_offering_ref, :portfolio_id => portfolio.id.to_s, :owner => "me"} }
+
+    before { post "#{api_version}/portfolio_items", :params => params, :headers => default_headers }
+
+    it "returns a 400" do
+      expect(response).to have_http_status(400)
+    end
+
+    it "returns a required parameter error in the body" do
+      expect(first_error_detail).to match(/unpermitted.*owner/)
+    end
+  end
+
   context "v1.0 provider control parameters" do
     let(:url) { "#{api_version}/portfolio_items/#{portfolio_item.id}/provider_control_parameters" }
 

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -295,6 +295,20 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
       end
     end
 
+    context 'when portfolio attributes are not valid' do
+      let(:invalid_attributes) { { :name => 'rspec 1', :description => 'rspec 1 description', :icon_id => "17" } }
+
+      before { post "#{api_version}/portfolios", :params => invalid_attributes, :headers => default_headers }
+
+      it 'returns status code 400' do
+        expect(response).to have_http_status(400)
+      end
+
+      it 'warns about unpermitted field' do
+        expect(first_error_detail).to match(/unpermitted.*icon_id/)
+      end
+    end
+
     shared_examples_for "#shared_test" do
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do


### PR DESCRIPTION
This is related to the common gem PR https://github.com/RedHatInsights/insights-api-common-rails/pull/135, it would break topo/sources so I implemented it here. 

Takes care of this bug: https://projects.engineering.redhat.com/browse/SSP-927

----

The premise of this is that it looks at the attributes on the object itself and also looks up to see if there is a request schema attached to the operation (ie `CreatePortfolioItem` which includes fields that are not on PortfolioItem). It gathers all of the attributes which are _not_ marked as readonly and permits them, this is differen than the common gem which just does `params.permit!` on POST requests which lets everything through. 