### PR TITLE
Ensure TagsController index calls are rbac scoped properly

### DIFF
--- a/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1/mixins/index_mixin.rb
@@ -21,7 +21,7 @@ module Api
           ).response
         end
 
-        def rbac_scope(relation, pre_authorized)
+        def rbac_scope(relation, pre_authorized = false)
           return relation if pre_authorized
 
           if Catalog::RBAC::Role.catalog_administrator?

--- a/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1/mixins/index_mixin.rb
@@ -3,7 +3,7 @@ module Api
     module Mixins
       module IndexMixin
         def scoped(relation, pre_authorized)
-          relation = rbac_scope(relation, pre_authorized) if Insights::API::Common::RBAC::Access.enabled?
+          relation = rbac_scope(relation, :pre_authorized => pre_authorized) if Insights::API::Common::RBAC::Access.enabled?
           if relation.model.respond_to?(:taggable?) && relation.model.taggable?
             ref_schema = {relation.model.tagging_relation_name => :tag}
 
@@ -12,7 +12,7 @@ module Api
           relation
         end
 
-        def collection(base_query, pre_authorized = false)
+        def collection(base_query, pre_authorized: false)
           render :json => Insights::API::Common::PaginatedResponse.new(
             :base_query => filtered(scoped(base_query, pre_authorized)),
             :request    => request,
@@ -21,7 +21,7 @@ module Api
           ).response
         end
 
-        def rbac_scope(relation, pre_authorized = false)
+        def rbac_scope(relation, pre_authorized: false)
           return relation if pre_authorized
 
           if Catalog::RBAC::Role.catalog_administrator?

--- a/app/controllers/api/v1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1/portfolio_items_controller.rb
@@ -10,7 +10,7 @@ module Api
           collection(Tag.find(params.require(:tag_id)).portfolio_items)
         else
           authorize(PortfolioItem)
-          collection(policy_scope(PortfolioItem.all))
+          collection(policy_scope(PortfolioItem.all), true)
         end
       end
 

--- a/app/controllers/api/v1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1/portfolio_items_controller.rb
@@ -10,7 +10,7 @@ module Api
           collection(Tag.find(params.require(:tag_id)).portfolio_items)
         else
           authorize(PortfolioItem)
-          collection(policy_scope(PortfolioItem.all), true)
+          collection(policy_scope(PortfolioItem.all), :pre_authorized => true)
         end
       end
 

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -10,13 +10,13 @@ module Api
           relevant_portfolio = policy_scope(scope, :policy_scope_class => PortfolioPolicy::Scope).first
           relevant_tags = relevant_portfolio.try(:tags) || Tag.none
 
-          collection(relevant_tags, true)
+          collection(relevant_tags, :pre_authorized => true)
         elsif params[:portfolio_item_id]
           scope = PortfolioItem.where(:id => params.require(:portfolio_item_id))
           relevant_portfolio_item = policy_scope(scope, :policy_scope_class => PortfolioItemPolicy::Scope).first
           relevant_tags = relevant_portfolio_item.try(:tags) || Tag.none
 
-          collection(relevant_tags, true)
+          collection(relevant_tags, :pre_authorized => true)
         else
           collection(Tag.all)
         end

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -6,9 +6,17 @@ module Api
 
       def index
         if params[:portfolio_id]
-          collection(Portfolio.find(params.require(:portfolio_id)).tags)
+          scope = Portfolio.where(:id => params.require(:portfolio_id))
+          relevant_portfolio = policy_scope(scope, :policy_scope_class => PortfolioPolicy::Scope).first
+          relevant_tags = relevant_portfolio.try(:tags) || Tag.none
+
+          collection(relevant_tags, true)
         elsif params[:portfolio_item_id]
-          collection(PortfolioItem.find(params.require(:portfolio_item_id)).tags)
+          scope = PortfolioItem.where(:id => params.require(:portfolio_item_id))
+          relevant_portfolio_item = policy_scope(scope, :policy_scope_class => PortfolioItemPolicy::Scope).first
+          relevant_tags = relevant_portfolio_item.try(:tags) || Tag.none
+
+          collection(relevant_tags, true)
         else
           collection(Tag.all)
         end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -40,7 +40,6 @@ class ApplicationPolicy
   end
 
   class Scope
-
     attr_reader :user, :scope
 
     def initialize(user, scope)
@@ -54,6 +53,12 @@ class ApplicationPolicy
 
     def rbac_access
       @rbac_access ||= Catalog::RBAC::Access.new(@user)
+    end
+
+    private
+
+    def catalog_administrator?
+      Catalog::RBAC::Role.catalog_administrator?
     end
   end
 end

