### PR TITLE
Spec cleanup for api paths

### DIFF
--- a/spec/requests/api/v1/application_controller_spec.rb
+++ b/spec/requests/api/v1/application_controller_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe ApplicationController, :type => [:request, :v1x1] do
   end
 
   context "with api version v1" do
-    it "get api/v1/portfolios with tenant" do
-      get("/api/v1/portfolios/#{portfolio_id}", :headers => default_headers)
+    it "get api/catalog/v1/portfolios with tenant" do
+      get("/api/catalog/v1/portfolios/#{portfolio_id}", :headers => default_headers)
       expect(response.status).to eq(302)
       expect(response.headers["Location"]).to eq "#{api_version}/portfolios/#{portfolio_id}"
     end
 
-    it "get api/v1/portfolios without tenant" do
+    it "get api/catalog/v1/portfolios without tenant" do
       headers = { "CONTENT_TYPE" => "application/json" }
 
-      get("/api/v1/portfolios/#{portfolio_id}", :headers => headers)
+      get("/api/catalog/v1/portfolios/#{portfolio_id}", :headers => headers)
       expect(response.status).to eq(302)
       expect(response.headers["Location"]).to eq "#{api_version}/portfolios/#{portfolio_id}"
     end

--- a/spec/requests/api/v1/root_spec.rb
+++ b/spec/requests/api/v1/root_spec.rb
@@ -7,7 +7,7 @@ describe "v1 - root", :type => [:request, :v1x1] do
   end
 
   it "handles redirects correctly" do
-    get("/api/v1/openapi.json")
+    get("/api/catalog/v1/openapi.json")
 
     expect(response.status).to eq(302)
     expect(response.headers["Location"]).to eq("#{api_version}/openapi.json")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ end
 
 ENV['RAILS_ENV'] ||= 'test'
 ENV['APP_NAME'] ||= 'catalog'
+ENV['PATH_PREFIX'] ||= 'api'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/support/v1_helper.rb
+++ b/spec/support/v1_helper.rb
@@ -1,5 +1,5 @@
 module V1Helper
   def api_version
-    "/api/v1.0"
+    File.join('/', ENV['PATH_PREFIX'], ENV['APP_NAME'], 'v1.0')
   end
 end

--- a/spec/support/v1x1_helper.rb
+++ b/spec/support/v1x1_helper.rb
@@ -1,5 +1,5 @@
 module V1x1Helper
   def api_version
-    "/api/v1.1"
+    File.join('/', ENV['PATH_PREFIX'], ENV['APP_NAME'], 'v1.1')
   end
 end


### PR DESCRIPTION
the PATH_PREFIX code wasn't being tested
https://github.com/RedHatInsights/catalog-api/blob/3160c87b08c925aa9029439c1bf2b591d0409a07/config/routes.rb#L9

When the pod is run we always pass in the APP_NAME and PATH_PREFIX
<img width="963" alt="Screen Shot 2020-04-27 at 12 45 59 PM" src="https://user-images.githubusercontent.com/6452699/80398169-32a62a80-8885-11ea-8fbc-901071a1a2b6.png">
