### PR TITLE
Memoize group_uuid RBAC call within UserContext

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -24,7 +24,7 @@ module Api
         def rbac_scope(relation, pre_authorized: false)
           return relation if pre_authorized
 
-          access_scopes = pundit_user.catalog_access.scopes(relation.model.table_name, 'read')
+          access_scopes = pundit_user.access.scopes(relation.model.table_name, 'read')
 
           if access_scopes.include?('admin')
             relation

--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -29,7 +29,7 @@ module Api
           if access_scopes.include?('admin')
             relation
           elsif access_scopes.include?('group')
-            ids = Catalog::RBAC::AccessControlEntries.new.ace_ids('read', relation.model)
+            ids = Catalog::RBAC::AccessControlEntries.new(pundit_user.group_uuids).ace_ids('read', relation.model)
             relation.where(:id => ids)
           elsif access_scopes.include?('user')
             relation.by_owner

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -48,10 +48,10 @@ class ApplicationPolicy
   end
 
   class Scope
-    attr_reader :user, :scope
+    attr_reader :user_context, :scope
 
-    def initialize(user, scope)
-      @user = user
+    def initialize(user_context, scope)
+      @user_context = user_context
       @scope = scope
     end
 

--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -48,7 +48,7 @@ class PortfolioItemPolicy < ApplicationPolicy
       if catalog_administrator?
         scope.all
       else
-        ids = Catalog::RBAC::AccessControlEntries.new.ace_ids('read', Portfolio)
+        ids = Catalog::RBAC::AccessControlEntries.new(@user_context.group_uuids).ace_ids('read', Portfolio)
         scope.where(:portfolio_id => ids)
       end
     end

--- a/app/policies/portfolio_policy.rb
+++ b/app/policies/portfolio_policy.rb
@@ -30,7 +30,7 @@ class PortfolioPolicy < ApplicationPolicy
       if catalog_administrator?
         scope.all
       else
-        ids = Catalog::RBAC::AccessControlEntries.new.ace_ids('read', Portfolio)
+        ids = Catalog::RBAC::AccessControlEntries.new(@user_context.group_uuids).ace_ids('read', Portfolio)
         scope.where(:id => ids)
       end
     end

--- a/app/policies/user_context.rb
+++ b/app/policies/user_context.rb
@@ -15,4 +15,10 @@ class UserContext
   def rbac_enabled?
     @rbac_enabled ||= Insights::API::Common::RBAC::Access.enabled?
   end
+
+  def group_uuids
+    @group_uuids ||= Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+      Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :scope => 'principal').collect(&:uuid)
+    end
+  end
 end

--- a/app/policies/user_context.rb
+++ b/app/policies/user_context.rb
@@ -1,15 +1,15 @@
 class UserContext
-  attr_reader :user, :params, :catalog_access
+  attr_reader :user, :params
 
   def initialize(user, params)
     @user = user
     @params = params
   end
 
-  def catalog_access
+  def access
     #TODO: Change argument to 'catalog,approval' once we can pass in a list
 
-    @catalog_access ||= Insights::API::Common::RBAC::Access.new("").process
+    @access ||= Insights::API::Common::RBAC::Access.new("").process
   end
 
   def rbac_enabled?

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -51,7 +51,7 @@ module Catalog
       end
 
       def access_id_list(verb, klass)
-        Catalog::RBAC::AccessControlEntries.new.ace_ids(verb, klass)
+        Catalog::RBAC::AccessControlEntries.new(@user_context.group_uuids).ace_ids(verb, klass)
       end
 
       def access_object

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -55,7 +55,7 @@ module Catalog
       end
 
       def access_object
-        @user_context.catalog_access
+        @user_context.access
       end
     end
   end

--- a/lib/catalog/rbac/access_control_entries.rb
+++ b/lib/catalog/rbac/access_control_entries.rb
@@ -1,10 +1,8 @@
 module Catalog
   module RBAC
     class AccessControlEntries
-      def initialize
-        @my_group_uuids = Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
-          Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :scope => 'principal').collect(&:uuid)
-        end
+      def initialize(group_uuids)
+        @group_uuids = group_uuids
       end
 
       def ace_ids(permission, klass)
@@ -13,7 +11,7 @@ module Catalog
             :name => permission
           },
           :access_control_entries => {
-            :group_uuid   => @my_group_uuids,
+            :group_uuid   => @group_uuids,
             :aceable_type => klass.to_s
           }
         ).collect { |ace| ace.aceable_id.to_s }

