### PR TITLE
Group ID should be in UUID format

### DIFF
--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 describe "v1.0 - Portfolios API", :type => [:request, :v1] do
   around do |example|
     bypass_rbac do
@@ -469,15 +470,16 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
   end
 
   describe "#share" do
+    let(:group_uuid) { SecureRandom.uuid }
     let(:params) do
-      {:group_uuids => ["group_uuids"], :permissions => ["read"]}
+      {:group_uuids => [group_uuid], :permissions => ["read"]}
     end
     let(:share_resource) { instance_double(Catalog::ShareResource) }
     let(:options) do
       {
         :object => portfolio,
         :permissions => ["read"],
-        :group_uuids => ["group_uuids"]
+        :group_uuids => [group_uuid]
       }
     end
 
@@ -507,15 +509,16 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
   end
 
   describe "#unshare" do
+    let(:group_uuid) { SecureRandom.uuid }
     let(:params) do
-      {:group_uuids => ["group_uuids"], :permissions => ["read"]}
+      {:group_uuids => [group_uuid], :permissions => ["read"]}
     end
     let(:unshare_resource) { instance_double(Catalog::UnshareResource) }
     let(:options) do
       {
         :object => portfolio,
         :permissions => ["read"],
-        :group_uuids => ["group_uuids"]
+        :group_uuids => [group_uuid]
       }
     end
 

--- a/spec/support/sharing_objects.rb
+++ b/spec/support/sharing_objects.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 RSpec.shared_context "sharing_objects" do
   let(:app_name) { 'catalog' }
   let!(:shared_portfolio) { create(:portfolio) }
@@ -10,8 +11,8 @@ RSpec.shared_context "sharing_objects" do
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:group_uuids) { [group1.uuid, group2.uuid, group3.uuid] }
-  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
-  let(:group2) { instance_double(RBACApiClient::GroupOut, :name => 'group2', :uuid => "12345") }
-  let(:group3) { instance_double(RBACApiClient::GroupOut, :name => 'group3', :uuid => "45665") }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => SecureRandom.uuid) }
+  let(:group2) { instance_double(RBACApiClient::GroupOut, :name => 'group2', :uuid => SecureRandom.uuid) }
+  let(:group3) { instance_double(RBACApiClient::GroupOut, :name => 'group3', :uuid => SecureRandom.uuid) }
   let(:groups) { [group1, group2, group3] }
 end


### PR DESCRIPTION
The Openapi Parser has been updated to support uuid format so
if the group uuid is not a valid UUID string it will fail validation. This PR fixes the spec that were not using the UUID format

https://github.com/ota42y/openapi_parser/pull/67
https://github.com/RedHatInsights/catalog-api/pull/605 had the openapi.json changes