### PR TITLE
Default Portofolio and PortfolioItem to case-insensitive sorting

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -7,7 +7,7 @@ class Portfolio < ApplicationRecord
 
   acts_as_tenant(:tenant)
   acts_as_taggable_on
-  default_scope -> { kept }
+  default_scope -> { kept.order(Arel.sql('LOWER(portfolios.name)')) }
   belongs_to :icon, :optional => true
 
   validates :name, :presence => true, :uniqueness => { :scope => %i(tenant_id discarded_at) }

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -7,7 +7,7 @@ class PortfolioItem < ApplicationRecord
   acts_as_tenant(:tenant)
   acts_as_taggable_on
 
-  default_scope -> { kept }
+  default_scope -> { kept.order(Arel.sql('LOWER(portfolio_items.name)')) }
 
   belongs_to :icon, :optional => true
   has_many :service_plans, :dependent => :destroy

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -35,4 +35,12 @@ describe PortfolioItem do
       expect(item).to be_valid
     end
   end
+
+  context "default socpe" do
+    it "returns portfolio_items sorted by case insensitive names" do
+      %w[ab bb Bc Ad].each { |name| create(:portfolio_item, :name => name) }
+
+      expect(PortfolioItem.pluck(:name)).to eq(%w[ab Ad bb Bc])
+    end
+  end
 end

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -78,4 +78,13 @@ describe Portfolio do
       end
     end
   end
+
+  context "default socpe" do
+    it "returns portfolios sorted by case insensitive names" do
+      Portfolio.destroy_all
+      %w[aa bb Bc Ad].each { |name| create(:portfolio, :name => name) }
+
+      expect(Portfolio.pluck(:name)).to eq(%w[aa Ad bb Bc])
+    end
+  end
 end


### PR DESCRIPTION
Update the existing default scope for `Portfolio` and `PortfolioItem` to use case-insensitive sorting.