### PR TITLE
Lock api-common to 3.7 until we adjust to the new rbac changes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 
 gem 'dhasher'
 gem 'discard', :git => 'https://github.com/jhawthorn/discard', :branch => 'master'
-gem 'insights-api-common', '~> 3.6'
+gem 'insights-api-common', '= 3.7'
 gem 'jbuilder', '~> 2.0'
 gem 'manageiq-loggers', '~> 0.2'
 gem 'manageiq-messaging', '~> 0.1.2', :require => false


### PR DESCRIPTION
@mkanoor Created this PR, if needed, to address expected issues with api-common 3.8 until we can adjust the catalog api code.

cc @eclarizio 