### PR TITLE
Versioning tool

### DIFF
--- a/lib/api/tools/add.rb
+++ b/lib/api/tools/add.rb
@@ -3,9 +3,28 @@ module Api
   module Tools
     class Add < Versioning
       def apply
-        %w[dirs files new_routes draw_file server_names].each do |apply|
+        %w[dirs files new_routes draw_file server_names spec_helpers spec_helper].each do |apply|
           self.send(apply)
         end
+      end
+
+      private
+
+      def spec_helper
+        file_name = "spec/spec_helper.rb"
+        text = File.read(file_name)
+        text = text.gsub("config.include V#{@previous}Helper, :type => :v#{@previous}", "config.include V#{@previous}Helper, :type => :v#{@previous}\n  config.include V#{@version}Helper, :type => :v#{@version}")
+
+        write(file_name, text)
+      end
+
+      def spec_helpers
+        file_name = "spec/support/v#{@version}_helper.rb"
+        text = File.read(file_name)
+        text = text.gsub("#{@dot_prev}","#{@dot_new}")
+        text = text.gsub("#{@previous}","#{@version}")
+
+        write(file_name, text)
       end
 
       def server_names
@@ -35,18 +54,17 @@ module Api
       end
 
       def dirs
-        # build new dirs
         %w[app/controllers/api spec/requests/api].each do |dir|
           path = dir.match('requests') ? "#{dir}/v#{@dot_new}" : "#{dir}/v#{@version}"
-          raise StandardError.new("Path already exists") if check_existing?(path)
+          raise StandardError.new("Path: #{path} already exists") if check_existing?(path)
           FileUtils.mkdir(path)
         end
       end
 
       def files
-        prev = ["app/controllers/api/v#{@previous}.rb", "config/routes/v#{@previous}.rb", "public/doc/openapi-3-v#{@dot_prev}.json"]
-        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json"].each_with_index do |file, index|
-          raise StandardError.new("File already exists") if check_existing?(file)
+        prev = ["app/controllers/api/v#{@previous}.rb", "config/routes/v#{@previous}.rb", "public/doc/openapi-3-v#{@dot_prev}.json", "spec/support/v#{@previous}_helper.rb"]
+        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json", "spec/support/v#{@version}_helper.rb"].each_with_index do |file, index|
+          raise StandardError.new("File: #{file} already exists") if check_existing?(file)
           FileUtils.cp(prev[index], file)
         end
       end

--- a/lib/api/tools/add.rb
+++ b/lib/api/tools/add.rb
@@ -1,0 +1,55 @@
+require 'fileutils'
+module Api
+  module Tools
+    class Add < Versioning
+      def apply
+        %w[dirs files new_routes draw_file server_names].each do |apply|
+          self.send(apply)
+        end
+      end
+
+      def server_names
+        file_name = "public/doc/openapi-3-v#{@dot_new}.json"
+        text = File.read(file_name)
+        text = text.gsub("/api/catalog/v#{@dot_prev}","/api/catalog/v#{@dot_new}")
+
+        write(file_name, text)
+      end
+
+      def new_routes
+        file_name = "config/routes.rb"
+        text = File.read(file_name)
+        text = text.gsub("draw(:v#{@previous})", "draw(:v#{@previous})\n    draw(:v#{@version})")
+        text = text.gsub("v#{@dot_prev}","v#{@dot_new}")
+
+        write(file_name, text)
+      end
+
+      def draw_file
+        file_name = "config/routes/v#{@version}.rb"
+        text = File.read(file_name)
+        text = text.gsub("#{@previous}", "#{@version}")
+        text = text.gsub("v#{@dot_prev}", "v#{@dot_new}")
+
+        write(file_name, text)
+      end
+
+      def dirs
+        # build new dirs
+        %w[app/controllers/api spec/requests/api].each do |dir|
+          path = dir.match('requests') ? "#{dir}/v#{@dot_new}" : "#{dir}/v#{@version}"
+          raise StandardError.new("Path already exists") if check_existing?(path)
+          FileUtils.mkdir(path)
+        end
+      end
+
+      def files
+        prev = ["app/controllers/api/v#{@previous}.rb", "config/routes/v#{@previous}.rb", "public/doc/openapi-3-v#{@dot_prev}.json"]
+        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json"].each_with_index do |file, index|
+          raise StandardError.new("File already exists") if check_existing?(file)
+          FileUtils.cp(prev[index], file)
+        end
+      end
+    end
+  end
+end

--- a/lib/api/tools/remove.rb
+++ b/lib/api/tools/remove.rb
@@ -3,16 +3,26 @@ module Api
   module Tools
     class Remove < Versioning
       def apply
