### PR TITLE
Removed the double expect in the spec

### DIFF
--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -70,18 +70,14 @@ describe Catalog::CreateApprovalRequest, :type => :service do
       end
 
       it "creates a progress message" do
-        expect do
-          subject.process
-          expect(ProgressMessage.last.message).to eq("Error while creating approval request")
-        end
+        expect { subject.process }.to raise_exception(Catalog::ApprovalError)
+        expect(ProgressMessage.last.message).to eq("Error while creating approval request")
       end
 
       it "fails the order" do
-        expect do
-          subject.process
-          order.reload
-          expect(order.state).to eq("Failed")
-        end
+        expect { subject.process }.to raise_exception(Catalog::ApprovalError)
+        order.reload
+        expect(order.state).to eq("Failed")
       end
     end
 


### PR DESCRIPTION
Fixed the spec to check for the exception

rspec doesn't like nested expects e.g
```
describe "test" do
  it "test double expect" do
    expect do
      raise "Hello"
      expect(1).to eq(1)
    end
  end

  it "test single expect" do
    raise "Hello"
    expect(1).to eq(1)
  end
end

```

Cleaned up the spec and fixed the exception checking
https://projects.engineering.redhat.com/browse/SSP-1438