### PR TITLE
Add ddf v2 components and validators.

### DIFF
--- a/lib/catalog/data_driven_form_validator.rb
+++ b/lib/catalog/data_driven_form_validator.rb
@@ -6,16 +6,26 @@ module Catalog
                     plain-text
                     radio
                     select-field
+                    select
                     sub-form
                     switch-field
+                    switch
                     tab-item
                     tabs
                     text-field
                     textarea-field
+                    textarea
                     time-picker
                     wizard].freeze
 
-    VALIDATORS = %i[exact-length-validator
+    VALIDATORS = %i[exact-length
+                    max-length
+                    min-items
+                    min-length
+                    pattern
+                    required
+                    url
+                    exact-length-validator
                     max-length-validator
                     max-number-value
                     min-items-validator
@@ -65,7 +75,7 @@ module Catalog
 
           # validator types that require other fields in the validator
           case validator[:type]
-          when "min-length-validator", "max-length-validator", "exact-length-validator"
+          when "min-length-validator", "max-length-validator", "exact-length-validator", "min-length", "max-length", "exact-length"
             raise Catalog::InvalidSurvey, "Validator type #{validator[:type]} requires a `threshold` key" if validator[:threshold].nil?
           when "min-number-value", "max-number-value"
             raise Catalog::InvalidSurvey, "Validator type #{validator[:type]} requires a `value` key" if validator[:value].nil?
@@ -75,7 +85,7 @@ module Catalog
 
       def check_options(schema_fields)
         schema_fields.map do |field|
-          next unless field[:component] == "select-field"
+          next unless field[:component] == "select-field" || field[:component] == "select" 
 
           # the options must contain label and value keys
           field[:options].each do |option|

--- a/spec/lib/catalog/data_driven_form_validator_spec.rb
+++ b/spec/lib/catalog/data_driven_form_validator_spec.rb
@@ -1,6 +1,7 @@
 describe Catalog::DataDrivenFormValidator do
   let(:subject) { described_class.valid?(ddf) }
   let(:ddf_file) { File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf.json")) }
+  let(:ddfv2_file) { File.read(Rails.root.join("spec", "support", "ddf", "valid_service_plan_ddf_v2.json")) }
 
   shared_examples_for "fails validation" do
     it "blows up" do
@@ -11,6 +12,13 @@ describe Catalog::DataDrivenFormValidator do
   describe "#valid?" do
     context "when given valid DDF JSON" do
       let(:ddf) { ddf_file }
+      it "validates successfully" do
+        expect(subject).to eq true
+      end
+    end
+
+    context "when given valid DDFv2 JSON" do
+      let(:ddf) { ddfv2_file }
       it "validates successfully" do
         expect(subject).to eq true
       end

--- a/spec/support/ddf/valid_service_plan_ddf_v2.json
+++ b/spec/support/ddf/valid_service_plan_ddf_v2.json
@@ -1,0 +1,66 @@
+
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "v2-validators",
+        "label": "V2 validators",
+        "validate": [
+          {
+            "type": "required"
+          },
+          {
+            "type": "min-length",
+            "threshold": 0
+          },
+          {
+            "type": "max-length",
+            "threshold": 255
+          },
+          {
+            "type": "exact-length",
+            "threshold": 50
+          },
+          {
+            "type": "pattern",
+            "pattern": "^foo?.bar$"
+          },
+          {
+            "type": "url",
+            "protocol": "https"
+          }
+        ],
+        "component": "text-field",
+        "isRequired": true
+      },
+      {
+        "name": "v2-select",
+        "label": "V2 select",
+        "options": [
+          {
+            "label": "Test Approval",
+            "value": "Test Approval"
+          }
+        ],
+        "validate": [
+          {
+            "type": "required-validator"
+          }
+        ],
+        "component": "select",
+        "isRequired": true
+      },
+      {
+        "name": "v2-textarea",
+        "component": "textarea",
+        "label": "V2 textarea",
+        "isRequired": true
+      },
+      {
+        "component": "switch",
+        "label": "V2 switch",
+        "name": "v2-switch"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
With the release of DDF v2, there were some changes to the schema definition in order to make it more consistent.

1. we have removed the `-field` affix from component types (except text field-field because that's the actual field name we want to use). This affected `select-field` and `textarea` which are now called just `select` and `textarea`
2. we have removed the `-validator` affix from all validators. So for example, `required-validator` is now just `required`

Thankfully everything is customizable in DDF so we can override them in UI to accept both the old and new constant values. But the survey editor validator now does not accept any of these new constants.

In order to gradually migrate over the version, we need to accept both formats for some until, until catalog-API, catalog-UI and topological inventory change these constants as well.

The catalog will also require DB migration for existing modified surveys, but that should only happen after the UI and topological inventory migrated.

#### Edit
I should probably point out that is not critical before GA. It can sit here for weeks.