### PR TITLE
Update Icon portfolio/portfolio_item relations to nullify instead of destroy

### DIFF
--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -6,8 +6,8 @@ class Icon < ApplicationRecord
   belongs_to :image
   belongs_to :restore_to, :polymorphic => true
 
-  has_one :portfolio, :dependent => :destroy
-  has_one :portfolio_item, :dependent => :destroy
+  has_one :portfolio, :dependent => :nullify
+  has_one :portfolio_item, :dependent => :nullify
 
   validates :image_id, :presence => true
 


### PR DESCRIPTION
As discussed in #640 this is just a bug waiting to happen, if code were to be introduced that called `Icon#destroy` it would go through and destroy the Portfolio/PortfolioItem it belonged to. 

cc @syncrou @eclarizio 