### PR TITLE
Use a class method to cache PolicyClass name

### DIFF
--- a/app/models/concerns/user_capabilities.rb
+++ b/app/models/concerns/user_capabilities.rb
@@ -6,12 +6,18 @@ module UserCapabilities
     attribute :metadata, ActiveRecord::Type::Json.new
   end
 
+  class_methods do
+    def policy_class
+      @policy_class ||= "#{self}Policy".constantize
+    end
+  end
+
   private
 
   def user_capabilities
     return nil if user_context.nil?
 
-    "#{self.class}Policy".constantize.new(user_context, self).user_capabilities
+    self.class.policy_class.new(user_context, self).user_capabilities
   end
 
   def user_context

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -43,4 +43,10 @@ describe PortfolioItem do
       expect(PortfolioItem.pluck(:name)).to eq(%w[ab Ad bb Bc])
     end
   end
+
+  context ".policy_class" do
+    it "is PortfolioItemPolicy" do
+      expect(PortfolioItem.policy_class).to eq(PortfolioItemPolicy)
+    end
+  end
 end

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -87,4 +87,10 @@ describe Portfolio do
       expect(Portfolio.pluck(:name)).to eq(%w[aa Ad bb Bc])
     end
   end
+
+  context ".policy_class" do
+    it "is PortfolioPolicy" do
+      expect(Portfolio.policy_class).to eq(PortfolioPolicy)
+    end
+  end
 end


### PR DESCRIPTION
When doing list view we keep calling the policy_class for every
portfolio instance. This PR uses a policy_class class method and caches the
name of the policy class.

https://projects.engineering.redhat.com/browse/SSP-1438