--- a/spec/lib/catalog/rbac/access_control_entries_spec.rb
+++ b/spec/lib/catalog/rbac/access_control_entries_spec.rb
@@ -1,30 +1,6 @@
-describe Catalog::RBAC::AccessControlEntries, :type => [:current_forwardable] do
-  around do |example|
-    with_modified_env(:RBAC_URL => "http://rbac.example.com") do
-      example.call
-    end
-  end
-
+describe Catalog::RBAC::AccessControlEntries do
   describe "#ace_ids" do
-    let(:group_pagination) do
-      RBACApiClient::GroupPagination.new(
-        :meta  => pagination_meta,
-        :links => pagination_links,
-        :data  => group_list
-      )
-    end
-    let(:pagination_meta) { RBACApiClient::PaginationMeta.new(:count => 1) }
-    let(:pagination_links) { RBACApiClient::PaginationLinks.new }
-    let(:group_list) { [RBACApiClient::GroupOut.new(:name => "group", :uuid => "123-456")] }
-
-    before do
-      stub_request(:get, "http://rbac.example.com/api/rbac/v1/groups/?limit=10&offset=0&scope=principal")
-        .to_return(
-          :status  => 200,
-          :body    => group_pagination.to_json,
-          :headers => default_headers
-        )
-    end
+    subject { described_class.new(["123-456"]) }
 
     context "when access control entries exist that match the given parameters" do
       before do

--- a/spec/lib/catalog/rbac/access_spec.rb
+++ b/spec/lib/catalog/rbac/access_spec.rb
@@ -17,7 +17,7 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
 
   before do
     allow(Insights::API::Common::RBAC::Access).to receive(:enabled?).and_return(rbac_enabled)
-    allow(user_context).to receive(:catalog_access).and_return(catalog_access)
+    allow(user_context).to receive(:access).and_return(catalog_access)
   end
 
   shared_examples_for "permission checking" do |method, arguments, verb|

--- a/spec/policies/portfolio_item_policy_scope_spec.rb
+++ b/spec/policies/portfolio_item_policy_scope_spec.rb
@@ -1,8 +1,8 @@
 describe PortfolioItemPolicy::Scope, :type => [:service] do
-  let(:user) { nil }
+  let(:user_context) { instance_double(UserContext, :group_uuids => ["123-456"]) }
   let(:scope) { PortfolioItem }
   let(:rbac_access) { instance_double(Catalog::RBAC::Access) }
-  let(:subject) { described_class.new(user, scope) }
+  let(:subject) { described_class.new(user_context, scope) }
 
   describe "#resolve" do
     let(:portfolio) { create(:portfolio) }
@@ -17,7 +17,7 @@ describe PortfolioItemPolicy::Scope, :type => [:service] do
 
     before do
       allow(Insights::API::Common::RBAC::Roles).to receive(:assigned_role?).with("Catalog Administrator").and_return(admin?)
-      allow(Catalog::RBAC::Access).to receive(:new).with(user, portfolio_item1).and_return(rbac_access)
+      allow(Catalog::RBAC::Access).to receive(:new).with(user_context, portfolio_item1).and_return(rbac_access)
     end
 
     context "when the user is a catalog administrator" do
@@ -30,25 +30,15 @@ describe PortfolioItemPolicy::Scope, :type => [:service] do
 
     context "when the user is not a catalog administrator" do
       let(:admin?) { false }
-
-      let(:rbac_paginated_response) do
-        RBACApiClient::GroupPagination.new(
-          :meta => RBACApiClient::PaginationMeta.new(:count => 1),
-          :data => [RBACApiClient::GroupOut.new(:uuid => "123-456")]
-        )
-      end
+      let(:rbac_aces) { instance_double(Catalog::RBAC::AccessControlEntries) }
 
       before do
-        stub_request(:get, "http://rbac/api/rbac/v1/groups/?limit=10&offset=0&scope=principal").to_return(
-          :status  => 200,
-          :body    => rbac_paginated_response.to_json,
-          :headers => default_headers
-        )
+        allow(Catalog::RBAC::AccessControlEntries).to receive(:new).with(["123-456"]).and_return(rbac_aces)
       end
 
       context "when the access control entries exist" do
         before do
-          create(:access_control_entry, :has_read_permission, :aceable_id => portfolio.id)
+          allow(rbac_aces).to receive(:ace_ids).with('read', Portfolio).and_return([portfolio.id])
         end
 
         it "returns the set limited by the correct portfolio ids" do
@@ -57,6 +47,10 @@ describe PortfolioItemPolicy::Scope, :type => [:service] do
       end
 
       context "when access control entries do not exist" do
