### PR TITLE
Only destroy join table entries instead of the AccessControlEntry

### DIFF
--- a/app/services/catalog/unshare_resource.rb
+++ b/app/services/catalog/unshare_resource.rb
@@ -9,12 +9,13 @@ module Catalog
     def process
       Insights::API::Common::RBAC::ValidateGroups.new(@group_uuids).process
 
-      AccessControlEntry
-        .joins(:permissions)
-        .where(:group_uuid  => @group_uuids,
-               :aceable     => @object,
-               :permissions => {:name => @permissions})
+      permission_ids = Permission.where(:name => @permissions).pluck(:id)
+      access_control_entry_id = AccessControlEntry.where(:group_uuid => @group_uuids, :aceable => @object).first.id
+
+      AccessControlPermission
+        .where(:permission_id => permission_ids, :access_control_entry_id => access_control_entry_id)
         .destroy_all
+
       self
     end
   end

--- a/spec/services/catalog/unshare_resource_spec.rb
+++ b/spec/services/catalog/unshare_resource_spec.rb
@@ -1,19 +1,11 @@
 describe Catalog::UnshareResource, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:uuid) { "123" }
-
-  let(:params) do
-    {
-      :group_uuids => [uuid],
-      :permissions => %w[read update],
-      :object      => portfolio
-    }
-  end
   let(:group_validator) { instance_double(Insights::API::Common::RBAC::ValidateGroups) }
 
   before do
-    create(:access_control_entry, :has_read_permission, :group_uuid => uuid, :aceable => portfolio)
-    create(:access_control_entry, :has_update_permission, :group_uuid => uuid, :aceable => portfolio)
+    create(:access_control_entry, :has_read_and_update_permission, :group_uuid => uuid, :aceable => portfolio)
+    create(:access_control_entry, :has_read_and_update_permission, :group_uuid => "456", :aceable => portfolio)
     allow(Insights::API::Common::RBAC::ValidateGroups).to receive(:new).with([uuid]).and_return(group_validator)
     allow(group_validator).to receive(:process)
   end
@@ -21,16 +13,62 @@ describe Catalog::UnshareResource, :type => :service do
   let(:subject) { described_class.new(params) }
 
   describe "#process" do
-    it "validates the groups" do
-      expect(group_validator).to receive(:process)
-      subject.process
+    context "when the permissions include all permissions available" do
+      let(:params) do
+        {
+          :group_uuids => [uuid],
+          :permissions => %w[read update order],
+          :object      => portfolio
+        }
+      end
+
+      it "validates the groups" do
+        expect(group_validator).to receive(:process)
+        subject.process
+      end
+
+      it "removes the permissions" do
+        expect(portfolio.access_control_entries.first.permissions.count).to eq(2)
+        subject.process
+        portfolio.reload
+        expect(portfolio.access_control_entries.first.permissions.count).to eq(0)
+      end
+
+      it "does not remove permissions from other access control entries" do
+        expect(portfolio.access_control_entries.last.permissions.collect(&:name)).to match_array(%w[read update])
+        subject.process
+        portfolio.reload
+        expect(portfolio.access_control_entries.last.permissions.collect(&:name)).to match_array(%w[read update])
+      end
     end
 
-    it "removes the access control entries on the portfolio" do
-      expect(portfolio.access_control_entries.count).to eq(2)
-      subject.process
-      portfolio.reload
-      expect(portfolio.access_control_entries.count).to eq(0)
+    context "when permissions are only 1 of the existing permissions" do
+      let(:params) do
+        {
+          :group_uuids => [uuid],
+          :permissions => %w[read],
+          :object      => portfolio
+        }
+      end
+
+      it "validates the groups" do
+        expect(group_validator).to receive(:process)
+        subject.process
+      end
+
+      it "removes the read permission" do
+        expect(portfolio.access_control_entries.first.permissions.collect(&:name)).to match_array(%w[read update])
+        subject.process
+        portfolio.reload
+        expect(portfolio.access_control_entries.first.permissions.collect(&:name)).to match_array(%w[update])
+      end
+
+      it "does not remove permissions from other access control entries" do
+        expect(portfolio.access_control_entries.last.permissions.collect(&:name)).to match_array(%w[read update])
+        subject.process
+        portfolio.reload
+        expect(portfolio.access_control_entries.last.permissions.collect(&:name)).to match_array(%w[read update])
+      end
     end
   end
 end


### PR DESCRIPTION
When we switched from solely using ACEs to using the join table, the unshare was still attempting to scope the delete call by ensuring that the ACE in question had the correct permissions. Unfortunately, that means that as long as it found a relevant ACE with the permission that was passed in, it would remove the entire ACE instead of only removing the associated permissions.

This changes that to simply remove the join table entry. I wanted to do this a more "rails" way, by adding a new `#remove_permissions` method to the `Portfolio` model, but the way rails handles the `has_many_through` with `.delete` I was seeing some strange issues in spec testing so I figured that would be better left to a separate PR. We can also potentially use `.push` in the `#add_permissions` method as well, which will help clean that up to be more "rails-y" too.

https://projects.engineering.redhat.com/browse/SSP-1240

@syncrou Please Review

@lgalis This should (hopefully) fix the corresponding UI bug too, now, since the share_info should be correct :).