### PR TITLE
Add set approval and edit survey user capabilities

### DIFF
--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -27,9 +27,9 @@ class PortfolioItemPolicy < ApplicationPolicy
     end
   end
 
-  # def edit_survey?
-  #   rbac_access.resource_check('update', @record.portfolio_id, Portfolio)
-  # end
+  def edit_survey?
+    rbac_access.resource_check('update', @record.portfolio_id, Portfolio)
+  end
 
   def set_approval?
     rbac_access.resource_check('update', @record.portfolio_id, Portfolio) &&

--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -31,10 +31,10 @@ class PortfolioItemPolicy < ApplicationPolicy
   #   rbac_access.resource_check('update', @record.portfolio_id, Portfolio)
   # end
 
-  # def set_approval?
-  #   # TODO: Add "Approval Administrator" check as &&
-  #   rbac_access.resource_check('update', @record.portfolio_id, Portfolio)
-  # end
+  def set_approval?
+    rbac_access.resource_check('update', @record.portfolio_id, Portfolio) &&
+      rbac_access.approval_workflow_check
+  end
 
   private
 

--- a/app/policies/portfolio_policy.rb
+++ b/app/policies/portfolio_policy.rb
@@ -23,10 +23,9 @@ class PortfolioPolicy < ApplicationPolicy
 
   alias unshare? share?
 
-  # def set_approval?
-  #   # TODO: Add "Approval Administrator" check as &&
-  #   rbac_access.update_access_check
-  # end
+  def set_approval?
+    rbac_access.update_access_check && rbac_access.approval_workflow_check
+  end
 
   class Scope < Scope
     def resolve

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -53,13 +53,9 @@ module Catalog
       def approval_workflow_check
         return true unless rbac_enabled?
 
-        read_scopes = access_object.scopes("workflows", "read")
-        link_scopes = access_object.scopes("workflows", "link")
-        unlink_scopes = access_object.scopes("workflows", "unlink")
-
-        [read_scopes, link_scopes, unlink_scopes].all? do |scope|
-          scope.include?("admin")
-        end
+        access_object.accessible?("workflows", "read", "approval") &&
+          access_object.accessible?("workflows", "link", "approval") &&
+          access_object.accessible?("workflows", "unlink", "approval")
       end
 
       private

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -50,6 +50,19 @@ module Catalog
         rbac_enabled? ? access_object.accessible?(klass.table_name, verb) : true
       end
 
+      def approval_workflow_check
+        return true unless rbac_enabled?
+
+        read_scopes = access_object.scopes("workflows", "read")
+        link_scopes = access_object.scopes("workflows", "link")
+        unlink_scopes = access_object.scopes("workflows", "unlink")
+
+        admin_scopes = [read_scopes, link_scopes, unlink_scopes].collect do |scope|
+          scope.include?("admin")
+        end
+        admin_scopes.all?
+      end
+
       private
 
       def rbac_enabled?

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -57,10 +57,9 @@ module Catalog
         link_scopes = access_object.scopes("workflows", "link")
         unlink_scopes = access_object.scopes("workflows", "unlink")
 
-        admin_scopes = [read_scopes, link_scopes, unlink_scopes].collect do |scope|
+        [read_scopes, link_scopes, unlink_scopes].all? do |scope|
           scope.include?("admin")
         end
-        admin_scopes.all?
       end
 
       private

--- a/spec/controllers/api/v1x0/application_controller_spec.rb
+++ b/spec/controllers/api/v1x0/application_controller_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe ApplicationController, :type => [:request, :v1] do
      allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
      allow(catalog_access).to receive(:process).and_return(catalog_access)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
+
+     #TODO: Remove these calls as it is stubbing out for user_capabilities,
+     # which should not be getting called on this version of the API
+     # When common gem gets updated, these can be removed.
      allow(catalog_access).to receive(:admin_scope?).with("portfolios", "update").and_return(true)
+     allow(catalog_access).to receive(:accessible?).and_return(true)
   end
 
   context "with tenancy enforcement" do

--- a/spec/lib/catalog/rbac/access_spec.rb
+++ b/spec/lib/catalog/rbac/access_spec.rb
@@ -220,4 +220,58 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
       end
     end
   end
