### PR TITLE
Removed methods that are not getting called for tagging

### DIFF
--- a/config/initializers/01_tag_presentation.rb
+++ b/config/initializers/01_tag_presentation.rb
@@ -1,10 +1,4 @@
 module TagPresentation
-  module PresentationNameMethod
-    def presentation_name
-      "Tag".freeze
-    end
-  end
-
   module TagAsJson
     def as_json(*args)
       super.tap do |json|
@@ -13,20 +7,10 @@ module TagPresentation
     end
   end
 
-  module TaggingAsJson
-    def as_json(*args)
-      super.tap do |json|
-        json["tag"] = tag.to_tag_string
-      end
-    end
-  end
-
   module ActAsTaggableOnEnhancements
     def acts_as_taggable_on
       super
       klass = tagging_relation_name.to_s.singularize.classify.safe_constantize
-      klass.singleton_class.prepend(TagPresentation::PresentationNameMethod)
-      klass.prepend(TagPresentation::TaggingAsJson)
     end
   end
 end


### PR DESCRIPTION
the as_json method is defined in 2 different modules only one of them gets called when we fetch the tags.

TagAsJson#as_json
TaggingAsJson#as_json 

I have tested this with **GET /portfolios/{id}/tags** and only the TagsAsJson#as_json gets called.
It might be because the perpend of TagsAsJson happens last.