-        %w[dirs files routes].each do |apply|
+        %w[dirs files routes spec_helper].each do |apply|
           send(apply)
         end
       end
+
+      private
 
       def routes
         file_name = "config/routes.rb"
         text = File.read(file_name)
         text = text.gsub("#{@dot_new}", "#{@dot_prev}")
         text = text.gsub("draw(:v#{@version})", '')
+
+        write(file_name, text)
+      end
+
+      def spec_helper
+        file_name = "spec/spec_helper.rb"
+        text = File.read(file_name)
+        text = text.gsub("config.include V#{@version}Helper, :type => :v#{@version}", '')
 
         write(file_name, text)
       end
@@ -25,7 +35,7 @@ module Api
       end
 
       def files
-        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json"].each_with_index do |file, index|
+        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json", "spec/support/v#{@version}_helper.rb"].each_with_index do |file, index|
           FileUtils.rm(file)
         end
       end

--- a/lib/api/tools/remove.rb
+++ b/lib/api/tools/remove.rb
@@ -1,0 +1,34 @@
+require 'fileutils'
+module Api
+  module Tools
+    class Remove < Versioning
+      def apply
+        %w[dirs files routes].each do |apply|
+          send(apply)
+        end
+      end
+
+      def routes
+        file_name = "config/routes.rb"
+        text = File.read(file_name)
+        text = text.gsub("#{@dot_new}", "#{@dot_prev}")
+        text = text.gsub("draw(:v#{@version})", '')
+
+        write(file_name, text)
+      end
+
+      def dirs
+        %w[app/controllers/api spec/requests/api].each do |dir|
+          path = dir.match('requests') ? "#{dir}/v#{@dot_new}" : "#{dir}/v#{@version}"
+          FileUtils.rm_rf(path)
+        end
+      end
+
+      def files
+        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json"].each_with_index do |file, index|
+          FileUtils.rm(file)
+        end
+      end
+    end
+  end
+end

--- a/lib/api/tools/template.rb
+++ b/lib/api/tools/template.rb
@@ -1,0 +1,28 @@
+module Api
+  module Tools
+    class Template < Versioning
+      def initialize(version, controller_names)
+        @version = version
+        @controller_names = controller_names
+      end
+
+      def controller(controller_name)
+<<RUBY
+module Api
+  module V#{@version}
+    class #{controller_name} < ApplicationController
+    end
+  end
+end
+RUBY
+      end
+
+      def write_templates
+        @controller_names.each do |controller_name|
+          file_name = "app/controllers/api/v#{@version}/#{controller_name.tableize.singularize}.rb"
+          write(file_name, controller(controller_name))
+        end
+      end
+    end
+  end
+end

--- a/lib/api/tools/versioning.rb
+++ b/lib/api/tools/versioning.rb
@@ -2,8 +2,12 @@ require 'fileutils'
 module Api
   module Tools
     class Versioning
-      def self.build_new(new_version, previous_version)
+      def self.build_new(new_version, previous_version, controller_names=[])
         Add.new(new_version, previous_version).apply
+
+        if controller_names.present?
+          Template.new(new_version, controller_names).write_templates
+        end
       end
 
       def self.remove(version, previous)

--- a/lib/api/tools/versioning.rb
+++ b/lib/api/tools/versioning.rb
@@ -1,0 +1,49 @@
+require 'fileutils'
+module Api
+  module Tools
+    class Versioning
+      def self.build_new(version)
+        _self = new(version)
+        _self.build_dirs
+        _self.build_files
+        _self.append_new_to_existing
+      end
+
+      def initialize(version)
+        @version = version
+        @last_known_minor
+        @last_known_major
+      end
+
+      def append_new_to_existing
+        puts "Appending stuff"
+      end
+
+      def build_dirs
+        # build new dirs
+        %w[app/controllers/api specs/requests/api].each do |dir|
+          path = "#{dir}/v#{@version}"
+          raise StandardError.new("Path already exists") if check_existing?(path)
+          FileUtils.mkdir(path)
+        end
+      end
+
+      def build_files
+        # build new filess
+        ["config/routes/v#{@version}", "public/doc/openapi-3v#{version}.json"].each do |file|
+          raise StandardError.new("File already exists") if check_existing?(file)
+          FileUtils.cp(file)
+        end
+      end
+
+      private
+
+      def check_existing?(file_path)
+        FileUtils.cd(file_path)
+        true
+      rescue Errno::ENOENT
+        false
+      end
+    end
+  end
+end

