### PR TITLE
Renamed a method to reflect the data it stores

### DIFF
--- a/app/services/group/seed.rb
+++ b/app/services/group/seed.rb
@@ -16,10 +16,6 @@ module Group
       true
     end
 
-    def external_tenant
-      @request.tenant
-    end
-
     def code(status)
       @status = status
     end
@@ -39,6 +35,10 @@ module Group
     end
 
     private
+
+    def external_tenant
+      @request.tenant
+    end
 
     def run_seeding
       seeded = Insights::API::Common::RBAC::Seed.new(Rails.root.join('data', 'rbac_catalog_seed.yml')).process

--- a/app/services/group/seed.rb
+++ b/app/services/group/seed.rb
@@ -16,7 +16,7 @@ module Group
       true
     end
 
-    def tenant
+    def external_tenant
       @request.tenant
     end
 
@@ -43,13 +43,13 @@ module Group
     def run_seeding
       seeded = Insights::API::Common::RBAC::Seed.new(Rails.root.join('data', 'rbac_catalog_seed.yml')).process
       if seeded
-        RbacSeed.create!(:external_tenant => @request.tenant)
+        RbacSeed.create!(:external_tenant => external_tenant)
         code(200)
       end
     end
 
     def mark_as_seeded
-      RbacSeed.find_or_create_by(:external_tenant => @request.tenant) if @seeded.data.present?
+      RbacSeed.find_or_create_by(:external_tenant => external_tenant) if @seeded.data.present?
     end
 
     def add_user_to_catalog_admin_group


### PR DESCRIPTION
We store the external_tenant in the request, changed the
method name to external_tenant instead of tenant.

The account_number which we call external_tenant in our tenant object is retrieved from here
https://github.com/RedHatInsights/insights-api-common-rails/blob/770bb10e8e681ddcc37c08545040a41aa0ed5a2a/lib/insights/api/common/tenant.rb#L10