### PR TITLE
Remove context setting from order_item

### DIFF
--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -5,18 +5,16 @@ module Catalog
     end
 
     def process
-      Insights::API::Common::Request.with_request(order_item_context) do
-        @task = TopologicalInventoryApiClient::Task.new(
-          :id      => @topic.payload["task_id"],
-          :state   => @topic.payload["state"],
-          :status  => @topic.payload["status"],
-          :context => @topic.payload["context"].try(&:with_indifferent_access)
-        )
+      @task = TopologicalInventoryApiClient::Task.new(
+        :id      => @topic.payload["task_id"],
+        :state   => @topic.payload["state"],
+        :status  => @topic.payload["status"],
+        :context => @topic.payload["context"].try(&:with_indifferent_access)
+      )
 
-        add_task_update_message
-        delegate_task if @task.state == "completed"
-        fail_order if @task.status == "error"
-      end
+      add_task_update_message
+      delegate_task if @task.state == "completed"
+      fail_order if @task.status == "error"
 
       self
     rescue StandardError => exception

--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -39,10 +39,6 @@ module Catalog
       @order_item ||= OrderItem.find_by!(:topology_task_ref => @topic.payload["task_id"])
     end
 
-    def order_item_context
-      order_item.context.transform_keys(&:to_sym)
-    end
-
     def add_task_update_message
       message = "Task update. State: #{@task.state}. Status: #{@task.status}. Context: #{@task.context}"
       @task.status == "error" ? add_update_message(:error, message) : add_update_message(:info, message)

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -7,16 +7,8 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
     )
   end
 
-  let!(:order_item) do
-    Insights::API::Common::Request.with_request(default_request) do
-      create(:order_item, :topology_task_ref => "123")
-    end
-  end
+  let!(:order_item) { create(:order_item, :topology_task_ref => "123") }
   let(:order_state_transition) { instance_double(Catalog::OrderStateTransition) }
-
-  before do
-    allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
-  end
 
   describe "#process" do
     context "when the state is running" do


### PR DESCRIPTION
We dont need to set the context anymore since the Topology & Approval
Service are now passing the headers to the minion which then forwards
it to the internal API

https://projects.engineering.redhat.com/browse/SSP-1115

Approval PR:
https://github.com/RedHatInsights/approval-api/pull/257

Topo PR:
https://github.com/RedHatInsights/topological_inventory-api/pull/270

Minion PR:
https://github.com/RedHatInsights/catalog-api-minion/pull/23