### PR TITLE
Fix access scope call to use proper object table name

### DIFF
--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -34,7 +34,7 @@ module Catalog
         elsif scopes.include?("user")
           @record.owner == @user_context.request.user.username
         else
-          Rails.logger.error("Error in resource checking for verb: #{verb}, id: #{id}, klass: #{klass}")
+          Rails.logger.error("Error in resource checking for verb: #{verb}, object id: #{id}, object class: #{@record.class}, class to check scopes against: #{klass}")
           Rails.logger.error("Scope does not include admin, group, or user. List of scopes: #{scopes}")
           false
         end

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -25,7 +25,7 @@ module Catalog
       def resource_check(verb, id = @record.id, klass = @record.class)
         return true unless rbac_enabled?
 
-        scopes = access_object.scopes(@record.class.table_name, verb)
+        scopes = access_object.scopes(klass.table_name, verb)
         if scopes.include?("admin")
           true
         elsif scopes.include?("group")

--- a/spec/factories/access_control_entry.rb
+++ b/spec/factories/access_control_entry.rb
@@ -8,6 +8,10 @@ FactoryBot.define do
       access_control_permissions { [create(:access_control_permission, :has_update_permission)] }
     end
 
+    trait :has_order_permission do
+      access_control_permissions { [create(:access_control_permission, :has_order_permission)] }
+    end
+
     trait :has_read_permission do
       access_control_permissions { [create(:access_control_permission, :has_read_permission)] }
     end

--- a/spec/factories/access_control_permission.rb
+++ b/spec/factories/access_control_permission.rb
@@ -12,4 +12,8 @@ FactoryBot.define do
   trait :has_delete_permission do
     permission { Permission.find_or_create_by(:name => 'delete') }
   end
+
+  trait :has_order_permission do
+    permission { Permission.find_or_create_by(:name => 'order') }
+  end
 end


### PR DESCRIPTION
The `access_object.scopes` call is meant to look at RBAC and determine what scopes the user is currently a part of, and then we can decide how to reconcile those with our group level permissions. However, when doing something like submitting an order, what was getting used as the `@record` was an `order` object, with the verb of `"order"`. But in the rbac-config we don't have an "orders:order" permission, that should be on Portfolios.

Basically the specs were incorrectly assuming that the `@record` object type that we're currently dealing with is what we should be querying RBAC for, when in most cases it's not, it's the `klass` that we specifically passed into `resource_check`. In the cases where we don't pass it in explicitly, the `@record` object type is `Portfolio`, so it works properly.

@mkanoor @syncrou Please Review. (Also Drew if you want to delegate your review to someone else because I'm sure you're busy with topo stuff, feel free, I just don't know who else to tag haha).

https://projects.engineering.redhat.com/browse/SSP-1444