### PR TITLE
Removed the show method for tags

### DIFF
--- a/app/controllers/api/v1x0/tags_controller.rb
+++ b/app/controllers/api/v1x0/tags_controller.rb
@@ -24,12 +24,6 @@ module Api
         end
       end
 
-      def show
-        tag = Tag.find(params.require(:id))
-
-        render :json => tag
-      end
-
       private
 
       def instance_link(instance)


### PR DESCRIPTION
We dont have any paths in openapi.json that allow us to fetch
individual tag given a ID