### PR TITLE
Set the format for group_uuids to be uuid

### DIFF
--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -3541,7 +3541,8 @@
             "title": "The Group UUIDs",
             "description": "An array of group UUID's retrieved from the RBAC Service with whom the resource has to be shared.",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             },
             "minItems": 1
           }
@@ -3573,7 +3574,8 @@
             "title": "The Group UUIDs",
             "description": "An array of group UUID's retrieved from the RBAC Service from which the permissions have to be removed. If group uuids are not specified we will unshare it from all groups.",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         }


### PR DESCRIPTION
This is to keep the group id formats in sync with the RBAC service

https://github.com/RedHatInsights/insights-rbac/blob/10381674c431e89f56c20eaf39f03dfd6079f3a6/docs/source/specs/openapi.json#L274

The openapi-parser doesn't support format check yet, when it starts doing that we would have to fix our specs.

I have added a PR https://github.com/ota42y/openapi_parser/pull/67 for validating UUID