### PR TITLE
Truncate copied portfolio names to 64 characters

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -23,10 +23,6 @@ class Portfolio < ApplicationRecord
     portfolio_items << portfolio_item
   end
 
-  def copy_name
-    Catalog::NameAdjust.create_copy_name(name, Portfolio.all.pluck(:name), MAX_NAME_LENGTH)
-  end
-
   def metadata
     {:user_capabilities => user_capabilities,
      :shared            => self.access_control_entries.any?}

--- a/app/services/api/v1x0/catalog/copy_portfolio.rb
+++ b/app/services/api/v1x0/catalog/copy_portfolio.rb
@@ -20,7 +20,7 @@ module Api
 
         def make_copy
           @portfolio.dup.tap do |new_portfolio|
-            new_portfolio.name = @name || ::Catalog::NameAdjust.create_copy_name(@portfolio.name, Portfolio.all.pluck(:name))
+            new_portfolio.name = @name || @portfolio.copy_name
 
             duplicate_icon(@portfolio, new_portfolio) if @portfolio.icon_id.present?
 

--- a/app/services/api/v1x0/catalog/copy_portfolio.rb
+++ b/app/services/api/v1x0/catalog/copy_portfolio.rb
@@ -20,7 +20,7 @@ module Api
 
         def make_copy
           @portfolio.dup.tap do |new_portfolio|
-            new_portfolio.name = @name || @portfolio.copy_name
+            new_portfolio.name = @name || ::Catalog::NameAdjust.create_copy_name(@portfolio.name, Portfolio.all.pluck(:name), Portfolio::MAX_NAME_LENGTH)
 
             duplicate_icon(@portfolio, new_portfolio) if @portfolio.icon_id.present?
 

--- a/lib/catalog/name_adjust.rb
+++ b/lib/catalog/name_adjust.rb
@@ -5,16 +5,12 @@ module Catalog
     def self.create_copy_name(original_name, names)
       original_name.sub!(COPY_REGEX, '')
       names.select! { |name| name.match("#{COPY_REGEX} #{original_name}") }
-
-      if names.any?
-        num = get_index(names)
-        "Copy (#{num + 1}) of " + original_name
-      else
-        "Copy of " + original_name
-      end
+      copy_name(original_name, names).truncate(64)
     end
 
     class << self
+      private
+
       def get_index(names)
         ####
         # This chain of maps takes a match for "Copy (#) of #{name}" and returns the highest index.
@@ -30,6 +26,15 @@ module Catalog
           .compact
           .map { |match| match.gsub(/[()]/, "").to_i }
           .max || 0
+      end
+
+      def copy_name(original_name, names)
+        if names.any?
+          num = get_index(names)
+          "Copy (#{num + 1}) of " + original_name
+        else
+          "Copy of " + original_name
+        end
       end
     end
   end

--- a/lib/catalog/name_adjust.rb
+++ b/lib/catalog/name_adjust.rb
@@ -2,10 +2,11 @@ module Catalog
   class NameAdjust
     COPY_REGEX = '^Copy (\(\d\) )?of'.freeze
 
-    def self.create_copy_name(original_name, names)
+    def self.create_copy_name(original_name, names, max_length = nil)
       original_name.sub!(COPY_REGEX, '')
       names.select! { |name| name.match("#{COPY_REGEX} #{original_name}") }
-      copy_name(original_name, names).truncate(64)
+      copied_name = copy_name(original_name, names)
+      max_length ? copied_name.truncate(max_length) : copied_name
     end
 
     class << self

--- a/spec/lib/catalog/name_adjust_spec.rb
+++ b/spec/lib/catalog/name_adjust_spec.rb
@@ -7,10 +7,10 @@ describe Catalog::NameAdjust do
       let(:names) { [item_name.to_s, "Copy of #{item_name}", "Copy (1) of #{item_name}"] }
 
       context "when the copied name would be greater than 64 characters" do
-        let(:item_name) { "CopiedNamesThatAreGreaterThanSixtyFourCharactersLongWillBeTruncated"}
+        let(:item_name) { "CopiedNamesThatAreGreaterThanSixtyFourCharactersLongWillBeTruncated" }
 
         it "returns the highest index in the array truncated to 64 characters" do
-          expect(create_copy_name).to eq "Copy (2) of #{item_name}".truncate(64)
+          expect(create_copy_name).to eq("Copy (2) of #{item_name}".truncate(64))
         end
       end
 
@@ -18,7 +18,7 @@ describe Catalog::NameAdjust do
         let(:names) { [item_name.to_s, "Copy of #{item_name}", "Copy (1) of #{item_name}"] }
 
         it "returns the highest index in the array" do
-          expect(create_copy_name).to eq "Copy (2) of #{item_name}"
+          expect(create_copy_name).to eq("Copy (2) of #{item_name}")
         end
       end
     end
@@ -27,17 +27,17 @@ describe Catalog::NameAdjust do
       let(:names) { [item_name.to_s, "anotheritem"] }
 
       context "when the copied name would be greater than 64 characters" do
-        let(:item_name) { "CopiedNamesThatAreGreaterThanSixtyFourCharactersLongWillBeTruncated"}
+        let(:item_name) { "CopiedNamesThatAreGreaterThanSixtyFourCharactersLongWillBeTruncated" }
 
         it "returns the right copy of string truncated to 64 characters" do
-          expect(create_copy_name).to eq "Copy of #{item_name}".truncate(64)
+          expect(create_copy_name).to eq("Copy of #{item_name}".truncate(64))
         end
       end
 
       context "when the copied name is less than 64 characters" do
 
         it "returns the right copy of string" do
-          expect(create_copy_name).to eq "Copy of #{item_name}"
+          expect(create_copy_name).to eq("Copy of #{item_name}")
         end
       end
     end