--- a/lib/api/tools/versioning.rb
+++ b/lib/api/tools/versioning.rb
@@ -3,18 +3,11 @@ module Api
   module Tools
     class Versioning
       def self.build_new(new_version, previous_version)
-        add = new(new_version, previous_version)
-        add.build_dirs
-        add.build_files
-        add.append_new_routes
-        add.append_draw_file
+        Add.new(new_version, previous_version).apply
       end
 
       def self.remove(version, previous)
-        remove = new(version, previous)
-        remove.rm_dirs
-        remove.rm_files
-        remove.remove_routes
+        Remove.new(version, previous).apply
       end
 
       def initialize(version, previous)
@@ -22,63 +15,6 @@ module Api
         @previous = previous
         @dot_prev = @previous.split('x').join('.')
         @dot_new = @version.split('x').join('.')
-      end
-
-      def append_new_routes
-        file_name = "config/routes.rb"
-        text = File.read(file_name)
-        text = text.gsub("draw(:v#{@previous})", "draw(:v#{@previous})\n    draw(:v#{@version})")
-        text = text.gsub("v#{@dot_prev}","v#{@dot_new}")
-
-        write(file_name, text)
-      end
-
-      def append_draw_file
-        file_name = "config/routes/v#{@version}.rb"
-        text = File.read(file_name)
-        text = text.gsub("#{@previous}", "#{@version}")
-        text = text.gsub("v#{@dot_prev}", "v#{@dot_new}")
-
-        write(file_name, text)
-      end
-
-      def remove_routes
-        file_name = "config/routes.rb"
-        text = File.read(file_name)
-        text = text.gsub("#{@dot_new}", "#{@dot_prev}")
-        text = text.gsub("draw(:v#{@version})", '')
-
-        write(file_name, text)
-      end
-
-      def rm_dirs
-        %w[app/controllers/api spec/requests/api].each do |dir|
-          path = dir.match('requests') ? "#{dir}/v#{@dot_new}" : "#{dir}/v#{@version}"
-          FileUtils.rm_rf(path)
-        end
-      end
-
-      def rm_files
-        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json"].each_with_index do |file, index|
-          FileUtils.rm(file)
-        end
-      end
-
-      def build_dirs
-        # build new dirs
-        %w[app/controllers/api spec/requests/api].each do |dir|
-          path = dir.match('requests') ? "#{dir}/v#{@dot_new}" : "#{dir}/v#{@version}"
-          raise StandardError.new("Path already exists") if check_existing?(path)
-          FileUtils.mkdir(path)
-        end
-      end
-
-      def build_files
-        prev = ["app/controllers/api/v#{@previous}.rb", "config/routes/v#{@previous}.rb", "public/doc/openapi-3-v#{@dot_prev}.json"]
-        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json"].each_with_index do |file, index|
-          raise StandardError.new("File already exists") if check_existing?(file)
-          FileUtils.cp(prev[index], file)
-        end
       end
 
       private

--- a/lib/api/tools/versioning.rb
+++ b/lib/api/tools/versioning.rb
@@ -3,66 +3,91 @@ module Api
   module Tools
     class Versioning
       def self.build_new(new_version, previous_version)
-        add_version = new(new_version, previous_version)
-        add_version.build_dirs
-        add_version.build_files
-        add_version.append_new_to_existing
+        add = new(new_version, previous_version)
+        add.build_dirs
+        add.build_files
+        add.append_new_routes
+        add.append_draw_file
       end
 
-      def self.remove(version)
-        remove_version = new(version, version)
-        remove_version.rm_dirs
-        remove_version.rm_files
+      def self.remove(version, previous)
+        remove = new(version, previous)
+        remove.rm_dirs
+        remove.rm_files
+        remove.remove_routes
       end
 
-      def initialize(new_version, previous)
-        @new_version = new_version
+      def initialize(version, previous)
+        @version = version
         @previous = previous
+        @dot_prev = @previous.split('x').join('.')
+        @dot_new = @version.split('x').join('.')
       end
 
-      def append_new_to_existing
-        puts "Need to append stuff here"
+      def append_new_routes
+        file_name = "config/routes.rb"
+        text = File.read(file_name)
+        text = text.gsub("draw(:v#{@previous})", "draw(:v#{@previous})\n    draw(:v#{@version})")
+        text = text.gsub("v#{@dot_prev}","v#{@dot_new}")
+
+        write(file_name, text)
+      end
+
+      def append_draw_file
+        file_name = "config/routes/v#{@version}.rb"
+        text = File.read(file_name)
+        text = text.gsub("#{@previous}", "#{@version}")
+        text = text.gsub("v#{@dot_prev}", "v#{@dot_new}")
+
+        write(file_name, text)
+      end
+
+      def remove_routes
+        file_name = "config/routes.rb"
+        text = File.read(file_name)
+        text = text.gsub("#{@dot_new}", "#{@dot_prev}")
+        text = text.gsub("draw(:v#{@version})", '')
+
+        write(file_name, text)
       end
 
       def rm_dirs