--- a/app/policies/portfolio_policy.rb
+++ b/app/policies/portfolio_policy.rb
@@ -26,4 +26,15 @@ class PortfolioPolicy < ApplicationPolicy
   end
 
   alias unshare? share?
+
+  class Scope < Scope
+    def resolve
+      if catalog_administrator?
+        scope.all
+      else
+        ids = Catalog::RBAC::AccessControlEntries.new.ace_ids('read', Portfolio)
+        scope.where(:id => ids)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -433,27 +433,6 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
     end
   end
 
-  context "GET /portfolio_items/{id}/tags" do
-    let(:name) { 'Gnocchi' }
-    let(:namespace) { 'default' }
-    let(:params) do
-      [{:tag => Tag.new(:name => name, :namespace => namespace).to_tag_string}]
-    end
-
-    before do
-      post "#{api_version}/portfolio_items/#{portfolio_item.id}/tag", :headers => default_headers, :params => params
-    end
-
-    context "when requesting all of the tags for a portfolio_item" do
-      it "returns the tags for the portfolio item" do
-        get "#{api_version}/portfolio_items/#{portfolio_item.id}/tags", :headers => default_headers
-
-        expect(json["meta"]["count"]).to eq 1
-        expect(json["data"].first["tag"]).to eq Tag.new(:name => name, :namespace => namespace).to_tag_string
-      end
-    end
-  end
-
   context "POST /portfolio_items/{id}/tag" do
     let(:name) { 'Gnocchi' }
     let(:params) do

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -406,21 +406,6 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
       end
     end
 
-    context "GET /portfolios/{id}/tags" do
-      let(:params) { {:name => tag_name, :namespace => tag_ns} }
-
-      before do
-        post "#{api_version}/portfolios/#{portfolio.id}/tag", :headers => default_headers, :params => tag_params
-      end
-
-      it "returns the tags for the portfolio" do
-        get "#{api_version}/portfolios/#{portfolio.id}/tags", :headers => default_headers
-
-        expect(json["meta"]["count"]).to eq 1
-        expect(json["data"].first["tag"]).to eq Tag.new(:name => tag_name, :namespace => tag_ns).to_tag_string
-      end
-    end
-
     context "POST /portfolios/{id}/tag" do
       context 'no namespace and value' do
         let(:params) { {:name => tag_name} }

--- a/spec/requests/api/v1.0/tags_spec.rb
+++ b/spec/requests/api/v1.0/tags_spec.rb
@@ -1,16 +1,26 @@
 describe "v1.0 - Tagging API", :type => [:request, :v1] do
   around do |example|
-    bypass_rbac do
+    with_modified_env(:RBAC_URL => "http://rbac.example.com") do
       example.call
     end
   end
 
-  let!(:portfolio_item) { create(:portfolio_item) }
+  let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => false) }
+  let(:rbac_aces) { instance_double(Catalog::RBAC::AccessControlEntries) }
+
+  let!(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio) }
   let!(:portfolio) { create(:portfolio) }
 
   before do
     portfolio_item.tag_add("yay")
     portfolio.tag_add("a_tag")
+
+    allow(Insights::API::Common::RBAC::Access).to receive(:new).with('tags', 'read').and_return(access_obj)
+    allow(access_obj).to receive(:process).and_return(access_obj)
+    allow(access_obj).to receive(:owner_scoped?).and_return(false)
+
+    allow(Catalog::RBAC::Role).to receive(:catalog_administrator?).and_return(false)
+    allow(Catalog::RBAC::AccessControlEntries).to receive(:new).and_return(rbac_aces)
   end
 
   describe "GET /tags" do
@@ -19,6 +29,62 @@ describe "v1.0 - Tagging API", :type => [:request, :v1] do
 
       expect(json["meta"]["count"]).to eq 2
       expect(json["data"].map { |e| Tag.parse(e["tag"])[:name] }).to match_array %w[yay a_tag]
