### PR TITLE
[WIP] Add Portfolio statistics data to metadata API results

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -7,6 +7,9 @@ class Portfolio < ApplicationRecord
 
   destroy_dependencies :portfolio_items
 
+  before_save { self.statistics = stats }
+  after_undiscard { update_statistics }
+
   acts_as_tenant(:tenant)
   acts_as_taggable_on
   default_scope -> { kept.order(Arel.sql('LOWER(portfolios.name)')) }
@@ -22,7 +25,25 @@ class Portfolio < ApplicationRecord
   end
 
   def metadata
-    {:user_capabilities => user_capabilities,
-     :shared            => self.access_control_entries.any?}
+    {:user_capabilities => user_capabilities}.tap do |data|
+      data[:statistics] = statistics
+    end
+  end
+
+  def update_statistics
+    current_stats = stats
+    return if current_stats.eql?(statistics)
+
+    update(:statistics => current_stats)
+  end
+
+  private
+
+  def stats
+    {
+      'approval_processes' => tags.where(:name => 'workflows', :namespace => 'approval').count,
+      'portfolio_items'    => portfolio_items.count,
+      'shared_groups'      => access_control_entries.select(:group_uuid).distinct.count
+    }
   end
 end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -10,6 +10,11 @@ class PortfolioItem < ApplicationRecord
 
   default_scope -> { kept.order(Arel.sql('LOWER(portfolio_items.name)')) }
 
+  after_create    { update_portfolio_stats }
+  after_discard   { update_portfolio_stats }
+  after_undiscard { update_portfolio_stats }
+  after_destroy   { update_portfolio_stats }
+
   belongs_to :icon, :optional => true
   has_many :service_plans, :dependent => :destroy
   belongs_to :portfolio
@@ -18,5 +23,11 @@ class PortfolioItem < ApplicationRecord
 
   def metadata
     {:user_capabilities => user_capabilities}
+  end
+
+  private
+
+  def update_portfolio_stats
+    portfolio&.update_statistics
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,6 +9,9 @@ class Tag < ApplicationRecord
   has_many :portfolio_item_tags, :dependent => :destroy
   has_many :portfolio_items, :through => :portfolio_item_tags
 
+  after_create    { update_portfolio_stats }
+  after_destroy   { update_portfolio_stats }
+
   def to_tag_string
     "/#{namespace}/#{name}".tap { |string| string << "=#{value}" if value.present? }
   end
@@ -32,5 +35,11 @@ class Tag < ApplicationRecord
 
     # FIXME: Doesn't exist on topo - but blows up when there are nil values in the db.
     tag_params.transform_values { |e| e || "" }
+  end
+
+  private
+
+  def update_portfolio_stats
+    portfolios.each(&:update_statistics)
   end
 end

--- a/app/services/catalog/share_resource.rb
+++ b/app/services/catalog/share_resource.rb
@@ -14,6 +14,9 @@ module Catalog
                                                    :aceable    => @object)
         ace.add_new_permissions(@permissions)
       end
+
+      @object&.update_statistics
+
       self
     end
   end

--- a/app/services/catalog/unshare_resource.rb
+++ b/app/services/catalog/unshare_resource.rb
@@ -16,6 +16,8 @@ module Catalog
         .where(:permission_id => permission_ids, :access_control_entry_id => access_control_entry_id)
         .destroy_all
 
+      @object&.update_statistics
+
       self
     end
   end

--- a/db/migrate/20200406122000_add_statistics_to_portfolio.rb
+++ b/db/migrate/20200406122000_add_statistics_to_portfolio.rb
@@ -1,0 +1,11 @@
+class AddStatisticsToPortfolio < ActiveRecord::Migration[5.2]
+  def change
+    add_column :portfolios, :statistics, :jsonb, :default => {}
+
+    reversible do |change|
+      change.up do
+        Portfolio.all.each(&:update_statistics)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_17_202326) do
+ActiveRecord::Schema.define(version: 2020_04_06_122000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2020_03_17_202326) do
     t.datetime "discarded_at"
     t.string "owner"
     t.bigint "icon_id"
+    t.jsonb "statistics", default: {}
     t.index ["discarded_at"], name: "index_portfolios_on_discarded_at"
     t.index ["tenant_id"], name: "index_portfolios_on_tenant_id"
   end

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -16,6 +16,7 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
   describe "GET /portfolios/:portfolio_id #show" do
     before do
       create(:access_control_entry, :has_read_permission, :aceable_id => portfolio_id, :group_uuid => "456-123")
+      portfolio.update_statistics
       get "#{api_version}/portfolios/#{portfolio_id}", :headers => default_headers
     end
 
@@ -44,7 +45,7 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
       end
 
       it "returns shared status" do
-        expect(json['metadata']['shared']).to be_truthy
+        expect(json.dig('metadata', 'statistics', 'shared_groups')).to eql(1)
       end
     end
 


### PR DESCRIPTION
This PR is likely replaced by #669

This solution requires objects (PortfolioItems, Tags) and sharing operations to call the Portfolio `update_statistics` method when actions are known to cause counts to change.