+        before do
+          allow(rbac_aces).to receive(:ace_ids).with('read', Portfolio).and_return([])
+        end
+
         it "returns an empty set" do
           expect(subject.resolve).to eq([])
         end

--- a/spec/policies/user_context_spec.rb
+++ b/spec/policies/user_context_spec.rb
@@ -1,0 +1,52 @@
+describe UserContext, [:type => :current_forwardble] do
+  let(:current_request) { Insights::API::Common::Request.new(default_request) }
+  subject do
+    described_class.new(current_request, "params")
+  end
+
+  describe "#catalog_access" do
+    let(:insights_access) { instance_double(Insights::API::Common::RBAC::Access) }
+
+    before do
+      allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(insights_access)
+      allow(insights_access).to receive(:process).and_return(insights_access)
+    end
+
+    it "fetches a memoized access list from RBAC" do
+      expect(Insights::API::Common::RBAC::Access).to receive(:new).with("").once
+      expect(insights_access).to receive(:process).once
+      subject.catalog_access
+      subject.catalog_access
+    end
+  end
+
+  describe "#rbac_enabled?" do
+    before do
+      allow(Insights::API::Common::RBAC::Access).to receive(:enabled?).and_return(true)
+    end
+
+    it "fetches a memoized enabled flag from RBAC" do
+      expect(Insights::API::Common::RBAC::Access).to receive(:enabled?).once
+      subject.rbac_enabled?
+      expect(subject.rbac_enabled?).to be(true)
+    end
+  end
+
+  describe "#group_uuids" do
+    let(:rbac_api) { instance_double(Insights::API::Common::RBAC::Service) }
+
+    before do
+      allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::GroupApi).and_yield(rbac_api)
+      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(rbac_api, :list_groups, :scope => 'principal')
+        .and_return(group_list)
+    end
+
+    let(:group_list) { [RBACApiClient::GroupOut.new(:name => "group", :uuid => "123-456")] }
+
+    it "returns a memoized group uuid list" do
+      expect(Insights::API::Common::RBAC::Service).to receive(:call).once
+      subject.group_uuids
+      expect(subject.group_uuids).to eq(["123-456"])
+    end
+  end
+end

--- a/spec/policies/user_context_spec.rb
+++ b/spec/policies/user_context_spec.rb
@@ -4,7 +4,7 @@ describe UserContext, [:type => :current_forwardble] do
     described_class.new(current_request, "params")
   end
 
-  describe "#catalog_access" do
+  describe "#access" do
     let(:insights_access) { instance_double(Insights::API::Common::RBAC::Access) }
 
     before do
@@ -15,8 +15,7 @@ describe UserContext, [:type => :current_forwardble] do
     it "fetches a memoized access list from RBAC" do
       expect(Insights::API::Common::RBAC::Access).to receive(:new).with("").once
       expect(insights_access).to receive(:process).once
-      subject.catalog_access
-      subject.catalog_access
+      2.times { subject.access }
     end
   end
 

--- a/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
@@ -4,10 +4,16 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
   let!(:portfolio_item2) { create(:portfolio_item) }
   let(:rbac_access) { instance_double(Catalog::RBAC::Access) }
   let(:access_control_entries) { instance_double(Catalog::RBAC::AccessControlEntries) }
+  let(:rbac_api) { instance_double(Insights::API::Common::RBAC::Service) }
+  let(:group_list) { [RBACApiClient::GroupOut.new(:name => "group", :uuid => "123-456")] }
 
   before do
+    allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::GroupApi).and_yield(rbac_api)
+    allow(Insights::API::Common::RBAC::Service).to receive(:paginate)
+      .with(rbac_api, :list_groups, :scope => 'principal')
+      .and_return(group_list)
     allow(Catalog::RBAC::Access).to receive(:new).and_return(rbac_access)
-    allow(Catalog::RBAC::AccessControlEntries).to receive(:new).and_return(access_control_entries)
+    allow(Catalog::RBAC::AccessControlEntries).to receive(:new).with(["123-456"]).and_return(access_control_entries)
     allow(Catalog::RBAC::Role).to receive(:catalog_administrator?).and_return(false)
     allow(rbac_access).to receive(:permission_check).with('read', Portfolio).and_return(true)
     allow(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)


### PR DESCRIPTION
This PR cuts down on another RBAC call that would otherwise likely to be replicated every time we needed to check ACE entries.

Also some cleanup of the `@user` variable to `@user_context` so it's more apparent that it is not an actual user object. I meant to include the `user_context_spec.rb` in the last user capabilities PR but I apparently missed it because it was a new file, so it's included here.