### PR TITLE
Move group_names RBAC call to UserContext

### DIFF
--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -73,7 +73,7 @@ module Api
 
       def share_info
         portfolio = Portfolio.find(params.require(:portfolio_id))
-        options = {:object => portfolio}
+        options = {:object => portfolio, :user_context => pundit_user}
         render :json => Catalog::ShareInfo.new(options).process.result
       end
 

--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -6,6 +6,7 @@ module Catalog
 
     def initialize(options)
       @object = options[:object]
+      @user_context = options[:user_context]
     end
 
     def process
@@ -15,7 +16,7 @@ module Catalog
         ace.group_uuid
       end
 
-      group_names = fetch_group_names(uuids.uniq)
+      group_names = @user_context.group_names(uuids)
       @result = group_permissions.each_with_object([]) do |(uuid, permissions), memo|
         next if permissions.empty?
 
@@ -27,17 +28,6 @@ module Catalog
       end
 
       self
-    end
-
-    private
-
-    def fetch_group_names(uuids)
-      opts = {:limit => MAX_GROUPS_LIMIT, :uuid => uuids}
-      Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
-        Insights::API::Common::RBAC::Service.paginate(api, :list_groups, opts).each_with_object({}) do |group, memo|
-          memo[group.uuid] = group.name
-        end
-      end
     end
   end
 end

--- a/spec/policies/user_context_spec.rb
+++ b/spec/policies/user_context_spec.rb
@@ -69,4 +69,42 @@ describe UserContext, [:type => :current_forwardble] do
       expect(subject.group_uuids).to eq(["123-456"])
     end
   end
+
+  describe "#group_names" do
+    let(:rbac_api) { instance_double(Insights::API::Common::RBAC::Service) }
+
+    before do
+      allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::GroupApi).and_yield(rbac_api)
+      options = {:limit => 500, :uuid => uuids}
+      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(rbac_api, :list_groups, options)
+        .and_return(group_list)
+    end
+
+    let(:group_list) do
+      [
+        RBACApiClient::GroupOut.new(:name => "group", :uuid => "123-456"),
+        RBACApiClient::GroupOut.new(:name => "group2", :uuid => "123-4567")
+      ]
+    end
+
+    context "when uuids are passed in" do
+      let(:uuids) { %w[123-456] }
+
+      it "ignores values not in the filter and returns a memoized hash" do
+        expect(Insights::API::Common::RBAC::Service).to receive(:call).once
+        subject.group_names(uuids)
+        expect(subject.group_names(uuids)).to eq({"123-456" => "group"})
+      end
+    end
+
+    context "when there are no uuids" do
+      let(:uuids) { [] }
+
+      it "returns a memoized empty hash" do
+        expect(Insights::API::Common::RBAC::Service).to receive(:call).once
+        subject.group_names(uuids)
+        expect(subject.group_names(uuids)).to eq({})
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -313,23 +313,23 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
     end
 
     context 'share_info' do
-      include_context "sharing_objects"
-      it "portfolio" do
-        with_modified_env :APP_NAME => app_name do
-          allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
-          allow(Insights::API::Common::RBAC::Service).to receive(:paginate) do |api_instance, method, options|
-            expect(method).to eq(:list_groups)
-            expect(options[:limit]).to eq(Catalog::ShareInfo::MAX_GROUPS_LIMIT)
-            expect(options[:uuid]).to match_array(group_uuids) if options.key?(:uuid)
-            groups
-          end
-          ace1
-          ace2
-          ace3
-          get "#{api_version}/portfolios/#{shared_portfolio.id}/share_info", :headers => default_headers
-          expect(response).to have_http_status(200)
-          expect(json.pluck('group_uuid')).to match_array(group_uuids)
-        end
+      let(:portfolio) { create(:portfolio) }
+      let(:uuid) { "123" }
+      let(:group_names) { {"123" => "group_name"} }
+
+      let(:share_info) { instance_double(Catalog::ShareInfo, :result => result) }
+      let(:result) { [:group_name => "group_name", :group_uuid => "123", :permissions => %w[read update]] }
+
+      before do
+        allow(Catalog::ShareInfo).to receive(:new).with(:object => portfolio, :user_context => an_instance_of(UserContext)).and_return(share_info)
+        allow(share_info).to receive(:process).and_return(share_info)
+      end
+
+      it "returns the sharing information" do
+        get "#{api_version}/portfolios/#{portfolio.id}/share_info", :headers => default_headers
+        expect(json.pluck('group_uuid')).to match_array(["123"])
+        expect(json.pluck('group_name')).to match_array(["group_name"])
+        expect(json.pluck('permissions')).to match_array([%w[read update]])
       end
     end
 


### PR DESCRIPTION
While working on #666 I found this other RBAC call that could be moved to the `UserContext` class so that we aren't doing it in the `ShareInfo` class. Simplifies the `ShareInfo` class a little bit, makes it easier to test, and isolates the RBAC test into the `user_context_spec.rb`.

@mkanoor Please Review.