### PR TITLE
Removed getting portfolios/portfolio_items based on tag_id

### DIFF
--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -6,8 +6,6 @@ module Api
       def index
         if params[:portfolio_id]
           collection(Portfolio.find(params.require(:portfolio_id)).portfolio_items)
-        elsif params[:tag_id]
-          collection(Tag.find(params.require(:tag_id)).portfolio_items)
         else
           authorize(PortfolioItem)
           collection(PortfolioItem.all)

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -4,11 +4,7 @@ module Api
       include Api::V1x0::Mixins::IndexMixin
 
       def index
-        if params[:tag_id]
-          collection(Tag.find(params.require(:tag_id)).portfolios)
-        else
-          collection(Portfolio.all)
-        end
+        collection(Portfolio.all)
       end
 
       def create


### PR DESCRIPTION
We don't have any paths in the openapi.json that pass in the
tag_id as a query parameter to get portfolios and portfolio items
based on a given tag_id.