### PR TITLE
Store the external_url on an order_item when the Order fails

### DIFF
--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -75,6 +75,7 @@ module Catalog
       @order_item.completed_at = DateTime.now
       @order_item.state = "Failed"
       @order_item.update_message("error", "Order Item Failed")
+      @order_item.external_url = fetch_external_url
 
       Rails.logger.info("Updating OrderItem: #{@order_item.id} with 'Failed' state")
       @order_item.save!

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -148,6 +148,12 @@ describe Catalog::UpdateOrderItem, :type => :service do
           expect(item.completed_at).to eq(fake_now)
         end
 
+        it "sets the external url" do
+          subject.process
+          item.reload
+          expect(item.external_url).to eq("external url")
+        end
+
         it "marks the item as failed" do
           subject.process
           item.reload


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1252

We weren't storing the external_url when an order_item failed even though topology provides one no matter what. This just adds a call to set the external_url in the `mark_item_failed` method. 

@miq-bot add_reviewer syncrou
@miq-bot add_reviewer eclarizio