### PR TITLE
The tenant has moved from user to request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::API
       if current.required_auth?
         raise Insights::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
 
-        ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
+        ActsAsTenant.with_tenant(current_tenant(current)) { yield }
       else
         ActsAsTenant.without_tenant { yield }
       end
@@ -31,8 +31,8 @@ class ApplicationController < ActionController::API
     json_response({:errors => e.message}, :unauthorized)
   end
 
-  def current_tenant(current_user)
-    Tenant.find_or_create_by(:external_tenant => current_user.tenant)
+  def current_tenant(request)
+    Tenant.find_or_create_by(:external_tenant => request.tenant)
   end
 
   def check_entitled(entitlement)

--- a/app/models/rbac_seed.rb
+++ b/app/models/rbac_seed.rb
@@ -2,5 +2,5 @@ class RbacSeed < ApplicationRecord
   validates :external_tenant, :uniqueness => true
   validates :external_tenant, :presence => true
 
-  scope :seeded, ->(user) { find_by(:external_tenant => user.tenant) }
+  scope :seeded, ->(request) { find_by(:external_tenant => request.tenant) }
 end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -1,5 +1,5 @@
 class Tenant < ApplicationRecord
-  scope :current, ->(user) { where(:external_tenant => user.tenant) }
+  scope :current, ->(request) { where(:external_tenant => request.tenant) }
 
   validates :external_tenant, :uniqueness => true, :presence => true
 
@@ -7,7 +7,7 @@ class Tenant < ApplicationRecord
   after_initialize :setup_settings, :unless => proc { settings.nil? }
 
   def self.scoped_tenants
-    current(Insights::API::Common::Request.current.user)
+    current(Insights::API::Common::Request.current)
   rescue NoMethodError
     []
   end

--- a/spec/requests/api/v1.0/tenant_spec.rb
+++ b/spec/requests/api/v1.0/tenant_spec.rb
@@ -107,7 +107,7 @@ describe "v1.0 - Group Seed API", :type => [:request, :v1] do
       end
 
       it 'account number is in RbacSeed table' do
-        expect(RbacSeed.seeded(Insights::API::Common::Request.current.user)).to be_truthy
+        expect(RbacSeed.seeded(Insights::API::Common::Request.current)).to be_truthy
       end
 
       it 'gets the current list of groups' do


### PR DESCRIPTION
Fixed all the deprecation warnings related to the tenant moving from the user to the request.

DEPRECATION WARNING: Please switch to request.tenant, request.user.tenant will be removed in a future release. (called from current_tenant at /Users/madhukanoor/devsrc/catalog-api/app/controllers/application_controller.rb:35)