### PR TITLE
Add `sort_by` option from common gem to index operations

### DIFF
--- a/app/controllers/api/v1x1.rb
+++ b/app/controllers/api/v1x1.rb
@@ -18,5 +18,7 @@ module Api
     class SettingsController                  < Api::V1x0::SettingsController; end
     class TagsController                      < Api::V1x0::TagsController; end
     class TenantsController                   < Api::V1x0::TenantsController; end
+
+    extend_each_subclass Api::V1x1::Mixins::IndexMixin
   end
 end

--- a/app/controllers/api/v1x1/icons_controller.rb
+++ b/app/controllers/api/v1x1/icons_controller.rb
@@ -2,7 +2,7 @@ require 'api/v1x1/catalog'
 module Api
   module V1x1
     class IconsController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
+      include Api::V1x1::Mixins::IndexMixin
 
       # Due to the fact form-data is getting uploaded and isn't supported by openapi_parser
       skip_before_action :validate_request, :only => %i[create]

--- a/app/controllers/api/v1x1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x1/mixins/index_mixin.rb
@@ -1,0 +1,55 @@
+module Api
+  module V1x1
+    module Mixins
+      module IndexMixin
+        def scoped(relation, pre_authorized)
+          relation = rbac_scope(relation, :pre_authorized => pre_authorized) if Insights::API::Common::RBAC::Access.enabled?
+          if relation.model.respond_to?(:taggable?) && relation.model.taggable?
+            ref_schema = {relation.model.tagging_relation_name => :tag}
+
+            relation = relation.includes(ref_schema).references(ref_schema)
+          end
+          relation
+        end
+
+        def collection(base_query, pre_authorized: false)
+          render :json => Insights::API::Common::PaginatedResponse.new(
+            :base_query => filtered(scoped(base_query, pre_authorized)),
+            :request    => request,
+            :limit      => pagination_limit,
+            :offset     => pagination_offset,
+            :sort_by    => query_sort_by
+          ).response
+        end
+
+        def rbac_scope(relation, pre_authorized: false)
+          return relation if pre_authorized
+
+          policy_scope(relation)
+        end
+
+        def filtered(base_query)
+          Insights::API::Common::Filter.new(base_query, params[:filter], api_doc_definition).apply
+        end
+
+        private
+
+        def api_doc_definition
+          @api_doc_definition ||= Api::Docs[api_version].definitions[model_name]
+        end
+
+        def api_version
+          @api_version ||= name.split("::")[1].downcase.delete("v").sub("x", ".")
+        end
+
+        def model_name
+          @model_name ||= controller_name.classify
+        end
+
+        def name
+          self.class.to_s
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/extend_module.rb
+++ b/config/initializers/extend_module.rb
@@ -1,0 +1,7 @@
+class Module
+  def extend_each_subclass(inklude)
+    constants.each do |sym|
+      const_get(sym).send(:include, inklude)
+    end
+  end
+end

--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -103,6 +103,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -303,6 +306,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -604,6 +610,9 @@
             "$ref": "#/components/parameters/QueryFilter"
           },
           {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -834,6 +843,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -1160,6 +1172,9 @@
             "$ref": "#/components/parameters/QueryFilter"
           },
           {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -1297,6 +1312,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -1429,6 +1447,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -1675,6 +1696,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -1830,6 +1854,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -1875,6 +1902,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -2662,6 +2692,15 @@
         "explode": true,
         "schema": {
           "type": "object"
+        }
+      },
+      "QuerySortBy": {
+        "in": "query",
+        "name": "sort_by",
+        "description": "Field to sort collection by.",
+        "required": false,
+        "schema": {
+          "type": "string"
         }
       }
     },

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -79,6 +79,24 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
         expect(json['data'].first['metadata']).to have_key('user_capabilities')
       end
     end
+
+    context "with sort_by" do
+      let!(:new_portfolio) { create(:portfolio, :owner => "a very new owner") }
+
+      it "sorts when specified" do
+        get "#{api_version}/portfolios?sort_by=owner", :headers => default_headers
+
+        expect(json["meta"]["count"]).to eq 2
+        expect(json["data"].first["owner"]).to eq new_portfolio.owner
+      end
+
+      it "does not sort when specified" do
+        get "#{api_version}/portfolios", :headers => default_headers
+
+        expect(json["meta"]["count"]).to eq 2
+        expect(json["data"].first["owner"]).not_to eq new_portfolio.owner
+      end
+    end
   end
 
   describe "POST /portfolios #create" do


### PR DESCRIPTION
Just adds the operation to tack `sort_by=field` to sort by any field on the object.

cc @syncrou @gmcculloug 