### PR TITLE
[Stable] Use the rubygems version of the topo ruby client gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'sources-api-client', '~> 1.0'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'topological_inventory-api-client', '~> 2.0', :git => "https://github.com/RedHatInsights/topological_inventory-api-client-ruby"
+gem 'topological_inventory-api-client', '~> 2.0'
 
 gem 'approval-api-client-ruby', :git => 'https://github.com/RedHatInsights/approval-api-client-ruby', :branch => "master"
 gem 'rbac-api-client', :git => "https://github.com/RedHatInsights/insights-rbac-api-client-ruby", :branch => "master"


### PR DESCRIPTION
No longer use the Red Hat Insights version of the Topo ruby client gem.

Stable branch PR of https://github.com/RedHatInsights/catalog-api/pull/600