### PR TITLE
If the permissions is empty dont create share_info object

### DIFF
--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -18,7 +18,7 @@ module Catalog
       group_names = fetch_group_names(uuids.uniq)
       @result = group_permissions.each_with_object([]) do |(uuid, permissions), memo|
         if group_names.key?(uuid)
-          memo << { :group_name => group_names[uuid], :group_uuid => uuid, :permissions => permissions }
+          memo << { :group_name => group_names[uuid], :group_uuid => uuid, :permissions => permissions } if permissions.any?
         else
           Rails.logger.warn("Skipping group UUID: #{uuid} since its missing from RBAC service")
         end

--- a/spec/factories/access_control_entry.rb
+++ b/spec/factories/access_control_entry.rb
@@ -20,6 +20,10 @@ FactoryBot.define do
       access_control_permissions { [create(:access_control_permission, :has_delete_permission)] }
     end
 
+    trait :has_no_permission do
+      access_control_permissions { [] }
+    end
+
     trait :has_read_and_update_permission do
       access_control_permissions do
         [


### PR DESCRIPTION
When unsharing we only remove the permissions which is kept in
a separate table and leave the group_uuid and portfolio in the
access_control_entry table. Which leads to share info object being
created with group_uuid but no permissions.

https://projects.engineering.redhat.com/browse/SSP-1440