### PR TITLE
Fixed RBAC calls and specs

### DIFF
--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -29,8 +29,7 @@ module Catalog
         if scopes.include?("admin")
           true
         elsif scopes.include?("group")
-          ids = access_id_list(verb, klass)
-          klass.try(:supports_access_control?) ? ids.include?(id.to_s) : true
+          klass.try(:supports_access_control?) ? access_id_list(verb, klass).include?(id.to_s) : true
         elsif scopes.include?("user")
           @record.owner == @user_context.request.user.username
         else

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -29,7 +29,7 @@ module Catalog
         if scopes.include?("admin")
           true
         elsif scopes.include?("group")
-          klass.try(:supports_access_control?) ? access_id_list(verb, klass).include?(id.to_s) : true
+          access_id_list(verb, klass).include?(id.to_s)
         elsif scopes.include?("user")
           @record.owner == @user_context.request.user.username
         else

--- a/lib/catalog/rbac/access_control_entries.rb
+++ b/lib/catalog/rbac/access_control_entries.rb
@@ -6,6 +6,7 @@ module Catalog
       end
 
       def ace_ids(permission, klass)
+        raise ArgumentError, "#{klass} doesn't support access control" unless klass.try(:supports_access_control?)
         AccessControlEntry.joins(:permissions).where(
           :permissions            => {
             :name => permission

--- a/spec/lib/catalog/rbac/access_control_entries_spec.rb
+++ b/spec/lib/catalog/rbac/access_control_entries_spec.rb
@@ -24,5 +24,11 @@ describe Catalog::RBAC::AccessControlEntries do
         expect(subject.ace_ids('read', Portfolio)).to eq([])
       end
     end
+
+    context "only portfolio supports aces" do
+      it "raises an exception" do
+        expect { subject.ace_ids('read', PortfolioItem) }.to raise_exception(ArgumentError)
+      end
+    end
   end
 end

--- a/spec/lib/catalog/rbac/access_control_entries_spec.rb
+++ b/spec/lib/catalog/rbac/access_control_entries_spec.rb
@@ -17,7 +17,6 @@ describe Catalog::RBAC::AccessControlEntries do
     context "when access control entries do not exist that match the given parameters" do
       before do
         create(:access_control_entry, :has_update_permission, :aceable_id => "123")
-        create(:access_control_entry, :has_read_permission, :aceable_id => "456", :aceable_type => "PortfolioItem")
         create(:access_control_entry, :has_read_permission, :aceable_id => "789", :group_uuid => "456-123")
       end
 

--- a/spec/lib/catalog/rbac/access_spec.rb
+++ b/spec/lib/catalog/rbac/access_spec.rb
@@ -67,25 +67,23 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
       context "when the user is in the group scope" do
         let(:scopes) { %w[group user] }
 
-        context "when the class supports access control" do
-          before do
-            create(:access_control_entry, permission_under_test, :aceable_id => aceable_id, :aceable_type => aceable_type)
+        before do
+          create(:access_control_entry, permission_under_test, :aceable_id => aceable_id, :aceable_type => aceable_type)
+        end
+
+        context "when the ids exclude the given id" do
+          let(:aceable_id) { "456" }
+
+          it "returns false" do
+            expect(subject.send(method, *arguments)).to eq(false)
           end
+        end
 
-          context "when the ids exclude the given id" do
-            let(:aceable_id) { "456" }
+        context "when the ids include the given id" do
+          let(:aceable_id) { portfolio.id }
 
-            it "returns false" do
-              expect(subject.send(method, *arguments)).to eq(false)
-            end
-          end
-
-          context "when the ids include the given id" do
-            let(:aceable_id) { portfolio.id }
-
-            it "returns true" do
-              expect(subject.send(method, *arguments)).to eq(true)
-            end
+          it "returns true" do
+            expect(subject.send(method, *arguments)).to eq(true)
           end
         end
       end


### PR DESCRIPTION
access_control_entries is only called if the model
supports_access_control. PortfolioItems never get into the
AccessControlEntry table. Raise an exception if ace_ids get called on a class that doesn't supports_access_control.

https://projects.engineering.redhat.com/browse/SSP-1438