### PR TITLE
Fail PortfolioItem copy process if Survey does not match Topology

### DIFF
--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -15,7 +15,13 @@ module Catalog
     end
 
     def process
-      @new_portfolio_item = make_copy
+      PortfolioItem.transaction do
+        @new_portfolio_item = make_copy
+      rescue StandardError => e
+        Rails.logger.error("Failed to copy Portfolio Item #{@portfolio_item.id}: #{e.message}")
+        raise
+      end
+
       @to_portfolio.portfolio_items << @new_portfolio_item
 
       self


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1384

Currently the copy process will throw an error, but the portfolio_item duplicate still gets created, leading to some weird behavior. This alleviates that by wrapping the copy process in a transaction.

cc @syncrou @eclarizio 