### PR TITLE
Separate submit order authorization and data validation checks

### DIFF
--- a/app/controllers/api/v1/mixins/service_offering_mixin.rb
+++ b/app/controllers/api/v1/mixins/service_offering_mixin.rb
@@ -8,11 +8,8 @@ module Api
           service_offering_service = Catalog::ServiceOffering.new(@order).process
           if service_offering_service.archived
             @order.order_items.each do |order_item|
-              order_item.update!(:completed_at => DateTime.now, :state => "Failed")
-              order_item.update_message("error", archived_error_message)
+              order_item.mark_failed(archived_error_message)
             end
-
-            @order.update!(:state => "Failed")
 
             raise Catalog::ServiceOfferingArchived, archived_error_message
           end

--- a/app/controllers/api/v1/mixins/service_offering_mixin.rb
+++ b/app/controllers/api/v1/mixins/service_offering_mixin.rb
@@ -4,13 +4,22 @@ module Api
       module ServiceOfferingMixin
         private
 
-        def service_offering_check(order)
-          service_offering_service = Catalog::ServiceOffering.new(order).process
+        def service_offering_check
+          service_offering_service = Catalog::ServiceOffering.new(@order).process
           if service_offering_service.archived
-            raise Catalog::ServiceOfferingArchived, "Service offering for order #{order.id} has been archived and can no longer be ordered"
-          end
+            @order.order_items.each do |order_item|
+              order_item.update!(:completed_at => DateTime.now, :state => "Failed")
+              order_item.update_message("error", archived_error_message)
+            end
 
-          true
+            @order.update!(:state => "Failed")
+
+            raise Catalog::ServiceOfferingArchived, archived_error_message
+          end
+        end
+
+        def archived_error_message
+          "Order Failed: Service offering for order #{@order.id} has been archived and can no longer be ordered"
         end
       end
     end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class OrdersController < ApplicationController
       include Api::V1::Mixins::IndexMixin
+      include Api::V1::Mixins::ServiceOfferingMixin
 
       def index
         collection(Order.all)
@@ -24,10 +25,12 @@ module Api
       end
 
       def submit_order
-        order = Order.find(params.require(:order_id))
-        authorize(order)
+        @order = Order.find(params.require(:order_id))
+        authorize(@order)
 
-        order = Catalog::CreateRequestForAppliedInventories.new(order).process.order
+        service_offering_check
+
+        order = Catalog::CreateRequestForAppliedInventories.new(@order).process.order
         render :json => order
       end
 

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -68,7 +68,7 @@ class OrderItem < ApplicationRecord
   def mark_item(msg, level: "info", **opts)
     update!(**opts)
     update_message(level, msg) if msg
-    Rails.logger.send(level, "Updated OrderItem: #{id} with '#{opts[:state]}' state".tap { |log| log << " message: #{msg}" if msg })
+    Rails.logger.send(level, "Updated OrderItem: #{id} with '#{opts[:state]}' state".tap { |log| log << " message: #{msg}" }) if msg
 
     Catalog::OrderStateTransition.new(order).process
   end

--- a/app/policies/order_policy.rb
+++ b/app/policies/order_policy.rb
@@ -1,6 +1,4 @@
 class OrderPolicy < ApplicationPolicy
-  include Api::V1::Mixins::ServiceOfferingMixin
-
   def show?
     rbac_access.read_access_check
   end
@@ -10,6 +8,6 @@ class OrderPolicy < ApplicationPolicy
       rbac_access.resource_check('order', order_item.portfolio_item.portfolio_id, Portfolio)
     end
 
-    order_items_check.all? && service_offering_check(@record)
+    order_items_check.all?
   end
 end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -72,19 +72,29 @@ describe OrderItem do
   end
 
   describe "#mark_failed" do