+
+  describe "#approval_workflow_check" do
+    context "when RBAC is enabled" do
+      let(:rbac_enabled) { true }
+
+      let(:read_scope) { %w[admin] }
+      let(:link_scope) { %w[admin] }
+      let(:unlink_scope) { %w[admin] }
+
+      before do
+        allow(catalog_access).to receive(:scopes).with("workflows", "read").and_return(read_scope)
+        allow(catalog_access).to receive(:scopes).with("workflows", "link").and_return(link_scope)
+        allow(catalog_access).to receive(:scopes).with("workflows", "unlink").and_return(unlink_scope)
+      end
+
+      context "when the user has admin scopes for read, link, and unlink" do
+        it "returns true" do
+          expect(subject.approval_workflow_check).to eq(true)
+        end
+      end
+
+      context "when the user does not have admin scopes for read" do
+        let(:read_scope) { [] }
+
+        it "returns false" do
+          expect(subject.approval_workflow_check).to eq(false)
+        end
+      end
+
+      context "when the user does not have admin scopes for link" do
+        let(:link_scope) { [] }
+
+        it "returns false" do
+          expect(subject.approval_workflow_check).to eq(false)
+        end
+      end
+
+      context "when the user does not have admin scopes for unlink" do
+        let(:unlink_scope) { [] }
+
+        it "returns false" do
+          expect(subject.approval_workflow_check).to eq(false)
+        end
+      end
+    end
+
+    context "when RBAC is not enabled" do
+      let(:rbac_enabled) { false }
+
+      it "returns true" do
+        expect(subject.admin_access_check("portfolios", "update")).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/lib/catalog/rbac/access_spec.rb
+++ b/spec/lib/catalog/rbac/access_spec.rb
@@ -225,14 +225,14 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
     context "when RBAC is enabled" do
       let(:rbac_enabled) { true }
 
-      let(:read_scope) { %w[admin] }
-      let(:link_scope) { %w[admin] }
-      let(:unlink_scope) { %w[admin] }
+      let(:read_accessible?) { true }
+      let(:link_accessible?) { true }
+      let(:unlink_accessible?) { true }
 
       before do
-        allow(catalog_access).to receive(:scopes).with("workflows", "read").and_return(read_scope)
-        allow(catalog_access).to receive(:scopes).with("workflows", "link").and_return(link_scope)
-        allow(catalog_access).to receive(:scopes).with("workflows", "unlink").and_return(unlink_scope)
+        allow(catalog_access).to receive(:accessible?).with("workflows", "read", "approval").and_return(read_accessible?)
+        allow(catalog_access).to receive(:accessible?).with("workflows", "link", "approval").and_return(link_accessible?)
+        allow(catalog_access).to receive(:accessible?).with("workflows", "unlink", "approval").and_return(unlink_accessible?)
       end
 
       context "when the user has admin scopes for read, link, and unlink" do
@@ -242,7 +242,7 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
       end
 
       context "when the user does not have admin scopes for read" do
-        let(:read_scope) { [] }
+        let(:read_accessible?) { false }
 
         it "returns false" do
           expect(subject.approval_workflow_check).to eq(false)
@@ -250,7 +250,7 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
       end
 
       context "when the user does not have admin scopes for link" do
-        let(:link_scope) { [] }
+        let(:link_accessible?) { false }
 
         it "returns false" do
           expect(subject.approval_workflow_check).to eq(false)
@@ -258,7 +258,7 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
       end
 
       context "when the user does not have admin scopes for unlink" do
-        let(:unlink_scope) { [] }
+        let(:unlink_accessible?) { false }
 
         it "returns false" do
           expect(subject.approval_workflow_check).to eq(false)

--- a/spec/policies/portfolio_item_policy_spec.rb
+++ b/spec/policies/portfolio_item_policy_spec.rb
@@ -54,12 +54,37 @@ describe PortfolioItemPolicy do
   #   end
   # end
 