+    end
+  end
+
+  describe "GET /portfolio_items/{id}/tags" do
+    context "when requesting all of the tags for a portfolio_item" do
+      before do
+        allow(rbac_aces).to receive(:ace_ids).with('read', Portfolio).and_return([portfolio.id.to_s])
+      end
+
+      it "returns the tags for the portfolio item" do
+        get "#{api_version}/portfolio_items/#{portfolio_item.id}/tags", :headers => default_headers
+
+        expect(json["meta"]["count"]).to eq 1
+        expect(json["data"].first["tag"]).to eq Tag.new(:name => "yay").to_tag_string
+      end
+    end
+
+    context "when requesting all tags for a portfolio item you do not have access to" do
+      before do
+        allow(rbac_aces).to receive(:ace_ids).with('read', Portfolio).and_return([])
+      end
+
+      it "returns an empty array" do
+        get "#{api_version}/portfolio_items/#{portfolio_item.id}/tags", :headers => default_headers
+
+        expect(json["meta"]["count"]).to eq 0
+        expect(json["data"]).to eq([])
+      end
+    end
+  end
+
+  describe "GET /portfolios/{id}/tags" do
+    context "when requesting all of the tags for a portfolio" do
+      before do
+        allow(rbac_aces).to receive(:ace_ids).with('read', Portfolio).and_return([portfolio.id.to_s])
+      end
+
+      it "returns the tags for the portfolio" do
+        get "#{api_version}/portfolios/#{portfolio.id}/tags", :headers => default_headers
+
+        expect(json["meta"]["count"]).to eq 1
+        expect(json["data"].first["tag"]).to eq Tag.new(:name => "a_tag").to_tag_string
+      end
+    end
+
+    context "when requesting all tags for a portfolio you do not have access to" do
+      before do
+        allow(rbac_aces).to receive(:ace_ids).with('read', Portfolio).and_return([])
+      end
+
+      it "returns an empty array" do
+        get "#{api_version}/portfolios/#{portfolio.id}/tags", :headers => default_headers
+
+        expect(json["meta"]["count"]).to eq 0
+        expect(json["data"]).to eq([])
+      end
     end
   end
 

--- a/spec/requests/api/v1.0/tags_spec.rb
+++ b/spec/requests/api/v1.0/tags_spec.rb
@@ -1,10 +1,4 @@
 describe "v1.0 - Tagging API", :type => [:request, :v1] do
-  around do |example|
-    with_modified_env(:RBAC_URL => "http://rbac.example.com") do
-      example.call
-    end
-  end
-
   let(:access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true, :owner_scoped? => false) }
   let(:rbac_aces) { instance_double(Catalog::RBAC::AccessControlEntries) }
 

--- a/spec/services/catalog/add_to_order_spec.rb
+++ b/spec/services/catalog/add_to_order_spec.rb
@@ -24,11 +24,14 @@ describe Catalog::AddToOrder, :type => :service do
 
   let(:request) { default_request }
   let(:service_plans_instance) { instance_double(Catalog::ServicePlans) }
+  let(:order_item_sanitized_parameters) { instance_double(Catalog::OrderItemSanitizedParameters, :sanitized_parameters => {"name" => "fred"}) }
 
   before do
     allow(Catalog::ServicePlans).to receive(:new).and_return(service_plans_instance)
     allow(service_plans_instance).to receive(:process).and_return(service_plans_instance)
     allow(service_plans_instance).to receive(:items).and_return([OpenStruct.new(:id => "1")])
+    allow(Catalog::OrderItemSanitizedParameters).to receive(:new).with(:order_item => order_item).and_return(order_item_sanitized_parameters)
+    allow(order_item_sanitized_parameters).to receive(:process).and_return(order_item_sanitized_parameters)
   end
 
   it "add order item" do

--- a/spec/support/requests_spec_helper.rb
+++ b/spec/support/requests_spec_helper.rb
@@ -20,6 +20,6 @@ module RequestSpecHelper
   end
 
   def catalog_admin_role
-    Api::V1::PortfoliosController::ADMINISTRATOR_ROLE_NAME
+    Catalog::RBAC::Role::ADMINISTRATOR_ROLE_NAME
   end
 end


### PR DESCRIPTION
This change should fix the issue where when requesting a Tag collection, it was going through RBAC and attempting to check ace records for tags when the only records that exist are for portfolios. If the user passes in a portfolio_id or portfolio_item_id, we will ensure that they have read access to the portfolio in question (either directly with the portfolio_id or the parent portfolio if a portfolio_item_id is passed in).

I'm not sure what, if any, changes need to be done for the regular `/tags` endpoint, it feels a little weird that we're being strict on what we show the user if you pass in a portfolio_id or portfolio_item_id, but if you just hit `/tags`, we return all of the ones that are available to your tenant.

This also changes the `spec/requests/api/v1.0/tags_spec.rb` into an "rbac" version where it tests our various internals. I'd rather we get to a place where we don't even need to do the `with_modified_env` and pass in an RBAC URL because it's all shielded behind the Policy objects, and then we test those individually, but this is a good middle ground for now.

https://projects.engineering.redhat.com/browse/SSP-1071

@mkanoor @syncrou @lindgrenj6 Please Review.