### PR TITLE
Check if the portfolio/portfolio_item exist

### DIFF
--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -6,16 +6,16 @@ module Api
 
       def index
         if params[:portfolio_id]
-          Portfolio.find(params.require(:portfolio_id))
           scope = Portfolio.where(:id => params.require(:portfolio_id))
           relevant_portfolio = policy_scope(scope, :policy_scope_class => PortfolioPolicy::Scope).first
+          raise ActiveRecord::RecordNotFound unless relevant_portfolio
           relevant_tags = relevant_portfolio.try(:tags) || Tag.none
 
           collection(relevant_tags, :pre_authorized => true)
         elsif params[:portfolio_item_id]
-          PortfolioItem.find(params.require(:portfolio_item_id))
           scope = PortfolioItem.where(:id => params.require(:portfolio_item_id))
           relevant_portfolio_item = policy_scope(scope, :policy_scope_class => PortfolioItemPolicy::Scope).first
+          raise ActiveRecord::RecordNotFound unless relevant_portfolio_item
           relevant_tags = relevant_portfolio_item.try(:tags) || Tag.none
 
           collection(relevant_tags, :pre_authorized => true)

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -9,14 +9,14 @@ module Api
           scope = Portfolio.where(:id => params.require(:portfolio_id))
           relevant_portfolio = policy_scope(scope, :policy_scope_class => PortfolioPolicy::Scope).first
           raise ActiveRecord::RecordNotFound unless relevant_portfolio
-          relevant_tags = relevant_portfolio.try(:tags) || Tag.none
+          relevant_tags = relevant_portfolio.tags || Tag.none
 
           collection(relevant_tags, :pre_authorized => true)
         elsif params[:portfolio_item_id]
           scope = PortfolioItem.where(:id => params.require(:portfolio_item_id))
           relevant_portfolio_item = policy_scope(scope, :policy_scope_class => PortfolioItemPolicy::Scope).first
           raise ActiveRecord::RecordNotFound unless relevant_portfolio_item
-          relevant_tags = relevant_portfolio_item.try(:tags) || Tag.none
+          relevant_tags = relevant_portfolio_item.tags || Tag.none
 
           collection(relevant_tags, :pre_authorized => true)
         else

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -6,12 +6,14 @@ module Api
 
       def index
         if params[:portfolio_id]
+          Portfolio.find(params.require(:portfolio_id))
           scope = Portfolio.where(:id => params.require(:portfolio_id))
           relevant_portfolio = policy_scope(scope, :policy_scope_class => PortfolioPolicy::Scope).first
           relevant_tags = relevant_portfolio.try(:tags) || Tag.none
 
           collection(relevant_tags, :pre_authorized => true)
         elsif params[:portfolio_item_id]
+          PortfolioItem.find(params.require(:portfolio_item_id))
           scope = PortfolioItem.where(:id => params.require(:portfolio_item_id))
           relevant_portfolio_item = policy_scope(scope, :policy_scope_class => PortfolioItemPolicy::Scope).first
           relevant_tags = relevant_portfolio_item.try(:tags) || Tag.none

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -435,6 +435,14 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
         end
       end
 
+      context 'bad portfolio' do
+        let(:params) { {:name => tag_name} }
+        it 'returns 404' do
+          post "#{api_version}/portfolios/1515151515/tag", :headers => default_headers, :params => tag_params
+          expect(response).to have_http_status(404)
+        end
+      end
+
       let(:endpoint) { "tag" }
       it_behaves_like "bad_tags"
       it_behaves_like "good_tags"

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -9,6 +9,7 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
   let!(:portfolio_item)  { create(:portfolio_item, :portfolio => portfolio) }
   let!(:portfolio_items) { portfolio.portfolio_items << portfolio_item }
   let(:portfolio_id)     { portfolio.id }
+  let(:bad_portfolio_id) { portfolio.id + 1}
 
   describe "GET /portfolios/:portfolio_id" do
     before do
@@ -438,7 +439,7 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
       context 'bad portfolio' do
         let(:params) { {:name => tag_name} }
         it 'returns 404' do