-    let(:params) { {:external_url => "not.a.real/url"} }
-    before do
-      order_item.mark_failed(params)
-      order_item.reload
+    context "when there are no message parameters passed in" do
+      let(:params) { {:external_url => "not.a.real/url"} }
+
+      before do
+        order_item.mark_failed(params)
+        order_item.reload
+      end
+
+      it "marks the order and order item as failed" do
+        expect(order_item.state).to eq "Failed"
+        expect(order_item.order.state).to eq "Failed"
+        expect(order_item.completed_at).to be_truthy
+      end
+
+      it_behaves_like "#mark_item"
     end
 
-    it "marks the order and order item as failed" do
-      expect(order_item.state).to eq "Failed"
-      expect(order_item.order.state).to eq "Failed"
-      expect(order_item.completed_at).to be_truthy
+    context "when there are no message parameters passed in" do
+      it "does not log a message" do
+        expect(Rails.logger).not_to receive(:error)
+        order_item.mark_failed
+      end
     end
-
-    it_behaves_like "#mark_item"
   end
 
   describe "#mark_ordered" do

--- a/spec/policies/order_policy_spec.rb
+++ b/spec/policies/order_policy_spec.rb
@@ -23,7 +23,7 @@ describe OrderPolicy do
   end
 
   describe "#submit_order?" do
-    let(:service_offering) { instance_double(Catalog::ServiceOffering, :archived => archived) }
+    let(:service_offering) { instance_double(Catalog::ServiceOffering) }
 
     before do
       allow(Catalog::ServiceOffering).to receive(:new).with(order).and_return(service_offering)
@@ -32,24 +32,30 @@ describe OrderPolicy do
       allow(rbac_access).to receive(:resource_check).with('order', portfolio2.id, Portfolio).and_return(order_check2)
     end
 
+    context "when the resource check for ordering from all portfolios is false" do
+      let(:order_check) { false }
+      let(:order_check2) { false }
+
+      it "returns false" do
+        expect(subject.submit_order?).to eq(false)
+      end
+    end
+
     context "when the resource check for ordering from any portfolio is false" do
       let(:order_check) { false }
       let(:order_check2) { true }
 
-      context "when the service offering is archived" do
-        let(:archived) { true }
-
-        it "returns false" do
-          expect(subject.submit_order?).to eq(false)
-        end
+      it "returns false" do
+        expect(subject.submit_order?).to eq(false)
       end
+    end
 
-      context "when the service offering is not archived" do
-        let(:archived) { false }
+    context "when the resource check for ordering from any portfolio is false" do
+      let(:order_check) { true }
+      let(:order_check2) { false }
 
-        it "returns false" do
-          expect(subject.submit_order?).to eq(false)
-        end
+      it "returns false" do
+        expect(subject.submit_order?).to eq(false)
       end
     end
 
@@ -57,20 +63,8 @@ describe OrderPolicy do
       let(:order_check) { true }
       let(:order_check2) { true }
 
-      context "when the service offering is archived" do
-        let(:archived) { true }
-
-        it "raises an error" do
-          expect { subject.submit_order? }.to raise_error(Catalog::ServiceOfferingArchived, /has been archived/)
-        end
-      end
-
-      context "when the service offering is not archived" do
-        let(:archived) { false }
-
-        it "returns true" do
-          expect(subject.submit_order?).to eq(true)
-        end
+      it "returns true" do
+        expect(subject.submit_order?).to eq(true)
       end
     end
   end

--- a/spec/requests/api/v1.0/orders_spec.rb
+++ b/spec/requests/api/v1.0/orders_spec.rb
@@ -61,7 +61,7 @@ describe "v1.0 - OrderRequests", :type => [:request, :v1] do
       it_behaves_like "action that tests authorization", :submit_order?, Order
 
       it "logs the error", :subject_inside do
