### PR TITLE
Add extra metadata for Portfolio

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -22,7 +22,9 @@ class Portfolio < ApplicationRecord
   end
 
   def metadata
-    {:user_capabilities => user_capabilities,
-     :shared            => self.access_control_entries.any?}
+    {:user_capabilities        => user_capabilities,
+     :groups_shared_count      => self.access_control_entries.collect(&:group_uuid).uniq.count,
+     :approval_processes_count => self.tags.select { |t| t.name == "workflows" && t.namespace == "approval"}.count,
+     :product_count            => self.portfolio_items.count}
   end
 end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -23,8 +23,8 @@ class Portfolio < ApplicationRecord
 
   def metadata
     {:user_capabilities        => user_capabilities,
-     :groups_shared_count      => self.access_control_entries.collect(&:group_uuid).uniq.count,
-     :approval_processes_count => self.tags.select { |t| t.name == "workflows" && t.namespace == "approval"}.count,
+     :groups_shared_count      => access_control_entries.select(:group_uuid).distinct.count,
+     :approval_processes_count => tags.where(:name => "workflows", :namespace => "approval").count,
      :product_count            => self.portfolio_items.count}
   end
 end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -22,9 +22,18 @@ class Portfolio < ApplicationRecord
   end
 
   def metadata
-    {:user_capabilities        => user_capabilities,
-     :groups_shared_count      => access_control_entries.select(:group_uuid).distinct.count,
+    x = {:user_capabilities        => user_capabilities}
+    if ENV['IGNORE_EXTRAS'] == 'true'
+      x
+    else
+      x.merge(extras)
+    end
+  end
+
+  def extras
+    {:groups_shared_count      => access_control_entries.select(:group_uuid).distinct.count,
      :approval_processes_count => tags.where(:name => "workflows", :namespace => "approval").count,
      :product_count            => self.portfolio_items.count}
   end
+
 end

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -16,6 +16,9 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
   describe "GET /portfolios/:portfolio_id #show" do
     before do
       create(:access_control_entry, :has_read_permission, :aceable_id => portfolio_id, :group_uuid => "456-123")
+      create(:access_control_entry, :has_update_permission, :aceable_id => portfolio_id, :group_uuid => "456-123")
+      portfolio.tag_add('workflows', :namespace => 'approval', :value => '1')
+      portfolio.tag_add('workflows', :namespace => 'approval', :value => '2')
       get "#{api_version}/portfolios/#{portfolio_id}", :headers => default_headers
     end
 
@@ -43,8 +46,16 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
         )
       end
 
-      it "returns shared status" do
-        expect(json['metadata']['shared']).to be_truthy
+      it "returns shared group count" do
+        expect(json['metadata']['groups_shared_count']).to eq(1)
+      end
+
+      it "check approval_processes_count" do
+        expect(json['metadata']['approval_processes_count']).to eq(2)
+      end
+
+      it "check product_count" do
+        expect(json['metadata']['product_count']).to eq(1)
       end
     end
 


### PR DESCRIPTION
 - Number of groups the Portfolio is shared with
 - Number of products
 - Number of approvals

This can be used by the UI to display extra information about the Portfolio in the tile.

<img width="489" alt="Screen Shot 2020-04-04 at 8 51 22 PM" src="https://user-images.githubusercontent.com/6452699/78464383-e79a5c80-76b6-11ea-8371-73c7b1a64cef.png">
