### PR TITLE
[Stable] Ensure only users in the portfolio update admin scope can share/unshare

### DIFF
--- a/app/policies/portfolio_policy.rb
+++ b/app/policies/portfolio_policy.rb
@@ -17,8 +17,11 @@ class PortfolioPolicy < ApplicationPolicy
     rbac_access.update_access_check
   end
 
-  alias share? update?
-  alias unshare? update?
+  def share?
+    rbac_access.admin_access_check("portfolios", "update")
+  end
+
+  alias unshare? share?
 
   # def set_approval?
   #   # TODO: Add "Approval Administrator" check as &&

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -40,6 +40,13 @@ module Catalog
         end
       end
 
+      def admin_access_check(table_name, verb)
+        return true unless rbac_enabled?
+
+        scopes = access_object.scopes(table_name, verb)
+        scopes.include?("admin")
+      end
+
       def permission_check(verb, klass = @record.class)
         rbac_enabled? ? access_object.accessible?(klass.table_name, verb) : true
       end

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -43,8 +43,7 @@ module Catalog
       def admin_access_check(table_name, verb)
         return true unless rbac_enabled?
 
-        scopes = access_object.scopes(table_name, verb)
-        scopes.include?("admin")
+        access_object.admin_scope?(table_name, verb)
       end
 
       def permission_check(verb, klass = @record.class)

--- a/spec/controllers/api/v1x0/application_controller_spec.rb
+++ b/spec/controllers/api/v1x0/application_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ApplicationController, :type => [:request, :v1] do
      allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
      allow(catalog_access).to receive(:process).and_return(catalog_access)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
+     allow(catalog_access).to receive(:admin_scope?).with("portfolios", "update").and_return(true)
   end
 
   context "with tenancy enforcement" do

--- a/spec/lib/catalog/rbac/access_spec.rb
+++ b/spec/lib/catalog/rbac/access_spec.rb
@@ -186,4 +186,38 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
   describe "#destroy_access_check" do
     it_behaves_like "resource checking", :destroy_access_check, [], "delete", PortfolioItem, :has_delete_permission
   end
+
+  describe "#admin_access_check" do
+    context "when RBAC is enabled" do
+      let(:rbac_enabled) { true }
+
+      before do
+        allow(catalog_access).to receive(:scopes).with("portfolios", "update").and_return(scopes)
+      end
+
+      context "when the user has admin scopes for the specified object" do
+        let(:scopes) { ["admin"] }
+
+        it "returns true" do
+          expect(subject.admin_access_check("portfolios", "update")).to eq(true)
+        end
+      end
+
+      context "when the user does not have admin scopes for the specified object" do
+        let(:scopes) { ["group"] }
+
+        it "returns false" do
+          expect(subject.admin_access_check("portfolios", "update")).to eq(false)
+        end
+      end
+    end
+
+    context "when RBAC is not enabled" do
+      let(:rbac_enabled) { false }
+
+      it "returns true" do
+        expect(subject.admin_access_check("portfolios", "update")).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/lib/catalog/rbac/access_spec.rb
+++ b/spec/lib/catalog/rbac/access_spec.rb
@@ -192,11 +192,11 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
       let(:rbac_enabled) { true }
 
       before do
-        allow(catalog_access).to receive(:scopes).with("portfolios", "update").and_return(scopes)
+        allow(catalog_access).to receive(:admin_scope?).with("portfolios", "update").and_return(admin_scope)
       end
 
       context "when the user has admin scopes for the specified object" do
-        let(:scopes) { ["admin"] }
+        let(:admin_scope) { true }
 
         it "returns true" do
           expect(subject.admin_access_check("portfolios", "update")).to eq(true)
@@ -204,7 +204,7 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
       end
 
       context "when the user does not have admin scopes for the specified object" do
-        let(:scopes) { ["group"] }
+        let(:admin_scope) { false }
 
         it "returns false" do
           expect(subject.admin_access_check("portfolios", "update")).to eq(false)

--- a/spec/policies/portfolio_policy_spec.rb
+++ b/spec/policies/portfolio_policy_spec.rb
@@ -16,13 +16,6 @@ describe PortfolioPolicy do
     end
   end
 
-  shared_examples "a policy action that requires update access" do |method|
-    it "delegates to the rbac access update check" do
-      expect(rbac_access).to receive(:update_access_check).and_return(true)
-      expect(subject.send(method)).to eq(true)
-    end
-  end
-
   describe "#show?" do
     it "delegates to the rbac access read check" do
       expect(rbac_access).to receive(:read_access_check).and_return(true)
@@ -50,9 +43,19 @@ describe PortfolioPolicy do
     end
   end
 
-  [:update?, :share?, :unshare?].each do |method|
+  describe "#update?" do
+    it "delegates to the rbac access update check" do
+      expect(rbac_access).to receive(:update_access_check).and_return(true)
+      expect(subject.update?).to eq(true)
+    end
+  end
+
+  [:share?, :unshare?].each do |method|
     describe "##{method}" do
-      it_behaves_like "a policy action that requires update access", method
+      it "delegates to the rbac access update check" do
+        expect(rbac_access).to receive(:admin_access_check).with("portfolios", "update").and_return(true)
+        expect(subject.send(method)).to eq(true)
+      end
     end
   end
 
@@ -62,6 +65,7 @@ describe PortfolioPolicy do
       allow(rbac_access).to receive(:create_access_check).and_return(true)
       allow(rbac_access).to receive(:destroy_access_check).and_return(true)
       allow(rbac_access).to receive(:update_access_check).and_return(true)
+      allow(rbac_access).to receive(:admin_access_check).with("portfolios", "update").and_return(true)
     end
 
     it "returns a hash of user capabilities" do

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -10,6 +10,7 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
      allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
      allow(catalog_access).to receive(:process).and_return(catalog_access)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
+     allow(catalog_access).to receive(:admin_scope?).with("portfolios", "update").and_return(true)
   end
 
   describe "GET /portfolios/:portfolio_id" do

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -11,6 +11,7 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
     allow(rbac_access).to receive(:update_access_check).and_return(true)
     allow(rbac_access).to receive(:create_access_check).and_return(true)
     allow(rbac_access).to receive(:destroy_access_check).and_return(true)
+    allow(rbac_access).to receive(:admin_access_check).with("portfolios", "update").and_return(true)
   end
 
   describe "GET /portfolios/:portfolio_id #show" do

--- a/spec/requests/api/v1/application_controller_spec.rb
+++ b/spec/requests/api/v1/application_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ApplicationController, :type => [:request, :v1x1] do
      allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
      allow(catalog_access).to receive(:process).and_return(catalog_access)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
+     allow(catalog_access).to receive(:admin_scope?).with("portfolios", "update").and_return(true)
   end
 
   context "with api version v1" do


### PR DESCRIPTION
Stable branch PR of https://github.com/RedHatInsights/catalog-api/pull/683

> Before this would go through the `update_access_check` logic, but because of that, if the user was in the group or user scopes, it would continue to look at the logic for those scopes. This PR changes that so that we basically short-circuit if the user isn't in the admin scope, we just return false. I assume we might want to use something like this for other permissions later, so I created a new method for it.
> 
> https://projects.engineering.redhat.com/browse/SSP-1233