### PR TITLE
Fix incorrect policy being used for PortfolioItemsController#create

### DIFF
--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -16,7 +16,7 @@ module Api
 
       def create
         portfolio = Portfolio.find(params.require(:portfolio_id))
-        authorize(portfolio)
+        authorize(portfolio, :policy_class => PortfolioItemPolicy)
 
         so = ServiceOffering::AddToPortfolioItem.new(writeable_params_for_create)
         render :json => so.process.item

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -198,7 +198,7 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
         subject unless example.metadata[:subject_inside]
       end
 
-      it_behaves_like "action that tests authorization", :create?, Portfolio
+      it_behaves_like "action that tests authorization", :create?, PortfolioItem
 
       it "returns not found when topology doesn't have the service_offering_ref" do
         expect(response).to have_http_status(:service_unavailable)
@@ -213,7 +213,7 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
         subject unless example.metadata[:subject_inside]
       end
 
-      it_behaves_like "action that tests authorization", :create?, Portfolio
+      it_behaves_like "action that tests authorization", :create?, PortfolioItem
 
       it "returns the new portfolio item when topology has the service_offering_ref" do
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
By passing in the `portfolio` to check against, pundit automatically assumes that the policy to use is the `PortfolioPolicy`, which in this case is incorrect. So we have to manually pass in the policy class

This should fix https://projects.engineering.redhat.com/browse/SSP-1412

@mkanoor @syncrou Please Review.