### PR TITLE
Handle empty schematype

### DIFF
--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -7,6 +7,10 @@ class ServicePlan < ApplicationRecord
   validate :modified_survey, :on => :update, :if => proc { modified.present? }
   validate :data_driven_form, :on => :update, :if => proc { modified.present? }
 
+  def empty_schema?
+    base["schemaType"].presence == "emptySchema"
+  end
+
   private
 
   def modified_survey

--- a/db/migrate/20200225203814_move_default_to_empty.rb
+++ b/db/migrate/20200225203814_move_default_to_empty.rb
@@ -1,0 +1,18 @@
+class MoveDefaultToEmpty < ActiveRecord::Migration[5.2]
+  def up
+    empty_service_plans = ServicePlan.all.map { |x| x.base.dig("schema", "fields").first["name"] == "empty-service-plan" ? x : next }.compact
+    empty_service_plans.each do |sp|
+      sp.base["schemaType"] = "emptySchema"
+      sp.save!
+    end
+  end
+
+  def down
+    empty_service_plans = ServicePlan.all.map { |x| x.base["schemaType"] == "emptySchema" ? x : next }.compact
+    empty_service_plans.each do |sp|
+      sp.base["schemaType"] = "default"
+      sp.save!
+    end
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_122000) do
+ActiveRecord::Schema.define(version: 2020_02_25_203814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/catalog/survey_compare.rb
+++ b/lib/catalog/survey_compare.rb
@@ -3,12 +3,17 @@ module Catalog
     attr_reader :base
     class << self
       def changed?(plan)
+        return false if empty?(plan)
         potential = new(plan)
         potential.topo_base != potential.base
       end
 
       def any_changed?(plans)
         plans.any? { |plan| changed?(plan) }
+      end
+
+      def empty?(plan)
+        plan.empty_schema?
       end
     end
 

--- a/schemas/json/no_service_plan.erb
+++ b/schemas/json/no_service_plan.erb
@@ -2,7 +2,7 @@
   "service_offering_id": "<%= @reference %>",
   "id": null,
   "create_json_schema": <%= {
-    "schemaType": "default",
+    "schemaType": "emptySchema",
     "schema": {
       "fields": [{
         "component": "plain-text",

--- a/spec/lib/catalog/survey_compare_spec.rb
+++ b/spec/lib/catalog/survey_compare_spec.rb
@@ -2,6 +2,7 @@ describe Catalog::SurveyCompare, :type => [:current_forwardable, :topology] do
   let!(:portfolio_item) { service_plan.portfolio_item }
   let!(:service_offering_ref) { portfolio_item.service_offering_ref }
   let(:valid_ddf) { JSON.parse(File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json"))) }
+  let(:empty_ddf) { JSON.parse(File.read(Rails.root.join("spec", "support", "ddf", "no_service_plan_ddf.json"))) }
 
   let(:topo_service_plan) do
     TopologicalInventoryApiClient::ServicePlan.new(
@@ -55,5 +56,16 @@ describe Catalog::SurveyCompare, :type => [:current_forwardable, :topology] do
         expect(Catalog::SurveyCompare.any_changed?(plans)).to be false
       end
     end
+  end
+
+  describe "empty?" do
+    context "when an empty service plan exists" do
+      let(:service_plan) { create(:service_plan, :base => empty_ddf) }
+
+      it "returns false" do
+        expect(Catalog::SurveyCompare.changed?(service_plan)).to be false
+      end
+    end
+
   end
 end

--- a/spec/models/service_plan_spec.rb
+++ b/spec/models/service_plan_spec.rb
@@ -3,6 +3,7 @@ describe ServicePlan do
   let!(:portfolio_item) { service_plan.portfolio_item }
   let!(:service_offering_ref) { portfolio_item.service_offering_ref }
   let(:valid_ddf) { JSON.parse(File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json"))) }
+  let(:empty_ddf) { JSON.parse(File.read(Rails.root.join("spec", "support", "ddf", "no_service_plan_ddf.json"))) }
 
   around do |example|
     with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com", :BYPASS_RBAC => 'true') do
@@ -53,6 +54,19 @@ describe ServicePlan do
 
       it "shows the modified column is unchanged" do
         expect(service_plan.modified["schema"]).to eq valid_ddf["schema"]
+      end
+    end
+
+    describe "empty_schema?" do
+      let(:empty_service_plan) { create(:service_plan, :base => empty_ddf) }
+      let(:full_service_plan) { create(:service_plan, :base => valid_ddf) }
+
+      it "returns true for a schemaType of emptySchema" do
+        expect(empty_service_plan.empty_schema?).to be_truthy
+      end
+
+      it "returns false for any other schema" do
+        expect(full_service_plan.empty_schema?).to be_falsey
       end
     end
 

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -32,7 +32,7 @@ describe Catalog::ServicePlans, :type => [:service, :topology, :current_forwarda
 
       it "returns an array with one object with a specific plain text create json schema" do
         json_schema = items.first["create_json_schema"]
-        expect(json_schema["schemaType"]).to eq("default")
+        expect(json_schema["schemaType"]).to eq("emptySchema")
         expect(json_schema["schema"]["fields"].first["component"]).to eq("plain-text")
         expect(json_schema["schema"]["fields"].first["name"]).to eq("empty-service-plan")
         expect(json_schema["schema"]["fields"].first["label"]).to match("requires no user input")

--- a/spec/support/ddf/no_service_plan_ddf.json
+++ b/spec/support/ddf/no_service_plan_ddf.json
@@ -1,0 +1,11 @@
+{
+  "schema": 
+  {"fields": [
+    {"name": "empty-service-plan", 
+     "label": "This product requires no user input and is fully configured by the system.\nClick submit to order this item.", 
+     "component": "plain-text"
+    }
+  ]
+  }, 
+  "schemaType": "emptySchema"
+}


### PR DESCRIPTION
This change internally checks for a specific schemaType `emptySchema` in the `ServicePlan#base`.

I found an issue where we were running `SurveyCompare.changed?` or `SurveyCompare.any_changed?` on an empty ( 'no-service-plan' ) survey as we save a dummy in `base` to handle returning information back to the user when there is no configuration needed to submit an order.

I also included a migration to change the `schemaType` to `emptySchema` for all saved 'no-service-plan' that currently exist.