### PR TITLE
Add service_instance_ref field to OrderItem to populate external_url on failure

### DIFF
--- a/app/services/catalog/determine_task_relevancy.rb
+++ b/app/services/catalog/determine_task_relevancy.rb
@@ -30,6 +30,8 @@ module Catalog
       elsif @task.context.has_key_path?(:applied_inventories)
         Rails.logger.info("Creating approval request for task")
         Catalog::CreateApprovalRequest.new(@task).process
+      elsif order_item.service_instance_ref.present? && order_item.external_url.nil?
+        Catalog::UpdateOrderItem.new(@topic, @task).process
       else
         Rails.logger.info("Incoming task has no current relevant delegation")
       end

--- a/db/migrate/20200317202326_add_service_instance_ref_to_order_item.rb
+++ b/db/migrate/20200317202326_add_service_instance_ref_to_order_item.rb
@@ -1,0 +1,5 @@
+class AddServiceInstanceRefToOrderItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_items, :service_instance_ref, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_25_203814) do
+ActiveRecord::Schema.define(version: 2020_03_17_202326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2020_02_25_203814) do
     t.string "insights_request_id"
     t.datetime "discarded_at"
     t.jsonb "service_parameters_raw"
+    t.string "service_instance_ref"
     t.index ["discarded_at"], name: "index_order_items_on_discarded_at"
     t.index ["tenant_id"], name: "index_order_items_on_tenant_id"
   end

--- a/spec/services/catalog/determine_task_relevancy_spec.rb
+++ b/spec/services/catalog/determine_task_relevancy_spec.rb
@@ -156,6 +156,24 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
             expect(progress_message.order_item_id).to eq(order_item.id.to_s)
           end
         end
+
+        context "when the service_instance_ref is present on the order_item but the external_url is nil" do
+          let(:status) { "error" }
+          let(:update_order_item) { instance_double("Catalog::UpdateOrderItem") }
+
+          before do
+            order_item.update(:service_instance_ref => "1")
+            order_item.reload
+
+            allow(Catalog::UpdateOrderItem).to receive(:new).and_return(update_order_item)
+            allow(update_order_item).to receive(:process)
+          end
+
+          it "updates the order_item" do
+            expect(update_order_item).to receive(:process)
+            subject.process
+          end
+        end
       end
     end
   end

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -148,10 +148,10 @@ describe Catalog::UpdateOrderItem, :type => :service do
           expect(item.completed_at).to eq(fake_now)
         end
 
-        it "sets the external url" do
+        it "sets the service_instance_ref" do
           subject.process
           item.reload
-          expect(item.external_url).to eq("external url")
+          expect(item.service_instance_ref).to eq("321")
         end
 
         it "marks the item as failed" do
@@ -172,6 +172,23 @@ describe Catalog::UpdateOrderItem, :type => :service do
           subject.process
           order.reload
           expect(order.state).to eq("Failed")
+        end
+      end
+
+      context "when the item had been marked failed before and the task does not have a service instance id" do
+        let(:status) { "error" }
+        let(:state) { "bar" }
+        let(:task) { TopologicalInventoryApiClient::Task.new(:context => {}) }
+
+        before do
+          item.update(:service_instance_ref => "321")
+          item.reload
+        end
+
+        it "sets the external url" do
+          subject.process
+          item.reload
+          expect(item.external_url).to eq("external url")
         end
       end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1252

This is so we can track when an order fails, if a new task update message comes through which lacks the service_instance_id, we can use this to look up the external_url and set it so the frontend has it for the user.

EDIT:
Here are the steps minion goes through just for clarification.
- Product gets ordered through catalog
- Applied Inventories come through 
- Submit approvals
- Approvals come through
- submit order
- order fails, minion gets a task update with the `service_instance_id`, but the `service_instance` does **NOT** have the `external_url` yet
- _another_ task update comes through, without the `service_instance_id`, but it's just letting us know the url was collected. 

The new logic basically adds the handling for that second task update message. 

\# TODO:
- [x] migration 
- [x] logic to populate external url when service_instance_ref is there and external_url is blank
- [x] specs