### PR TITLE
Remove PATCH /icons/:id endpoint since it is not used

### DIFF
--- a/app/controllers/api/v1x1/icons_controller.rb
+++ b/app/controllers/api/v1x1/icons_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Api::V1::Mixins::IndexMixin
 
       # Due to the fact form-data is getting uploaded and isn't supported by openapi_parser
-      skip_before_action :validate_request, :only => %i[create update]
+      skip_before_action :validate_request, :only => %i[create]
 
       def create
         icon = Catalog::CreateIcon.new(icon_params).process.icon
@@ -14,11 +14,6 @@ module Api
       def destroy
         Catalog::SoftDelete.new(Icon.find(params.require(:id))).process
         head :no_content
-      end
-
-      def update
-        icon = Catalog::UpdateIcon.new(params.require(:id), icon_patch_params).process.icon
-        render :json => icon
       end
 
       def raw_icon
@@ -35,11 +30,7 @@ module Api
 
       def icon_params
         params.require(:content)
-        icon_patch_params
-      end
-
-      def icon_patch_params
-        params.permit(:content, :source_ref, :source_id, :portfolio_item_id, :portfolio_id, :id)
+        params.permit(:content, :portfolio_item_id, :portfolio_id)
       end
 
       def find_icon(ids)

--- a/config/routes/v1x1.rb
+++ b/config/routes/v1x1.rb
@@ -37,7 +37,7 @@ namespace :v1x1, :path => "v1.1" do
     post :copy, :action => 'copy', :controller => 'portfolio_items'
     post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
   end
-  resources :icons, :only => [:create, :destroy, :update]
+  resources :icons, :only => [:create, :destroy]
   resources :settings
   resources :tags, :only => [:index]
   resources :tenants, :only => [:index, :show] do

--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -2037,51 +2037,6 @@
       }
     },
     "/icons/{id}": {
-      "patch": {
-        "tags": [
-          "Icon"
-        ],
-        "summary": "Edit an existing Icon",
-        "description": "Edits Icon specified by the given ID.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/ID"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Icon"
-              }
-            }
-          },
-          "description": "Parameters needed to update an Icon",
-          "required": true
-        },
-        "operationId": "updateIcon",
-        "responses": {
-          "200": {
-            "description": "Return the updated Icon object",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Icon"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "description": "Icon not found."
-          }
-        }
-      },
       "delete": {
         "tags": [
           "Icon"

--- a/spec/requests/api/v1.1/icons_spec.rb
+++ b/spec/requests/api/v1.1/icons_spec.rb
@@ -151,27 +151,6 @@ describe "v1.1 - IconsRequests", :type => [:request, :v1x1] do
     end
   end
 
-  describe "#update" do
-    let(:params) { {:content => form_upload_test_image("miq_logo.svg") } }
-
-    before do
-      patch "#{api_version}/icons/#{icon.id}", :params => params, :headers => default_headers, :as => :form
-      icon.reload
-    end
-
-    it "returns a 200" do
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "updates the fields passed in" do
-      expect(icon.image.content).to eq Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "miq_logo.svg")))
-    end
-
-    it "updated to a new image record" do
-      expect(icon.image_id).to_not eq image.id
-    end
-  end
-
   describe "#raw_icon" do
     context "when the icon exists" do
       it "/portfolio_items/{portfolio_item_id}/icon returns the icon" do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1286

Was going to remove the `Catalog::UpdateIcon` service class - but it's needed for v1.0 of the API still. It'll be nice once we have these versioned. 

@miq-bot add_reviewer syncrou