### PR TITLE
Refactor the code paths to mark orders/order_items as completed/failed

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -34,6 +34,18 @@ class OrderItem < ApplicationRecord
     touch
   end
 
+  def mark_completed(msg = nil, **opts)
+    mark_item(msg, :completed_at => DateTime.now, :state => "Completed", **opts)
+  end
+
+  def mark_failed(msg = nil, **opts)
+    mark_item(msg, :completed_at => DateTime.now, :state => "Failed", :level => "error", **opts)
+  end
+
+  def mark_ordered(msg = nil, **opts)
+    mark_item(msg, :order_request_sent_at => DateTime.now, :state => "Ordered",  **opts)
+  end
+
   private
 
   def sanitize_parameters
@@ -51,5 +63,12 @@ class OrderItem < ApplicationRecord
 
   def parameters_contain_sanitized_values?(val)
     val.to_s.include?("\"#{Catalog::OrderItemSanitizedParameters::MASKED_VALUE}\"")
+  end
+
+  def mark_item(msg, level: "info", **opts)
+    update!(**opts)
+    update_message(level, msg) if msg
+
+    Catalog::OrderStateTransition.new(order).process
   end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -68,6 +68,7 @@ class OrderItem < ApplicationRecord
   def mark_item(msg, level: "info", **opts)
     update!(**opts)
     update_message(level, msg) if msg
+    Rails.logger.send(level, "Updated OrderItem: #{id} with '#{opts[:state]}' state".tap { |log| log << " message: #{msg}" if msg })
 
     Catalog::OrderStateTransition.new(order).process
   end

--- a/app/services/catalog/approval_transition.rb
+++ b/app/services/catalog/approval_transition.rb
@@ -30,7 +30,7 @@ module Catalog
         mark_canceled
       else
         @state = "Pending"
-        Catalog::OrderStateTransition.new(@order_item.order_id).process
+        Catalog::OrderStateTransition.new(@order_item.order).process
       end
     end
 
@@ -57,7 +57,7 @@ module Catalog
 
     def finalize_order
       @order_item.update(:state => @state)
-      Catalog::OrderStateTransition.new(@order_item.order_id).process
+      Catalog::OrderStateTransition.new(@order_item.order).process
     end
 
     def approved?

--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -15,7 +15,7 @@ module Catalog
       @order.update(:state => "Approval Pending", :order_request_sent_at => Time.now.utc)
       self
     rescue Catalog::ApprovalError => e
-      fail_order
+      @order.order_items.first.mark_failed("Error while creating approval request")
       Rails.logger.error("Error putting in approval Request for #{order.id}: #{e.message}")
       raise
     end
@@ -34,11 +34,6 @@ module Catalog
       )
 
       Rails.logger.info("Approval Requests Submitted for Order #{@order.id}")
-    end
-
-    def fail_order
-      @order.order_items.first.update_message(:error, "Error while creating approval request")
-      @order.update!(:state => "Failed")
     end
   end
 end

--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -14,7 +14,7 @@ module Catalog
 
       add_task_update_message
       delegate_task if @task.state == "completed"
-      fail_order if @task.status == "error"
+      order_item.mark_failed if @task.status == "error"
 
       self
     rescue StandardError => exception
@@ -47,11 +47,6 @@ module Catalog
     def add_update_message(state, message)
       order_item.update_message(state, message)
       Rails.logger.send(state, message)
-    end
-
-    def fail_order
-      order_item.update!(:state => "Failed")
-      Catalog::OrderStateTransition.new(order_item.order_id).process
     end
   end
 end

--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -47,13 +47,11 @@ module Catalog
         case @payload["state"]
         when "completed"
           @order_item.mark_completed("Order Item Complete", :external_url => fetch_external_url)
-          Rails.logger.info("Updated OrderItem: #{@order_item.id} with 'Completed' state")
         when "running"
           @order_item.update_message("info", "Order Item being processed with context: #{@payload["context"]}")
         end
       when "error"
         @order_item.mark_failed("Order Item Failed", :external_url => fetch_external_url)
-        Rails.logger.info("Updated OrderItem: #{@order_item.id} with 'Failed' state")
       else
         # Do nothing for now, only other case is "warn"
       end

--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -46,40 +46,17 @@ module Catalog
       when "ok"
         case @payload["state"]
         when "completed"
-          mark_item_finished
-          Catalog::OrderStateTransition.new(@order_item.order_id).process
+          @order_item.mark_completed("Order Item Complete", :external_url => fetch_external_url)
+          Rails.logger.info("Updated OrderItem: #{@order_item.id} with 'Completed' state")
         when "running"
           @order_item.update_message("info", "Order Item being processed with context: #{@payload["context"]}")
-          @order_item.save!
         end
       when "error"
-        mark_item_failed
-        Catalog::OrderStateTransition.new(@order_item.order_id).process
+        @order_item.mark_failed("Order Item Failed", :external_url => fetch_external_url)
+        Rails.logger.info("Updated OrderItem: #{@order_item.id} with 'Failed' state")
       else
         # Do nothing for now, only other case is "warn"
       end
-    end
-
-    def mark_item_finished
-      @order_item.completed_at = DateTime.now
-      @order_item.state = "Completed"
-      @order_item.update_message("info", "Order Item Complete")
-      @order_item.external_url = fetch_external_url
-
-      Rails.logger.info("Updating OrderItem: #{@order_item.id} with 'Completed' state and #{@order_item.external_url} external url")
-      @order_item.save!
-      Rails.logger.info("Finished updating OrderItem: #{@order_item.id} with 'Completed' state")
-    end
-
-    def mark_item_failed
-      @order_item.completed_at = DateTime.now
-      @order_item.state = "Failed"
-      @order_item.update_message("error", "Order Item Failed")
-      @order_item.external_url = fetch_external_url
-
-      Rails.logger.info("Updating OrderItem: #{@order_item.id} with 'Failed' state")
-      @order_item.save!
-      Rails.logger.info("Finished updating OrderItem: #{@order_item.id} with 'Failed' state")
     end
   end
 end

