### PR TITLE
RBAC service has added support to list_groups by uuid

### DIFF
--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -10,7 +10,6 @@ module Catalog
 
     def process
       group_permissions = {}
-      uuids = []
       uuids = @object.access_control_entries.collect do |ace|
         group_permissions[ace.group_uuid] = ace.permissions.map(&:name)
         ace.group_uuid

--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -10,10 +10,13 @@ module Catalog
 
     def process
       group_permissions = {}
+      uuids = []
       @object.access_control_entries.each do |ace|
         group_permissions[ace.group_uuid] = ace.permissions.map(&:name)
+        uuids << ace.group_uuid
       end
 
+      group_names = fetch_group_names(uuids.uniq)
       @result = group_permissions.each_with_object([]) do |(uuid, permissions), memo|
         if group_names.key?(uuid)
           memo << { :group_name => group_names[uuid], :group_uuid => uuid, :permissions => permissions }
@@ -26,9 +29,10 @@ module Catalog
 
     private
 
-    def group_names
-      @group_names ||= Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
-        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :limit => MAX_GROUPS_LIMIT).each_with_object({}) do |group, memo|
+    def fetch_group_names(uuids)
+      opts = {:limit => MAX_GROUPS_LIMIT, :uuid => uuids}
+      Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, opts).each_with_object({}) do |group, memo|
           memo[group.uuid] = group.name
         end
       end

--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -11,9 +11,9 @@ module Catalog
     def process
       group_permissions = {}
       uuids = []
-      @object.access_control_entries.each do |ace|
+      uuids = @object.access_control_entries.collect do |ace|
         group_permissions[ace.group_uuid] = ace.permissions.map(&:name)
-        uuids << ace.group_uuid
+        ace.group_uuid
       end
 
       group_names = fetch_group_names(uuids.uniq)

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -313,7 +313,7 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
 
     context 'share_info' do
       include_context "sharing_objects"
-      let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT} }
+      let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => group_uuids} }
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -313,11 +313,15 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
 
     context 'share_info' do
       include_context "sharing_objects"
-      let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => group_uuids} }
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
           allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-          allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, pagination_options).and_return(groups)
+          allow(Insights::API::Common::RBAC::Service).to receive(:paginate) do |api_instance, method, options|
+            expect(method).to eq(:list_groups)
+            expect(options[:limit]).to eq(Catalog::ShareInfo::MAX_GROUPS_LIMIT)
+            expect(options[:uuid]).to match_array(group_uuids) if options.key?(:uuid)
+            groups
+          end
           ace1
           ace2
           ace3

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -1,6 +1,7 @@
 describe Catalog::ShareInfo, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:uuids) { [group1.uuid] }
   let(:permissions) { ['read', 'update'] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
@@ -11,8 +12,12 @@ describe Catalog::ShareInfo, :type => :service do
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, principal_options).and_return([group1])
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, pagination_options).and_return([group1])
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate) do |api_instance, method, options|
+      expect(method).to eq(:list_groups)
+      expect(options[:limit]).to eq(Catalog::ShareInfo::MAX_GROUPS_LIMIT)
+      expect(options[:uuid]).to match_array(uuids) if options.key?(:uuid)
+      [group1]
+    end
     create(:access_control_entry, :has_read_and_update_permission, :group_uuid => group1.uuid, :aceable => portfolio)
   end
 
@@ -33,7 +38,8 @@ describe Catalog::ShareInfo, :type => :service do
   end
 
   context "when only some group uuids exist" do
-    let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => [group1.uuid, 'non-existent']} }
+    let(:uuids) { [group1.uuid, 'non-existent'] }
+    let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => uuids} }
     before do
       create(:access_control_entry, :has_update_permission, :group_uuid => "non-existent", :aceable => portfolio)
     end

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -5,7 +5,7 @@ describe Catalog::ShareInfo, :type => :service do
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
-  let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT} }
+  let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => [group1.uuid]} }
 
   let(:params) { { :object => portfolio } }
 
@@ -33,6 +33,7 @@ describe Catalog::ShareInfo, :type => :service do
   end
 
   context "when only some group uuids exist" do
+    let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => [group1.uuid, 'non-existent']} }
     before do
       create(:access_control_entry, :has_update_permission, :group_uuid => "non-existent", :aceable => portfolio)
     end


### PR DESCRIPTION
https://github.com/RedHatInsights/insights-rbac/pull/243
This PR changes our list_groups call when called for share_info.
We only fetch the groups that we are interested in.
In our ACE table we store the group UUID we need the name from the
RBAC service, so the UI can display the name instead of ID.

Depends on PR https://github.com/RedHatInsights/insights-rbac-api-client-ruby/pull/8 (Merged)