### PR TITLE
The pundit_user object needs to be cached

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,6 @@ class ApplicationController < ActionController::API
   end
 
   def pundit_user
-    UserContext.new(Insights::API::Common::Request.current!, params)
+    @user ||= UserContext.new(Insights::API::Common::Request.current!, params)
   end
 end


### PR DESCRIPTION
Within a single request the policy_scope method defined in the
pundit gem can get called multiple times. We need to cache the
user object so we dont end up generating a new one everytime
the policy_scope gets called. We discovered this while testing the
approval API.
https://github.com/varvet/pundit/blob/6be4621538f916124f76b57460c8cc46597a3b6a/lib/pundit.rb#L253
Approval API Change
https://github.com/RedHatInsights/approval-api/blob/0aa4af67cd215c4b882239ce1580b3bf17026d6a/app/controllers/application_controller.rb#L46