-        # build new dirs
-        dot_new = @new_version.split('x').join('.')
         %w[app/controllers/api spec/requests/api].each do |dir|
-          path = dir.match('requests') ? "#{dir}/v#{dot_new}" : "#{dir}/v#{@new_version}"
+          path = dir.match('requests') ? "#{dir}/v#{@dot_new}" : "#{dir}/v#{@version}"
           FileUtils.rm_rf(path)
         end
       end
 
       def rm_files
-        # build new filess
-        dot_new = @new_version.split('x').join('.')
-        ["app/controllers/api/v#{@new_version}.rb", "config/routes/v#{@new_version}.rb", "public/doc/openapi-3-v#{dot_new}.json"].each_with_index do |file, index|
+        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json"].each_with_index do |file, index|
           FileUtils.rm(file)
         end
       end
 
       def build_dirs
         # build new dirs
-        dot_new = @new_version.split('x').join('.')
         %w[app/controllers/api spec/requests/api].each do |dir|
-          path = dir.match('requests') ? "#{dir}/v#{dot_new}" : "#{dir}/v#{@new_version}"
+          path = dir.match('requests') ? "#{dir}/v#{@dot_new}" : "#{dir}/v#{@version}"
           raise StandardError.new("Path already exists") if check_existing?(path)
           FileUtils.mkdir(path)
         end
       end
 
       def build_files
-        # build new files
-        dot_prev = @previous.split('x').join('.')
-        dot_new = @new_version.split('x').join('.')
-        prev = ["app/controllers/api/v#{@previous}.rb", "config/routes/v#{@previous}.rb", "public/doc/openapi-3-v#{dot_prev}.json"]
-        ["app/controllers/api/v#{@new_version}.rb", "config/routes/v#{@new_version}.rb", "public/doc/openapi-3-v#{dot_new}.json"].each_with_index do |file, index|
+        prev = ["app/controllers/api/v#{@previous}.rb", "config/routes/v#{@previous}.rb", "public/doc/openapi-3-v#{@dot_prev}.json"]
+        ["app/controllers/api/v#{@version}.rb", "config/routes/v#{@version}.rb", "public/doc/openapi-3-v#{@dot_new}.json"].each_with_index do |file, index|
           raise StandardError.new("File already exists") if check_existing?(file)
           FileUtils.cp(prev[index], file)
         end
       end
 
       private
+
+      def write(file_name, text)
+        File.open(file_name, "w") do |file|
+          file.puts text
+        end
+      end
 
       def check_existing?(file_path)
         FileUtils.cd(file_path)

--- a/lib/tasks/versioning.rake
+++ b/lib/tasks/versioning.rake
@@ -1,0 +1,22 @@
+require 'rake'
+
+namespace :api do
+  namespace :versioning do
+    desc "Add minor version"
+    task :minor, [:version] => :environment do |_task, args|
+      version = args.version
+      Api::Tools::Versioning.build_new(version)
+    end
+
+    desc "Add major version"
+    task :major, [:version] => :environment do |_task, args|
+      version = args.version
+      Api::Tools::Versioning.build_new(version)
+    end
+
+    desc "Deprecate version"
+    task :deprecate, [:version] => :environment do |_task, args|
+
+    end
+  end
+end

--- a/lib/tasks/versioning.rake
+++ b/lib/tasks/versioning.rake
@@ -16,10 +16,11 @@ namespace :api do
       Api::Tools::Versioning.build_new(new_version, previous_version)
     end
 
-    desc "Remove version [version_to_remove] rake api:versioning:remove['1x2']"
-    task :remove, [:version] => :environment do |_task, args|
-      version = args.version
-      Api::Tools::Versioning.remove(version)
+    desc "Remove version [version_to_remove, restore_version] rake api:versioning:remove['1x2','1x1']"
+    task :remove, [:version_to_remove, :restore_version] => :environment do |_task, args|
+      version_to_remove = args.version_to_remove
+      restore = args.restore_version
+      Api::Tools::Versioning.remove(version_to_remove, restore)
     end
   end
 end

--- a/lib/tasks/versioning.rake
+++ b/lib/tasks/versioning.rake
@@ -2,18 +2,20 @@ require 'rake'
 
 namespace :api do
   namespace :versioning do
