### PR TITLE
Send platform information to Approval

### DIFF
--- a/app/services/catalog/create_request_body_from.rb
+++ b/app/services/catalog/create_request_body_from.rb
@@ -27,11 +27,8 @@ module Catalog
     private
 
     def platform(portfolio_item)
-      service_offering = TopologicalInventory.call do |api_instance|
-        api_instance.show_service_offering(portfolio_item.service_offering_ref)
-      end
       source = Sources.call do |api_instance|
-        api_instance.show_source(service_offering.source_id)
+        api_instance.show_source(portfolio_item.service_offering_source_ref)
       end
       source.name
     end

--- a/app/services/catalog/create_request_body_from.rb
+++ b/app/services/catalog/create_request_body_from.rb
@@ -15,6 +15,7 @@ module Catalog
           :product   => @order_item.portfolio_item.name,
           :portfolio => @order_item.portfolio_item.portfolio.name,
           :order_id  => @order_item.order_id.to_s,
+          :platform  => platform(@order_item.portfolio_item),
           :params    => @order_item.service_parameters
         }
         request.tag_resources = all_tag_resources
@@ -24,6 +25,16 @@ module Catalog
     end
 
     private
+
+    def platform(portfolio_item)
+      service_offering = TopologicalInventory.call do |api_instance|
+        api_instance.show_service_offering(portfolio_item.service_offering_ref)
+      end
+      source = Sources.call do |api_instance|
+        api_instance.show_source(service_offering.source_id)
+      end
+      source.name
+    end
 
     def all_tag_resources
       local_tag_resources = Tags::CollectLocalOrderResources.new(:order_id => @order.id).process.tag_resources

--- a/spec/lib/sources_spec.rb
+++ b/spec/lib/sources_spec.rb
@@ -2,7 +2,7 @@ describe Sources, :type => :current_forwardable do
   let(:sources_ex) { SourcesApiClient::ApiError.new("kaboom") }
 
   it "raises SourcesError" do
-    with_modified_env :SOURCES_URL => 'http://source.example.com' do
+    with_modified_env :SOURCES_URL => 'http://sources.example.com' do
       allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
       expect do
         described_class.call do |_klass|

--- a/spec/services/catalog/create_request_body_from_spec.rb
+++ b/spec/services/catalog/create_request_body_from_spec.rb
@@ -23,9 +23,7 @@ describe Catalog::CreateRequestBodyFrom, :type => [:service, :current_forwardabl
       allow(Tags::Topology::RemoteInventory).to receive(:new).with(task).and_return(remote_tag_service_instance)
       allow(remote_tag_service_instance).to receive(:process).and_return(remote_tag_service_instance)
 
-      stub_request(:get, topological_url("service_offerings/#{order_item.portfolio_item.service_offering_ref}"))
-        .to_return(:status => 200, :body => service_offering_response.to_json, :headers => default_headers)
-      stub_request(:get, sources_url("sources/#{service_offering_response.source_id}"))
+      stub_request(:get, sources_url("sources/#{order_item.portfolio_item.service_offering_source_ref}"))
         .to_return(:status => 200, :body => source_response.to_json, :headers => default_headers)
     end
 

--- a/spec/services/catalog/create_request_body_from_spec.rb
+++ b/spec/services/catalog/create_request_body_from_spec.rb
@@ -12,7 +12,7 @@ describe Catalog::CreateRequestBodyFrom, :type => [:service, :current_forwardabl
       TopologicalInventoryApiClient::ServiceOffering.new(:extra => {"survey_enabled" => true}, :source_id => "333", :name => "test-platform-name")
     end
     let(:source_response) do
-      SourcesApiClient::Source.new
+      SourcesApiClient::Source.new(:name => 'the platform')
     end
 
     before do
@@ -34,13 +34,14 @@ describe Catalog::CreateRequestBodyFrom, :type => [:service, :current_forwardabl
           :product   => order_item.portfolio_item.name,
           :portfolio => order_item.portfolio_item.portfolio.name,
           :order_id  => order_item.order_id.to_s,
-          :platform  => Catalog::CreateRequestBodyFrom.new(order_item.order, order_item, 1).send(:platform, order_item.portfolio_item),
+          :platform  => "the platform",
           :params    => {:a => 1}
         }
         request.tag_resources = ["a", "b"]
       end
 
       expect(subject.process.result.to_json).to eq(req.to_json)
+      expect(subject.process.result.content[:platform]).to eq (source_response.name)
     end
   end
 end

--- a/spec/services/catalog/validate_source_spec.rb
+++ b/spec/services/catalog/validate_source_spec.rb
@@ -7,7 +7,7 @@ describe Catalog::ValidateSource do
   let(:validate_source) { described_class.new(portfolio_item.service_offering_source_ref).process }
 
   around do |example|
-    with_modified_env(:SOURCES_URL => "http://source.example.com") do
+    with_modified_env(:SOURCES_URL => "http://sources.example.com") do
       Insights::API::Common::Request.with_request(default_request) { example.call }
     end
   end

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -12,7 +12,7 @@ describe ServiceOffering::AddToPortfolioItem, :type => [:service, :topology] do
 
   around do |example|
     Insights::API::Common::Request.with_request(default_request) do
-      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com", :SOURCES_URL => "http://source.example.com") do
+      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com", :SOURCES_URL => "http://sources.example.com") do
         example.call
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |config|
 
   config.include ServiceSpecHelper
   config.include TopologySpecHelper, :type => :topology
+  config.include SourcesSpecHelper, :type => :sources
   config.include CurrentForwardableSpecHelper, :type => :current_forwardable
 
   config.use_transactional_fixtures = true

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -44,7 +44,7 @@ module ServiceSpecHelper
   end
 
   def sources_url(partial_path, api_version = "v1.0")
-    url_string = "http://source.example.com"
+    url_string = "http://sources.example.com"
     url = URI.join(url_string, "api/", "sources/", "#{api_version}/", "#{partial_path}")
     url.to_s
   end

--- a/spec/support/sources_spec_helper.rb
+++ b/spec/support/sources_spec_helper.rb
@@ -1,0 +1,9 @@
+module SourcesSpecHelper
+  RSpec.configure do |config|
+    config.around(:example, :type => :sources) do |example|
+      with_modified_env(:SOURCES_URL => "http://sources.example.com") do
+        example.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
When creating an approval request we were not passing the platform information as part of the payload.

This change passes the platform information as part of the `Catalog::CreateRequestBodyFrom` class.


JIRA: https://projects.engineering.redhat.com/browse/SSP-1178