### PR TITLE
Expose Canceled as an enum type on OrderItem

### DIFF
--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -3111,7 +3111,8 @@
               "Failed",
               "Completed",
               "Approved",
-              "Denied"
+              "Denied",
+              "Canceled"
             ],
             "title": "State",
             "description": "Current state of this order item.",


### PR DESCRIPTION
As stated in the JIRA ticket. The backend was setting an `OrderItem` as canceled but the `openapi.json` spec did not expose `Canceled` as an allowed enum type for the `OrderItem` schema object.


JIRA: https://projects.engineering.redhat.com/browse/SSP-1124