-          post "#{api_version}/portfolios/1515151515/tag", :headers => default_headers, :params => tag_params
+          post "#{api_version}/portfolios/#{bad_portfolio_id}/tag", :headers => default_headers, :params => tag_params
           expect(response).to have_http_status(404)
         end
       end

--- a/spec/requests/api/v1.0/tags_spec.rb
+++ b/spec/requests/api/v1.0/tags_spec.rb
@@ -38,6 +38,12 @@ describe "v1.0 - Tagging API", :type => [:request, :v1] do
         expect(json["meta"]["count"]).to eq 1
         expect(json["data"].first["tag"]).to eq Tag.new(:name => "yay").to_tag_string
       end
+
+      it "returns not found when portfolio item missing" do
+        get "#{api_version}/portfolio_items/8888888/tags", :headers => default_headers
+
+        expect(response).to have_http_status(404)
+      end
     end
 
     context "when requesting all tags for a portfolio item you do not have access to" do
@@ -65,6 +71,12 @@ describe "v1.0 - Tagging API", :type => [:request, :v1] do
 
         expect(json["meta"]["count"]).to eq 1
         expect(json["data"].first["tag"]).to eq Tag.new(:name => "a_tag").to_tag_string
+      end
+
+      it "returns not found when portfolio is missing" do
+        get "#{api_version}/portfolios/8888888/tags", :headers => default_headers
+
+        expect(response).to have_http_status(404)
       end
     end
 

--- a/spec/requests/api/v1.0/tags_spec.rb
+++ b/spec/requests/api/v1.0/tags_spec.rb
@@ -4,6 +4,8 @@ describe "v1.0 - Tagging API", :type => [:request, :v1] do
 
   let!(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio) }
   let!(:portfolio) { create(:portfolio) }
+  let(:bad_portfolio_id) { portfolio.id + 1 }
+  let(:bad_portfolio_item_id) { portfolio_item.id + 1 }
 
   before do
     portfolio_item.tag_add("yay")
@@ -40,7 +42,7 @@ describe "v1.0 - Tagging API", :type => [:request, :v1] do
       end
 
       it "returns not found when portfolio item missing" do
-        get "#{api_version}/portfolio_items/8888888/tags", :headers => default_headers
+        get "#{api_version}/portfolio_items/#{bad_portfolio_item_id}/tags", :headers => default_headers
 
         expect(response).to have_http_status(404)
       end
@@ -51,11 +53,10 @@ describe "v1.0 - Tagging API", :type => [:request, :v1] do
         allow(rbac_aces).to receive(:ace_ids).with('read', Portfolio).and_return([])
       end
 
-      it "returns an empty array" do
+      it "returns 404" do
         get "#{api_version}/portfolio_items/#{portfolio_item.id}/tags", :headers => default_headers
 
-        expect(json["meta"]["count"]).to eq 0
-        expect(json["data"]).to eq([])
+        expect(response).to have_http_status(404)
       end
     end
   end
@@ -74,7 +75,7 @@ describe "v1.0 - Tagging API", :type => [:request, :v1] do
       end
 
       it "returns not found when portfolio is missing" do
-        get "#{api_version}/portfolios/8888888/tags", :headers => default_headers
+        get "#{api_version}/portfolios/#{bad_portfolio_id}/tags", :headers => default_headers
 
         expect(response).to have_http_status(404)
       end
@@ -85,11 +86,10 @@ describe "v1.0 - Tagging API", :type => [:request, :v1] do
         allow(rbac_aces).to receive(:ace_ids).with('read', Portfolio).and_return([])
       end
 
-      it "returns an empty array" do
+      it "returns a 404" do
         get "#{api_version}/portfolios/#{portfolio.id}/tags", :headers => default_headers
 
-        expect(json["meta"]["count"]).to eq 0
-        expect(json["data"]).to eq([])
+        expect(response).to have_http_status(404)
       end
     end
   end


### PR DESCRIPTION
Tags should be validated based on if there is access to the Portfolio/Portfolio Item.
https://projects.engineering.redhat.com/browse/SSP-1363

We were not checking if the object existed leading to the where clause returning an empty array with a success code (HTTP 200)