### PR TITLE
[WIP] Portfolio metadata with static and dynamic properties

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -7,6 +7,8 @@ class Portfolio < ApplicationRecord
 
   destroy_dependencies :portfolio_items
 
+  before_save { self[:metadata] = static_metadata }
+
   acts_as_tenant(:tenant)
   acts_as_taggable_on
   default_scope -> { kept.order(Arel.sql('LOWER(portfolios.name)')) }
@@ -22,7 +24,25 @@ class Portfolio < ApplicationRecord
   end
 
   def metadata
-    {:user_capabilities => user_capabilities,
-     :shared            => self.access_control_entries.any?}
+    # Merge dynamic user_capabilities properties
+    self[:metadata].merge(:user_capabilities => user_capabilities)
+  end
+
+  def update_metadata
+    current_metadata = static_metadata
+    return if current_metadata.eql?(self[:metadata])
+
+    update(:metadata => current_metadata)
+  end
+
+  private
+
+  def static_metadata
+    {'statistics' =>
+                     {
+                       'approval_processes' => tags.where(:name => 'workflows', :namespace => 'approval').count,
+                       'portfolio_items'    => portfolio_items.count,
+                       'shared_groups'      => access_control_entries.select(:group_uuid).distinct.count
+                     }}
   end
 end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -19,4 +19,10 @@ class PortfolioItem < ApplicationRecord
   def metadata
     {:user_capabilities => user_capabilities}
   end
+
+  private
+
+  def update_portfolio_stats
+    portfolio&.update_metadata
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -33,4 +33,10 @@ class Tag < ApplicationRecord
     # FIXME: Doesn't exist on topo - but blows up when there are nil values in the db.
     tag_params.transform_values { |e| e || "" }
   end
+
+  private
+
+  def update_portfolio_stats
+    portfolios.each(&:update_metadata)
+  end
 end

--- a/app/services/catalog/share_resource.rb
+++ b/app/services/catalog/share_resource.rb
@@ -14,6 +14,9 @@ module Catalog
                                                    :aceable    => @object)
         ace.add_new_permissions(@permissions)
       end
+
+      @object&.update_metadata
+
       self
     end
   end

--- a/app/services/catalog/unshare_resource.rb
+++ b/app/services/catalog/unshare_resource.rb
@@ -16,6 +16,8 @@ module Catalog
         .where(:permission_id => permission_ids, :access_control_entry_id => access_control_entry_id)
         .destroy_all
 
+      @object&.update_metadata
+
       self
     end
   end

--- a/db/migrate/20200406122000_add_metadata_to_portfolio.rb
+++ b/db/migrate/20200406122000_add_metadata_to_portfolio.rb
@@ -1,0 +1,11 @@
+class AddMetadataToPortfolio < ActiveRecord::Migration[5.2]
+  def change
+    add_column :portfolios, :metadata, :jsonb, :default => {}
+
+    reversible do |change|
+      change.up do
+        Portfolio.all.each(&:update_metadata)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_17_202326) do
+ActiveRecord::Schema.define(version: 2020_04_06_122000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2020_03_17_202326) do
     t.datetime "discarded_at"
     t.string "owner"
     t.bigint "icon_id"
+    t.jsonb "metadata", default: {}
     t.index ["discarded_at"], name: "index_portfolios_on_discarded_at"
     t.index ["tenant_id"], name: "index_portfolios_on_tenant_id"
   end

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -16,6 +16,7 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
   describe "GET /portfolios/:portfolio_id #show" do
     before do
       create(:access_control_entry, :has_read_permission, :aceable_id => portfolio_id, :group_uuid => "456-123")
+      portfolio.update_metadata
       get "#{api_version}/portfolios/#{portfolio_id}", :headers => default_headers
     end
 
@@ -44,7 +45,7 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
       end
 
       it "returns shared status" do
-        expect(json['metadata']['shared']).to be_truthy
+        expect(json.dig('metadata', 'statistics', 'shared_groups')).to eql(1)
       end
     end
 


### PR DESCRIPTION
Potential replacement for #665 

This PR is **similar** in that it still requires objects (PortfolioItems, Tags) and sharing operations to call the Portfolio `update_metadata` method when actions are known to cause counts to change.

The **difference** is how the data is stored.  The Portfolio models has a `metadata` column where the data is stored and the `statistics` properties are moved into a key on the `metadata` column.  (Before `statistics` was a column merged into the metadata method results.)

When the `metadata` method is called on a Portfolio instance the method gets the existing column data and merges in the dynamic `user_capabilities` data.

```ruby
def metadata
  self[:metadata].merge(:user_capabilities => user_capabilities)
end
```

This approach makes the `metadata` property easy to expand if there is other data (dynamic and/or static) that needs to be included.