-        expect(Rails.logger).to receive(:error).with(/Service offering for order #{order.id} has been archived/)
+        expect(Rails.logger).to receive(:error).with(/Service offering for order #{order.id} has been archived/).twice
 
         subject
       end

--- a/spec/requests/api/v1.0/orders_spec.rb
+++ b/spec/requests/api/v1.0/orders_spec.rb
@@ -12,6 +12,7 @@ describe "v1.0 - OrderRequests", :type => [:request, :v1] do
 
   describe "#submit_order" do
     let(:service_offering_service) { instance_double("Catalog::ServiceOffering") }
+    subject { post "#{api_version}/orders/#{order.id}/submit_order", :headers => default_headers }
 
     before do
       allow(Catalog::ServiceOffering).to receive(:new).with(order).and_return(service_offering_service)
@@ -24,27 +25,26 @@ describe "v1.0 - OrderRequests", :type => [:request, :v1] do
       let(:archived) { false }
       let(:svc_object) { instance_double("Catalog::CreateRequestForAppliedInventories") }
 
-      before do
+      before do |example|
         allow(Catalog::CreateRequestForAppliedInventories).to receive(:new).with(order).and_return(svc_object)
         allow(svc_object).to receive(:process).and_return(svc_object)
         allow(svc_object).to receive(:order).and_return(order)
+        subject unless example.metadata[:subject_inside]
       end
 
-      it "creates a request for applied inventories" do
+      it_behaves_like "action that tests authorization", :submit_order?, Order
+
+      it "creates a request for applied inventories", :subject_inside do
         expect(svc_object).to receive(:process)
-        post "#{api_version}/orders/#{order.id}/submit_order", :headers => default_headers
+        subject
       end
 
       it "returns a 200" do
-        post "#{api_version}/orders/#{order.id}/submit_order", :headers => default_headers
-
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
       end
 
       it "returns the order in json format" do
-        post "#{api_version}/orders/#{order.id}/submit_order", :headers => default_headers
-
         parsed_body = JSON.parse(response.body)
         expect(parsed_body["state"]).to eq("Created")
         expect(parsed_body["id"]).to eq(order.id.to_s)
@@ -54,15 +54,28 @@ describe "v1.0 - OrderRequests", :type => [:request, :v1] do
     context "when the service offering has been archived" do
       let(:archived) { true }
 
-      it "logs the error" do
+      before do |example|
+        subject unless example.metadata[:subject_inside]
+      end
+
+      it_behaves_like "action that tests authorization", :submit_order?, Order
+
+      it "logs the error", :subject_inside do
         expect(Rails.logger).to receive(:error).with(/Service offering for order #{order.id} has been archived/)
 
-        post "#{api_version}/orders/#{order.id}/submit_order", :headers => default_headers
+        subject
+      end
+
+      it "creates progress messages for the order items" do
+        expect(ProgressMessage.last.message).to match(/has been archived/)
+      end
+
+      it "marks the order as failed" do
+        order.reload
+        expect(order.state).to eq("Failed")
       end
 
       it "returns a 400" do
-        post "#{api_version}/orders/#{order.id}/submit_order", :headers => default_headers
-
         expect(response).to have_http_status(:bad_request)
       end
     end
@@ -73,13 +86,15 @@ describe "v1.0 - OrderRequests", :type => [:request, :v1] do
       let!(:order_item) { create(:order_item, :order => order) }
       let!(:service_plan) { create(:service_plan, :portfolio_item => order.order_items.first.portfolio_item) }
 
-      before do
+      before do |example|
         allow(Catalog::SurveyCompare).to receive(:any_changed?).with(order.order_items.first.portfolio_item.service_plans).and_return(true)
+
+        subject unless example.metadata[:subject_inside]
       end
 
-      it "returns a 400" do
-        post "#{api_version}/orders/#{order.id}/submit_order", :headers => default_headers
+      it_behaves_like "action that tests authorization", :submit_order?, Order
 
+      it "returns a 400" do
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(400)
         expect(first_error_detail).to match(/Catalog::InvalidSurvey/)


### PR DESCRIPTION
As @mkanoor pointed out, separating the "authorization" logic versus the data validation logic is probably a good idea since the policy shouldn't "deny" access because of the state of the data.

So this PR moves out the service offering check from the policy and puts it directly into the controller. The logic of the check hasn't changed, but progress messages also get added to each order item. Each order item and the order itself are set to a `"Failed"` state when a service offering is archived, since the order can't be placed anymore.

@mkanoor @syncrou Please Review

https://projects.engineering.redhat.com/browse/SSP-1339