--- a/spec/lib/catalog/name_adjust_spec.rb
+++ b/spec/lib/catalog/name_adjust_spec.rb
@@ -6,16 +6,39 @@ describe Catalog::NameAdjust do
     context "when passing in multiple Copy Names" do
       let(:names) { [item_name.to_s, "Copy of #{item_name}", "Copy (1) of #{item_name}"] }
 
-      it "returns the highest index in the array" do
-        expect(create_copy_name).to eq "Copy (2) of #{item_name}"
+      context "when the copied name would be greater than 64 characters" do
+        let(:item_name) { "CopiedNamesThatAreGreaterThanSixtyFourCharactersLongWillBeTruncated"}
+
+        it "returns the highest index in the array truncated to 64 characters" do
+          expect(create_copy_name).to eq "Copy (2) of #{item_name}".truncate(64)
+        end
+      end
+
+      context "when the copied name is less than 64 characters" do
+        let(:names) { [item_name.to_s, "Copy of #{item_name}", "Copy (1) of #{item_name}"] }
+
+        it "returns the highest index in the array" do
+          expect(create_copy_name).to eq "Copy (2) of #{item_name}"
+        end
       end
     end
 
     context "when there are not any other copies" do
       let(:names) { [item_name.to_s, "anotheritem"] }
 
-      it "returns the right copy of string" do
-        expect(create_copy_name).to eq "Copy of #{item_name}"
+      context "when the copied name would be greater than 64 characters" do
+        let(:item_name) { "CopiedNamesThatAreGreaterThanSixtyFourCharactersLongWillBeTruncated"}
+
+        it "returns the right copy of string truncated to 64 characters" do
+          expect(create_copy_name).to eq "Copy of #{item_name}".truncate(64)
+        end
+      end
+
+      context "when the copied name is less than 64 characters" do
+
+        it "returns the right copy of string" do
+          expect(create_copy_name).to eq "Copy of #{item_name}"
+        end
       end
     end
   end

--- a/spec/lib/catalog/name_adjust_spec.rb
+++ b/spec/lib/catalog/name_adjust_spec.rb
@@ -1,20 +1,22 @@
 describe Catalog::NameAdjust do
   describe "#create_copy_name" do
     let(:item_name) { "MyItem" }
+    let(:max_length) { 20 }
     let(:create_copy_name) { described_class.create_copy_name(item_name, names) }
 
     context "when passing in multiple Copy Names" do
       let(:names) { [item_name.to_s, "Copy of #{item_name}", "Copy (1) of #{item_name}"] }
 
-      context "when the copied name would be greater than 64 characters" do
-        let(:item_name) { "CopiedNamesThatAreGreaterThanSixtyFourCharactersLongWillBeTruncated" }
+      context "when a max_length is provided" do
+        let(:item_name) { "SomeLongItemName" }
+        let(:create_copy_name) { described_class.create_copy_name(item_name, names, max_length) }
 
-        it "returns the highest index in the array truncated to 64 characters" do
-          expect(create_copy_name).to eq("Copy (2) of #{item_name}".truncate(64))
+        it "returns the highest index in the array truncated to the max_length" do
+          expect(create_copy_name).to eq("Copy (2) of SomeL...")
         end
       end
 
-      context "when the copied name is less than 64 characters" do
+      context "when a max_length is not provided" do
         let(:names) { [item_name.to_s, "Copy of #{item_name}", "Copy (1) of #{item_name}"] }
 
         it "returns the highest index in the array" do
@@ -26,15 +28,16 @@ describe Catalog::NameAdjust do
     context "when there are not any other copies" do
       let(:names) { [item_name.to_s, "anotheritem"] }
 
-      context "when the copied name would be greater than 64 characters" do
-        let(:item_name) { "CopiedNamesThatAreGreaterThanSixtyFourCharactersLongWillBeTruncated" }
+      context "when a max_length is provided" do
+        let(:item_name) { "SomeLongItemName" }
+        let(:create_copy_name) { described_class.create_copy_name(item_name, names, max_length) }
 
-        it "returns the right copy of string truncated to 64 characters" do
-          expect(create_copy_name).to eq("Copy of #{item_name}".truncate(64))
+        it "returns the right copy of string truncated to the max_length" do
+          expect(create_copy_name).to eq("Copy of SomeLongI...")
         end
       end
 
-      context "when the copied name is less than 64 characters" do
+      context "when a max_length is not provided" do
 
         it "returns the right copy of string" do
           expect(create_copy_name).to eq("Copy of #{item_name}")

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -132,7 +132,6 @@ describe Portfolio do
   end
 
   describe "#copy_name" do
-
     it "calls create_copy_name" do
       expect(Catalog::NameAdjust).to receive(:create_copy_name).with(portfolio.name, [portfolio.name], 64)
       portfolio.copy_name

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -130,11 +130,4 @@ describe Portfolio do
       expect(Portfolio.taggable?).to be_truthy
     end
   end
-
-  describe "#copy_name" do
-    it "calls create_copy_name" do
-      expect(Catalog::NameAdjust).to receive(:create_copy_name).with(portfolio.name, [portfolio.name], 64)
-      portfolio.copy_name
-    end
-  end
 end

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -130,4 +130,12 @@ describe Portfolio do
       expect(Portfolio.taggable?).to be_truthy
     end
   end
+
+  describe "#copy_name" do
+
+    it "calls create_copy_name" do
+      expect(Catalog::NameAdjust).to receive(:create_copy_name).with(portfolio.name, [portfolio.name], 64)
+      portfolio.copy_name
+    end
+  end
 end


### PR DESCRIPTION
Fixes: #717 