### PR TITLE
[Stable] Store UserContext object on the current thread to reduce RBAC calls

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,24 +1,10 @@
 require "acts_as_tenant"
 
 class ApplicationRecord < ActiveRecord::Base
-  include Pundit
-
   self.abstract_class = true
 
   require 'act_as_taggable_on'
   ActiveSupport.on_load(:active_record) do
     extend ActAsTaggableOn
-  end
-
-  private
-
-  def user_capabilities
-    return nil if user_context.nil?
-
-    PolicyFinder.new(self).policy.new(user_context, self).user_capabilities
-  end
-
-  def user_context
-    Thread.current[:user]
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,10 +1,24 @@
 require "acts_as_tenant"
 
 class ApplicationRecord < ActiveRecord::Base
+  include Pundit
+
   self.abstract_class = true
 
   require 'act_as_taggable_on'
   ActiveSupport.on_load(:active_record) do
     extend ActAsTaggableOn
+  end
+
+  private
+
+  def user_capabilities
+    return nil if user_context.nil?
+
+    PolicyFinder.new(self).policy.new(user_context, self).user_capabilities
+  end
+
+  def user_context
+    Thread.current[:user]
   end
 end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -3,6 +3,8 @@ class Portfolio < ApplicationRecord
   include Discard::Model
   include Catalog::DiscardRestore
   include Aceable
+  include Catalog::UserCapabilities
+
   destroy_dependencies :portfolio_items
 
   acts_as_tenant(:tenant)
@@ -18,8 +20,6 @@ class Portfolio < ApplicationRecord
   def add_portfolio_item(portfolio_item)
     portfolio_items << portfolio_item
   end
-
-  attribute :metadata, ActiveRecord::Type::Json.new
 
   def metadata
     {:user_capabilities => user_capabilities,

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -22,9 +22,16 @@ class Portfolio < ApplicationRecord
   attribute :metadata, ActiveRecord::Type::Json.new
 
   def metadata
-    user = UserContext.new(Insights::API::Common::Request.current!, nil)
-
-    {:user_capabilities => PortfolioPolicy.new(user, self).user_capabilities,
+    {:user_capabilities => user_capabilities,
      :shared            => self.access_control_entries.any?}
+  end
+
+  private
+
+  def user_capabilities
+    return nil if Thread.current[:user].nil?
+
+    user = Thread.current[:user]
+    PortfolioPolicy.new(user, self).user_capabilities
   end
 end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -25,13 +25,4 @@ class Portfolio < ApplicationRecord
     {:user_capabilities => user_capabilities,
      :shared            => self.access_control_entries.any?}
   end
-
-  private
-
-  def user_capabilities
-    return nil if Thread.current[:user].nil?
-
-    user = Thread.current[:user]
-    PortfolioPolicy.new(user, self).user_capabilities
-  end
 end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -20,13 +20,4 @@ class PortfolioItem < ApplicationRecord
   def metadata
     {:user_capabilities => user_capabilities}
   end
-
-  private
-
-  def user_capabilities
-    return nil if Thread.current[:user].nil?
-
-    user = Thread.current[:user]
-    PortfolioItemPolicy.new(user, self).user_capabilities
-  end
 end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -18,8 +18,15 @@ class PortfolioItem < ApplicationRecord
   attribute :metadata, ActiveRecord::Type::Json.new
 
   def metadata
-    user = UserContext.new(Insights::API::Common::Request.current!, nil)
+    {:user_capabilities => user_capabilities}
+  end
 
-    {:user_capabilities => PortfolioItemPolicy.new(user, self).user_capabilities}
+  private
+
+  def user_capabilities
+    return nil if Thread.current[:user].nil?
+
+    user = Thread.current[:user]
+    PortfolioItemPolicy.new(user, self).user_capabilities
   end
 end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -2,6 +2,7 @@ class PortfolioItem < ApplicationRecord
   include OwnerField
   include Discard::Model
   include Catalog::DiscardRestore
+  include Catalog::UserCapabilities
   destroy_dependencies :service_plans
 
   acts_as_tenant(:tenant)
@@ -14,8 +15,6 @@ class PortfolioItem < ApplicationRecord
   belongs_to :portfolio
   validates :service_offering_ref, :name, :presence => true
   validates :favorite_before_type_cast, :format => { :with => /\A(true|false)\z/i }, :allow_blank => true
-
-  attribute :metadata, ActiveRecord::Type::Json.new
 
   def metadata
     {:user_capabilities => user_capabilities}

--- a/app/services/catalog/user_capabilities.rb
+++ b/app/services/catalog/user_capabilities.rb
@@ -1,0 +1,22 @@
+module Catalog
+  module UserCapabilities
+    include Pundit
+    extend ActiveSupport::Concern
+
+    included do
+      attribute :metadata, ActiveRecord::Type::Json.new
+    end
+
+    private
+
+    def user_capabilities
+      return nil if user_context.nil?
+
+      "#{self.class}Policy".constantize.new(user_context, self).user_capabilities
+    end
+
+    def user_context
+      Thread.current[:user]
+    end
+  end
+end


### PR DESCRIPTION
Stable branch PR of https://github.com/RedHatInsights/catalog-api/pull/655

Turns out memoizing the pundit_user didn't do as much as we wanted it to because the user capabilities metadata was just instantiating a new UserContext anyway. So this PR shifts to storing the UserContext in the current Thread, which then gets nil'd out at the end of every request, otherwise multiple users wouldn't work at all.

Edit: Forgot to mention, when testing with a master pod, requests for the portfolio page were taking ~2 seconds, after this change, it got cut by a factor of 10 to just 200ms. 👍