-  # describe "#set_approval?" do
-  #   it "delegates to the check for update permissions on the portfolio" do
-  #     expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
-  #     expect(subject.set_approval?).to eq(true)
-  #   end
-  # end
+  describe "#set_approval?" do
+    let(:resource_check) { true }
+    let(:approval_workflow_check) { true }
+
+    before do
+      allow(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(resource_check)
+      allow(rbac_access).to receive(:approval_workflow_check).and_return(approval_workflow_check)
+    end
+
+    context "when the resource check is false" do
+      let(:resource_check) { false }
+
+      it "returns false" do
+        expect(subject.set_approval?).to eq(false)
+      end
+    end
+
+    context "when the approval workflow check is false" do
+      let(:approval_workflow_check) { false }
+
+      it "returns false" do
+        expect(subject.set_approval?).to eq(false)
+      end
+    end
+
+    context "when the resource check and the approval workflow check are true" do
+      it "returns true" do
+        expect(subject.set_approval?).to eq(true)
+      end
+    end
+  end
 
   describe "#destroy?" do
     it "delegates to the check for update permissions on the portfolio" do
@@ -204,6 +229,9 @@ describe PortfolioItemPolicy do
 
       # Other half of Copy
       allow(rbac_access).to receive(:resource_check).with('read', portfolio.id, Portfolio).and_return(true)
+
+      # Set approval
+      allow(rbac_access).to receive(:approval_workflow_check).and_return(true)
     end
 
     it "returns a hash of user capabilities" do
@@ -212,7 +240,7 @@ describe PortfolioItemPolicy do
         "update"       => true,
         "destroy"      => true,
         "copy"         => true,
-        # "set_approval" => true,
+        "set_approval" => true,
         # "edit_survey"  => true
       })
     end

--- a/spec/policies/portfolio_item_policy_spec.rb
+++ b/spec/policies/portfolio_item_policy_spec.rb
@@ -47,12 +47,12 @@ describe PortfolioItemPolicy do
     end
   end
 
-  # describe "#edit_survey?" do
-  #   it "delegates to the check for update permissions on the portfolio" do
-  #     expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
-  #     expect(subject.edit_survey?).to eq(true)
-  #   end
-  # end
+  describe "#edit_survey?" do
+    it "delegates to the check for update permissions on the portfolio" do
+      expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
+      expect(subject.edit_survey?).to eq(true)
+    end
+  end
 
   describe "#set_approval?" do
     let(:resource_check) { true }
@@ -241,7 +241,7 @@ describe PortfolioItemPolicy do
         "destroy"      => true,
         "copy"         => true,
         "set_approval" => true,
-        # "edit_survey"  => true
+        "edit_survey"  => true
       })
     end
   end

--- a/spec/policies/portfolio_policy_spec.rb
+++ b/spec/policies/portfolio_policy_spec.rb
@@ -23,12 +23,37 @@ describe PortfolioPolicy do
     end
   end
 
-  # describe "#set_approval?" do
-  #   it "delegates to the rbac access update check" do
-  #     expect(rbac_access).to receive(:update_access_check).and_return(true)
-  #     expect(subject.set_approval?).to eq(true)
-  #   end
-  # end
+  describe "#set_approval?" do
+    let(:update_access_check) { true }
+    let(:approval_workflow_check) { true }
+
+    before do
+      allow(rbac_access).to receive(:update_access_check).and_return(update_access_check)
+      allow(rbac_access).to receive(:approval_workflow_check).and_return(approval_workflow_check)
+    end
+
+    context "when the update check is false" do
+      let(:update_access_check) { false }
+
+      it "returns false" do
+        expect(subject.set_approval?).to eq(false)
+      end
+    end
+
+    context "when the approval workflow check is false" do
+      let(:approval_workflow_check) { false }
+
+      it "returns false" do
+        expect(subject.set_approval?).to eq(false)
+      end
+    end
+
+    context "when the update check and the approval workflow check are true" do
+      it "returns true" do
+        expect(subject.set_approval?).to eq(true)
+      end
+    end
+  end
 
   describe "#destroy?" do
     it "delegates to the rbac access destroy check" do
@@ -66,6 +91,7 @@ describe PortfolioPolicy do
       allow(rbac_access).to receive(:destroy_access_check).and_return(true)
       allow(rbac_access).to receive(:update_access_check).and_return(true)
       allow(rbac_access).to receive(:admin_access_check).with("portfolios", "update").and_return(true)
+      allow(rbac_access).to receive(:approval_workflow_check).and_return(true)
     end
 
     it "returns a hash of user capabilities" do
@@ -77,7 +103,7 @@ describe PortfolioPolicy do
         "share"        => true,
         "unshare"      => true,
         "show"         => true,
-        # "set_approval" => true
+        "set_approval" => true
       })
     end
   end