--- a/lib/catalog/order_state_transition.rb
+++ b/lib/catalog/order_state_transition.rb
@@ -2,8 +2,8 @@ module Catalog
   class OrderStateTransition
     attr_reader :state
 
-    def initialize(order_id)
-      @order = Order.find(order_id)
+    def initialize(order)
+      @order = order
     end
 
     def process

--- a/spec/lib/catalog/order_state_transition_spec.rb
+++ b/spec/lib/catalog/order_state_transition_spec.rb
@@ -10,7 +10,7 @@ describe Catalog::OrderStateTransition do
     end
 
     let(:transition) do
-      described_class.new(order.id).process
+      described_class.new(order).process
       order.reload
     end
 

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -45,4 +45,62 @@ describe OrderItem do
       end
     end
   end
+
+  shared_examples_for "#mark_item" do
+    it "sets the params properly" do
+      params.each do |k,v|
+        expect(order_item.send(k)).to eq v
+      end
+    end
+  end
+
+  describe "#mark_completed" do
+    let(:params) { {:external_url => "not.a.real/url"} }
+
+    before do
+      order_item.mark_completed(params)
+      order_item.reload
+    end
+
+    it "marks the order and order item as completed" do
+      expect(order_item.state).to eq "Completed"
+      expect(order_item.order.state).to eq "Completed"
+      expect(order_item.completed_at).to be_truthy
+    end
+
+    it_behaves_like "#mark_item"
+  end
+
+  describe "#mark_failed" do
+    let(:params) { {:external_url => "not.a.real/url"} }
+    before do
+      order_item.mark_failed(params)
+      order_item.reload
+    end
+
+    it "marks the order and order item as failed" do
+      expect(order_item.state).to eq "Failed"
+      expect(order_item.order.state).to eq "Failed"
+      expect(order_item.completed_at).to be_truthy
+    end
+
+    it_behaves_like "#mark_item"
+  end
+
+  describe "#mark_ordered" do
+    let(:params) { {:topology_task_ref => "an id", :external_url => "not.a.real/url"} }
+
+    before do
+      order_item.mark_ordered(params)
+      order_item.reload
+    end
+
+    it "marks the order and order item as failed" do
+      expect(order_item.state).to eq "Ordered"
+      expect(order_item.order.state).to eq "Ordered"
+      expect(order_item.completed_at).to be_falsey
+    end
+
+    it_behaves_like "#mark_item"
+  end
 end

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -137,7 +137,7 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
           let(:status) { "error" }
 
           before do
-            allow(Catalog::OrderStateTransition).to receive(:new).with(order_item.order.id).and_return(order_state_transition)
+            allow(Catalog::OrderStateTransition).to receive(:new).with(order_item.order).and_return(order_state_transition)
             allow(order_state_transition).to receive(:process)
           end
 

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -23,14 +23,6 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
         expect(progress_message.message).to match(/Task update/)
         expect(progress_message.order_item_id).to eq(order_item.id.to_s)
       end
-
-      it "logs an info message" do
-        allow(Rails.logger).to receive(:info).with(anything)
-        expect(Rails.logger).to receive(:info).with(
-          "Task update. State: running. Status: ok. Context: "
-        )
-        subject.process
-      end
     end
 
     context "when the state is something else" do
@@ -44,14 +36,6 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
         expect(progress_message.level).to eq("info")
         expect(progress_message.message).to match(/Task update/)
         expect(progress_message.order_item_id).to eq(order_item.id.to_s)
-      end
-
-      it "logs an info message" do
-        allow(Rails.logger).to receive(:info).with(anything)
-        expect(Rails.logger).to receive(:info).with(
-          "Task update. State: what. Status: ok. Context: "
-        )
-        subject.process
       end
     end
 
@@ -149,20 +133,6 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
             expect(progress_message.order_item_id).to eq(order_item.id.to_s)
           end
 
-          it "logs an error" do
-            expect(Rails.logger).to receive(:error).with(
-              "Task update. State: completed. Status: error. Context: #{payload_context}"
-            )
-            subject.process
-          end
-
-          it "logs an info message" do
-            expect(Rails.logger).to receive(:info).with(
-              "Incoming task has no current relevant delegation"
-            )
-            subject.process
-          end
-
           it "transitions the order state and marks the order item failed" do
             expect(order_state_transition).to receive(:process)
             subject.process
@@ -184,20 +154,6 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
             expect(progress_message.level).to eq("info")
             expect(progress_message.message).to match(/Task update/)
             expect(progress_message.order_item_id).to eq(order_item.id.to_s)
-          end
-
-          it "logs an info message" do
-            expect(Rails.logger).to receive(:info).with(
-              "Incoming task has no current relevant delegation"
-            )
-            subject.process
-          end
-
-          it "logs an info message" do
-            expect(Rails.logger).to receive(:info).with(
-              "Task update. State: completed. Status: updated. Context: #{payload_context}"
-            )
-            subject.process
           end
         end
       end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1265

There was a lot of code throughout the application to mark orders and
order_items completed/failed. This condenses the code down a few
instance methods on OrderItem. (`DRY`'s it up if you will)