### PR TITLE
Add extra logging to track requests through the system

### DIFF
--- a/app/services/catalog/approval_transition.rb
+++ b/app/services/catalog/approval_transition.rb
@@ -46,11 +46,13 @@ module Catalog
     def mark_canceled
       finalize_order
       @order_item.update_message("info", "Order #{@order_item.order_id} has been canceled")
+      Rails.logger.info("Order #{@order_item.order_id} has been canceled")
     end
 
     def mark_denied
       finalize_order
       @order_item.update_message("info", "Order #{@order_item.order_id} has been denied")
+      Rails.logger.info("Order #{@order_item.order_id} has been denied")
     end
 
     def finalize_order

--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -32,6 +32,8 @@ module Catalog
         :state                => response.decision.to_sym,
         :tenant_id            => order_item.tenant_id
       )
+
+      Rails.logger.info("Approval Requests Submitted for Order #{@order.id}")
     end
 
     def fail_order

--- a/app/services/catalog/submit_order.rb
+++ b/app/services/catalog/submit_order.rb
@@ -15,12 +15,14 @@ module Catalog
         fail_item(order_item) if Catalog::SurveyCompare.any_changed?(order_item.portfolio_item.service_plans)
 
         submit_order_item(order_item)
+
+        Rails.logger.info("Order #{@order_id} submitted for provisioning")
       end
       @order.update(:state => 'Ordered', :order_request_sent_at => Time.now.utc)
       @order.reload
       self
     rescue StandardError => e
-      Rails.logger.error("Submit Order #{e.message}")
+      Rails.logger.error("Error Submitting Order #{@order_id}: #{e.message}")
       raise
     end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1232

Part of researching how to better track orders through the system, this _should_ make things easier since it'll just log whenever we add a ProgressMessage.

\# TODO:
- [x] researching whether topo has log statements like this
- [x] ~maybe add logging to minion~ ended up just adding logging to notify controller

https://kibana-kibana.5a9f.insights-dev.openshiftapps.com/app/kibana#/discover?_g=(refreshInterval:(pause:!f,value:60000),time:(from:now%2Fd,mode:quick,to:now%2Fd))&_a=(columns:!(hostname,request_id),filters:!(),index:d2da0310-7048-11e9-a501-7998195d35a8,interval:auto,query:(language:lucene,query:%27%27),sort:!(%27@timestamp%27,desc))

Paste the req id in the search bar and it should bring up the appropriate requests, going to make a document with this information.