### PR TITLE
Fixed regular expression for tags

### DIFF
--- a/public/doc/openapi-3-v1.0.json
+++ b/public/doc/openapi-3-v1.0.json
@@ -3682,7 +3682,7 @@
           "tag": {
             "example": "/namespace/architecture=x86_64",
             "type": "string",
-            "pattern": "\\/.*\\/.+(=.+|[^=]$)"
+            "pattern": "^/.*/.+(=.+|[^=]$)"
           }
         },
         "additionalProperties": false

--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -3608,7 +3608,7 @@
           "tag": {
             "example": "/namespace/architecture=x86_64",
             "type": "string",
-            "pattern": "\\/.*\\/.+(=.+|[^=]$)"
+            "pattern": "^/.*/.+(=.+|[^=]$)"
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
This is to fix an issue in the openapi generator
When we have regular expressions they come in 2 formats
1. /pattern/
2. "pattern"

In the first one if the pattern contains a forward slash
(aka Solidus from
https://www.ecma-international.org/archive/ecmascript/2013/GA/ga-2013-076.pdf)
it needs to be escaped with a backslash (reverse solidus)

In the second case we dont have to escape the forward slash

In our openapi spec we have always tended to use the second format.

The openapi generator checks the first charachter and if it starts
with a forward slash it assumes it's the first format and doesn't
escape the / contained in the string

https://github.com/OpenAPITools/openapi-generator/blob/de2753dfc7d17a8afcc14fdd705ade3f6cca3cb2/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L4825

In our tags we are expecting values like
/approval/workspace=55

Since our regexp starts with a / it bypasses the escaping process in the
openapi generator

To temporarily resolve this issue I have modified our regular expression to have a ^
which bypasses the first charachter to be / in the openapi-generator

I have opened an issue with the openapi-generator repository which might
resolve the issue on the generator
https://github.com/OpenAPITools/openapi-generator/issues/5582