### PR TITLE
Return an empty array when groups have no permissions

### DIFF
--- a/app/services/catalog/share_info.rb
+++ b/app/services/catalog/share_info.rb
@@ -17,12 +17,15 @@ module Catalog
 
       group_names = fetch_group_names(uuids.uniq)
       @result = group_permissions.each_with_object([]) do |(uuid, permissions), memo|
+        next if permissions.empty?
+
         if group_names.key?(uuid)
           memo << { :group_name => group_names[uuid], :group_uuid => uuid, :permissions => permissions }
         else
           Rails.logger.warn("Skipping group UUID: #{uuid} since its missing from RBAC service")
         end
       end
+
       self
     end
 

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -1,12 +1,14 @@
 describe Catalog::ShareInfo, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:group2) { instance_double(RBACApiClient::GroupOut, :name => 'group2', :uuid => "321") }
   let(:uuids) { [group1.uuid] }
   let(:permissions) { ['read', 'update'] }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { double }
   let(:principal_options) { {:scope=>"principal"} }
   let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => [group1.uuid]} }
+  let(:group_list) { [group1] }
 
   let(:params) { { :object => portfolio } }
 
@@ -16,15 +18,14 @@ describe Catalog::ShareInfo, :type => :service do
       expect(method).to eq(:list_groups)
       expect(options[:limit]).to eq(Catalog::ShareInfo::MAX_GROUPS_LIMIT)
       expect(options[:uuid]).to match_array(uuids) if options.key?(:uuid)
-      [group1]
+      group_list
     end
-    create(:access_control_entry, :has_read_and_update_permission, :group_uuid => group1.uuid, :aceable => portfolio)
   end
 
   let(:subject) { described_class.new(params) }
 
   shared_examples_for "#process" do
-    it "#process" do
+    it "gets the correct group name, group uuid, and permissions" do
       info = subject.process.result
       expect(info.count).to eq(1)
       expect(info[0][:group_name]).to eq(group1.name)
@@ -33,17 +34,53 @@ describe Catalog::ShareInfo, :type => :service do
     end
   end
 
-  context "when all group uuids exist" do
-    it_behaves_like "#process"
-  end
+  describe "#process" do
+    context "when all group uuids exist" do
+      before do
+        create(:access_control_entry, :has_read_and_update_permission, :group_uuid => group1.uuid, :aceable => portfolio)
+      end
 
-  context "when only some group uuids exist" do
-    let(:uuids) { [group1.uuid, 'non-existent'] }
-    let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => uuids} }
-    before do
-      create(:access_control_entry, :has_update_permission, :group_uuid => "non-existent", :aceable => portfolio)
+      it_behaves_like "#process"
     end
 
-    it_behaves_like "#process"
+    context "when only some group uuids exist" do
+      let(:uuids) { [group1.uuid, 'non-existent'] }
+      let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => uuids} }
+      before do
+        create(:access_control_entry, :has_read_and_update_permission, :group_uuid => group1.uuid, :aceable => portfolio)
+        create(:access_control_entry, :has_update_permission, :group_uuid => "non-existent", :aceable => portfolio)
+      end
+
+      it_behaves_like "#process"
+    end
+
+    context "when there are no permissions for the access control entry" do
+      before do
+        create(:access_control_entry, :group_uuid => group1.uuid, :aceable => portfolio)
+      end
+
+      it "returns an empty array" do
+        expect(subject.process.result.count).to eq(0)
+      end
+    end
+
+    context "when there are no permissions for one access control entry but permissions for another" do
+      let(:uuids) { [group1.uuid, group2.uuid] }
+      let(:pagination_options) { {:limit => Catalog::ShareInfo::MAX_GROUPS_LIMIT, :uuid => uuids} }
+      let(:group_list) { [group1, group2] }
+
+      before do
+        create(:access_control_entry, :group_uuid => group1.uuid, :aceable => portfolio)
+        create(:access_control_entry, :has_update_permission, :group_uuid => group2.uuid, :aceable => portfolio)
+      end
+
+      it "returns the permissions for the group with permissions" do
+        share_info = subject.process.result
+        expect(share_info.count).to eq(1)
+        expect(share_info[0][:group_name]).to eq(group2.name)
+        expect(share_info[0][:group_uuid]).to eq(group2.uuid)
+        expect(share_info[0][:permissions]).to match_array(["update"])
+      end
+    end
   end
 end

--- a/spec/services/catalog/share_info_spec.rb
+++ b/spec/services/catalog/share_info_spec.rb
@@ -24,7 +24,7 @@ describe Catalog::ShareInfo, :type => :service do
 
   let(:subject) { described_class.new(params) }
 
-  shared_examples_for "#process" do
+  shared_examples_for "#process that has permissions" do
     it "gets the correct group name, group uuid, and permissions" do
       info = subject.process.result
       expect(info.count).to eq(1)
@@ -40,7 +40,7 @@ describe Catalog::ShareInfo, :type => :service do
         create(:access_control_entry, :has_read_and_update_permission, :group_uuid => group1.uuid, :aceable => portfolio)
       end
 
-      it_behaves_like "#process"
+      it_behaves_like "#process that has permissions"
     end
 
     context "when only some group uuids exist" do
@@ -51,7 +51,7 @@ describe Catalog::ShareInfo, :type => :service do
         create(:access_control_entry, :has_update_permission, :group_uuid => "non-existent", :aceable => portfolio)
       end
 
-      it_behaves_like "#process"
+      it_behaves_like "#process that has permissions"
     end
 
     context "when there are no permissions for the access control entry" do
@@ -70,17 +70,11 @@ describe Catalog::ShareInfo, :type => :service do
       let(:group_list) { [group1, group2] }
 
       before do
-        create(:access_control_entry, :group_uuid => group1.uuid, :aceable => portfolio)
-        create(:access_control_entry, :has_update_permission, :group_uuid => group2.uuid, :aceable => portfolio)
+        create(:access_control_entry, :group_uuid => group2.uuid, :aceable => portfolio)
+        create(:access_control_entry, :has_read_and_update_permission, :group_uuid => group1.uuid, :aceable => portfolio)
       end
 
-      it "returns the permissions for the group with permissions" do
-        share_info = subject.process.result
-        expect(share_info.count).to eq(1)
-        expect(share_info[0][:group_name]).to eq(group2.name)
-        expect(share_info[0][:group_uuid]).to eq(group2.uuid)
-        expect(share_info[0][:permissions]).to match_array(["update"])
-      end
+      it_behaves_like "#process that has permissions"
     end
   end
 end


### PR DESCRIPTION
#666 Fixed the issue where removing permissions was deleting groups, but if all of the permissions are removed, it doesn't really make sense to continue to show the group in the `#share_info` call. This fixes that by only adding values to the `@result` if permissions exist.

https://projects.engineering.redhat.com/browse/SSP-1440