### PR TITLE
Add after_discard callback on Icon to handle nullifying restore_to reference

### DIFF
--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -10,4 +10,8 @@ class Icon < ApplicationRecord
   has_one :portfolio_item, :dependent => :destroy
 
   validates :image_id, :presence => true
+
+  after_discard do
+    restore_to.update!(:icon_id => nil)
+  end
 end

--- a/spec/requests/api/v1.1/icons_spec.rb
+++ b/spec/requests/api/v1.1/icons_spec.rb
@@ -25,6 +25,11 @@ describe "v1.1 - IconsRequests", :type => [:request, :v1x1] do
     it "deletes the icon" do
       expect { Icon.find(icon.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it "removes the reference on the restore_to object" do
+      icon.reload
+      expect(icon.restore_to.icon_id).to be_falsey
+    end
   end
 
   describe "#create" do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1324

Before this, when destroying an icon we were left with a dangling reference on the portfolio_item or portfolio which referred to the icon. This changes the behavior to nullify on destroy.