### PR TITLE
When copying a product set the :restore_to properly

### DIFF
--- a/app/services/concerns/icon_mixin.rb
+++ b/app/services/concerns/icon_mixin.rb
@@ -1,5 +1,5 @@
 module IconMixin
   def duplicate_icon(src, dest)
-    dest.create_icon!(:restore_to => src, :image_id => src.icon.image_id)
+    dest.create_icon!(:restore_to => dest, :image_id => src.icon.image_id)
   end
 end

--- a/spec/services/catalog/copy_portfolio_item_spec.rb
+++ b/spec/services/catalog/copy_portfolio_item_spec.rb
@@ -63,6 +63,7 @@ describe Catalog::CopyPortfolioItem, :type => :service do
 
         expect(new.icon_id).not_to eq portfolio_item.icon_id
         expect(new.icon.image_id).to eq portfolio_item.icon.image_id
+        expect(new.icon.restore_to).to eq new
       end
     end
 

--- a/spec/services/catalog/copy_portfolio_spec.rb
+++ b/spec/services/catalog/copy_portfolio_spec.rb
@@ -23,6 +23,7 @@ describe Catalog::CopyPortfolio, :type => :service do
 
         expect(new.icon_id).not_to eq portfolio.icon_id
         expect(new.icon.image_id).to eq portfolio.icon.image_id
+        expect(new.icon.restore_to).to eq new_portfolio
       end
 
       it "copies over all of the portfolio items" do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1328

It would help if I tell the icon where it belongs correctly instead of just basically kicking out the old one. 

@miq-bot add_reviewer syncrou