### PR TITLE
Update Catalog::ServicePlanJson to account for nil modified

### DIFF
--- a/app/services/catalog/service_plan_json.rb
+++ b/app/services/catalog/service_plan_json.rb
@@ -21,7 +21,7 @@ module Catalog
       relevant_service_plans.each do |plan|
         @reference = plan.portfolio_item.service_offering_ref
         @portfolio_item_id = plan.portfolio_item.id
-        @modified = plan.modified.present?
+        @modified = true
         @service_plan = OpenStruct.new(
           :id                 => plan.id,
           :create_json_schema => relevant_schema(plan),

--- a/app/services/catalog/service_plan_json.rb
+++ b/app/services/catalog/service_plan_json.rb
@@ -21,7 +21,7 @@ module Catalog
       relevant_service_plans.each do |plan|
         @reference = plan.portfolio_item.service_offering_ref
         @portfolio_item_id = plan.portfolio_item.id
-        @modified = true
+        @imported = true
         @service_plan = OpenStruct.new(
           :id                 => plan.id,
           :create_json_schema => relevant_schema(plan),

--- a/app/services/catalog/service_plans.rb
+++ b/app/services/catalog/service_plans.rb
@@ -10,7 +10,7 @@ module Catalog
 
     def process
       @reference = PortfolioItem.find(@portfolio_item_id).service_offering_ref
-      @modified = false
+      @imported = false
 
       TopologicalInventory.call do |api_instance|
         service_offering = api_instance.show_service_offering(@reference)

--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -3321,10 +3321,10 @@
             "description": "The unique identifier for this service plan.",
             "readOnly": true
           },
-          "modified": {
+          "imported": {
             "type": "boolean",
-            "title": "Modified",
-            "description": "Whether or not the ServicePlan has a modified create_json_schema property",
+            "title": "Imported",
+            "description": "Whether or not the ServicePlan has been imported for editing",
             "readOnly": true
           }
         }

--- a/schemas/json/service_plan.erb
+++ b/schemas/json/service_plan.erb
@@ -5,5 +5,5 @@
   "name": "<%= @service_plan.name %>",
   "description": "<%= @service_plan.description %>",
   "portfolio_item_id": "<%= @portfolio_item_id %>",
-  "modified": <%= @modified %>
+  "imported": <%= @imported %>
 }

--- a/spec/requests/api/v1.0/service_plans_spec.rb
+++ b/spec/requests/api/v1.0/service_plans_spec.rb
@@ -43,8 +43,8 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
           get "#{api_version}/portfolio_items/#{portfolio_item_without_service_plan.id}/service_plans", :headers => default_headers
         end
 
-        it "returns modified as true" do
-          expect(json.first['modified']).to be_truthy
+        it "returns imported as true" do
+          expect(json.first['imported']).to be_truthy
         end
 
         it "returns the base schema" do
@@ -58,11 +58,11 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
           get "#{api_version}/portfolio_items/#{portfolio_item_without_service_plan.id}/service_plans", :headers => default_headers
         end
 
-        it "returns modified as true" do
-          expect(json.first['modified']).to be_truthy
+        it "returns imported as true" do
+          expect(json.first['imported']).to be_truthy
         end
 
-        it "returns the modified schema" do
+        it "returns the imported schema" do
           expect(json.first['create_json_schema']).to eq JSON.parse(modified_schema)
         end
       end
@@ -77,8 +77,8 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
         expect(json.first["create_json_schema"]).to eq topo_service_plan.create_json_schema
       end
 
-      it "shows modified as false" do
-        expect(json.first["modified"]).to be_falsey
+      it "shows imported as false" do
+        expect(json.first["imported"]).to be_falsey
       end
     end
   end
@@ -103,7 +103,7 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
 
       it "returns the specified service_plan" do
         expect(json["id"]).to eq service_plan.id.to_s
-        expect(json.keys).to match_array %w[service_offering_id create_json_schema portfolio_item_id id description name modified]
+        expect(json.keys).to match_array %w[service_offering_id create_json_schema portfolio_item_id id description name imported]
       end
     end
   end
@@ -179,8 +179,8 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
         expect(json["create_json_schema"]["schema"]).not_to eq service_plan.base["schema"]
       end
 
-      it "shows modified as true" do
-        expect(json["modified"]).to be_truthy
+      it "shows imported as true" do
+        expect(json["imported"]).to be_truthy
       end
     end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1241

Before we were not checking whether the plan#base was present even if plan#modified was not there, giving a false positive that the plan had been modified. This change updates the logic so it will show  in the json schema when we have a record in the db even when modified isn't there.