-    desc "Add minor version [new_version,previsou] rake api:versioning:minor['1x2','1x1']"
-    task :minor, [:new_version, :previous_version] => :environment do |_task, args|
+    desc "Add minor version [new_version,previous,controllers] rake api:versioning:minor['1x2','1x1','TestController;TestTwoController']"
+    task :minor, [:new_version, :previous_version, :controllers] => :environment do |_task, args|
+      controllers = args.controllers ? args.controllers.split(';') : []
       new_version = args.new_version
       previous_version = args.previous_version
-      Api::Tools::Versioning.build_new(new_version, previous_version)
+      Api::Tools::Versioning.build_new(new_version, previous_version, controllers)
     end
 
-    desc "Add major version [new_major,previous] rake api:versioning:major['2x0','1x9']"
-    task :major, [:new_version, :previous_version] => :environment do |_task, args|
+    desc "Add major version [new_major,previous] rake api:versioning:major['2x0','1x9','TestControllerOne;TestTwoController']"
+    task :major, [:new_version, :previous_version, :controllers] => :environment do |_task, args|
+      controllers = args.controllers ? args.controllers.split(';') : []
       new_version = args.new_version
       previous_version = args.previous_version
-      Api::Tools::Versioning.build_new(new_version, previous_version)
+      Api::Tools::Versioning.build_new(new_version, previous_version, controllers)
     end
 
     desc "Remove version [version_to_remove, restore_version] rake api:versioning:remove['1x2','1x1']"

--- a/lib/tasks/versioning.rake
+++ b/lib/tasks/versioning.rake
@@ -2,21 +2,24 @@ require 'rake'
 
 namespace :api do
   namespace :versioning do
-    desc "Add minor version"
-    task :minor, [:version] => :environment do |_task, args|
-      version = args.version
-      Api::Tools::Versioning.build_new(version)
+    desc "Add minor version [new_version,previsou] rake api:versioning:minor['1x2','1x1']"
+    task :minor, [:new_version, :previous_version] => :environment do |_task, args|
+      new_version = args.new_version
+      previous_version = args.previous_version
+      Api::Tools::Versioning.build_new(new_version, previous_version)
     end
 
-    desc "Add major version"
-    task :major, [:version] => :environment do |_task, args|
-      version = args.version
-      Api::Tools::Versioning.build_new(version)
+    desc "Add major version [new_major,previous] rake api:versioning:major['2x0','1x9']"
+    task :major, [:new_version, :previous_version] => :environment do |_task, args|
+      new_version = args.new_version
+      previous_version = args.previous_version
+      Api::Tools::Versioning.build_new(new_version, previous_version)
     end
 
-    desc "Deprecate version"
-    task :deprecate, [:version] => :environment do |_task, args|
-
+    desc "Remove version [version_to_remove] rake api:versioning:remove['1x2']"
+    task :remove, [:version] => :environment do |_task, args|
+      version = args.version
+      Api::Tools::Versioning.remove(version)
     end
   end
 end


### PR DESCRIPTION
Builds out a versioning tool to build out minor versions:
```
rake api:versioning:minor[new_version,previous_version,controllers]  # Add minor version [new_version,previous,controllers] rake api:versioning:minor['1x2','1x1','TestController;OtherTestController']
```
1. Copies `config/routes/v<previous>.rb` -> `config/routes/v<new_version>.rb`.
2. Creates `new_version` directories in `app/controllers/api/` and `spec/requests/api`.
3. Creates a copy of `openapi-3-v<new_version>.json` as a copy of the `openapi-3-v<previous>.json`.
4. Edits `config/routes/v<new_version>.rb` with the new_version values.
5. Edits 'config/routes.rb` with the new_version draw entry and the major version redirect from `new_version`.
6. Adds empty versions of new controllers when passed in as an array (separated by ';'.)

Provides a way to remove a version:
```
rake api:versioning:remove[version,restore_version]      # Remove version [version_to_remove] rake api:versioning:remove['1x2','1x1']
```
1. Removes `version` directories `app/controllers/api/` and `spec/requests/api`.
2. Removes `config/routes/v<version>.rb`.
3. Removes `openapi-3-v<version>.json`.
4. Edits `config/routes.rb` removing the `version` draw entry and the major version redirects to the `restore_version` value.

Additions still needed:
~1. Edit server entries in the new openapi json spec.~
~2. Take arguments for the controllers in the <new_version> directories.~
~3. Edit `spec_helper.rb` and add `spec/support/V<new version>_helper.rb` file.~

JIRA: https://projects.engineering.redhat.com/browse/SSP-1019