--- a/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
@@ -18,6 +18,7 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
     allow(rbac_access).to receive(:permission_check).with('read', Portfolio).and_return(true)
     allow(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
     allow(rbac_access).to receive(:resource_check).with('read', portfolio.id, Portfolio).and_return(true)
+    allow(rbac_access).to receive(:approval_workflow_check).and_return(true)
 
     allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
     allow(catalog_access).to receive(:process).and_return(catalog_access)

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -5,6 +5,11 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
      allow(catalog_access).to receive(:process).and_return(catalog_access)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "read").and_return(true)
+
+     #TODO: Remove this call as it is stubbing out for user_capabilities,
+     # which should not be getting called on this version of the API
+     # When common gem gets updated, this can be removed.
+     allow(catalog_access).to receive(:accessible?).and_return(true)
   end
   let(:service_offering_ref) { "998" }
   let(:service_offering_source_ref) { "568" }

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -10,7 +10,12 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
      allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
      allow(catalog_access).to receive(:process).and_return(catalog_access)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
+
+     #TODO: Remove these calls as it is stubbing out for user_capabilities,
+     # which should not be getting called on this version of the API
+     # When common gem gets updated, these can be removed.
      allow(catalog_access).to receive(:admin_scope?).with("portfolios", "update").and_return(true)
+     allow(catalog_access).to receive(:accessible?).and_return(true)
   end
 
   describe "GET /portfolios/:portfolio_id" do

--- a/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
@@ -37,6 +37,7 @@ describe "v1.1 - PortfolioItemRequests", :type => [:request, :topology, :v1x1] d
           "create"       => true,
           "destroy"      => true,
           "update"       => true,
+          "edit_survey"  => true,
           "set_approval" => true
         )
       end

--- a/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
@@ -10,6 +10,7 @@ describe "v1.1 - PortfolioItemRequests", :type => [:request, :topology, :v1x1] d
     allow(rbac_access).to receive(:resource_check).with('read', portfolio.id, Portfolio).and_return(true)
     allow(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
     allow(rbac_access).to receive(:permission_check).with('read', Portfolio).and_return(true)
+    allow(rbac_access).to receive(:approval_workflow_check).and_return(true)
   end
 
   describe "GET /portfolio_items/:portfolio_item_id #show" do
@@ -32,10 +33,11 @@ describe "v1.1 - PortfolioItemRequests", :type => [:request, :topology, :v1x1] d
 
       it "returns the metadata" do
         expect(json["metadata"]["user_capabilities"]).to eq(
-          "copy"    => true,
-          "create"  => true,
-          "destroy" => true,
-          "update"  => true
+          "copy"         => true,
+          "create"       => true,
+          "destroy"      => true,
+          "update"       => true,
+          "set_approval" => true
         )
       end
     end

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -12,6 +12,7 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
     allow(rbac_access).to receive(:create_access_check).and_return(true)
     allow(rbac_access).to receive(:destroy_access_check).and_return(true)
     allow(rbac_access).to receive(:admin_access_check).with("portfolios", "update").and_return(true)
+    allow(rbac_access).to receive(:approval_workflow_check).and_return(true)
   end
 
   describe "GET /portfolios/:portfolio_id #show" do
@@ -34,13 +35,14 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
 
       it "returns the user capabilities based on the allowed access" do
         expect(json['metadata']['user_capabilities']).to eq(
-          "copy"    => true,
-          "create"  => true,
-          "destroy" => true,
-          "share"   => true,
-          "show"    => true,
-          "unshare" => true,
-          "update"  => true
+          "copy"         => true,
+          "create"       => true,
+          "destroy"      => true,
+          "share"        => true,
+          "show"         => true,
+          "unshare"      => true,
+          "update"       => true,
+          "set_approval" => true
         )
       end
 


### PR DESCRIPTION
`#set_approval?` is the only kinda complicated one here, as it looks like we've determined all we need is `catalog:portfolio:update` permissions for editing the survey.

@mkanoor Let me know if the logic for the `approval_workflow_check` looks right. I figured we didn't need to pass anything in since we don't have the `Workflow` class but the access object should still be able to reconcile the `"workflows"`. According to the rbac-config, `link` and `unlink` don't exist in a non-admin scope, so I thought we could just check if all three of the permissions required have an admin scope, but if that's wrong then I'll change it.

This should finish up https://projects.engineering.redhat.com/browse/SSP-1120