### PR TITLE
The yield should return the current user context

### DIFF
--- a/app/policies/user_context.rb
+++ b/app/policies/user_context.rb
@@ -46,7 +46,7 @@ class UserContext
   def self.with_user_context(user_context)
     saved_user_context   = Thread.current[:user_context]
     self.current_user_context = user_context
-    yield
+    yield current_user_context
   ensure
     Thread.current[:user_context] = saved_user_context
   end

--- a/spec/policies/user_context_spec.rb
+++ b/spec/policies/user_context_spec.rb
@@ -23,7 +23,8 @@ describe UserContext, [:type => :current_forwardble] do
   describe ".with_user_context" do
     it "uses the given user" do
       expect(Thread.current[:user_context]).to be_nil
-      UserContext.with_user_context(subject) do
+      UserContext.with_user_context(subject) do |uc|
+        expect(uc).to eq(subject)
         expect(Thread.current[:user_context]).not_to be_nil
       end
       expect(Thread.current[:user_context]).to be_nil


### PR DESCRIPTION
Discovered this while debugging an issue. The with_user_context
should be returning the current value akin to
https://github.com/RedHatInsights/insights-api-common-rails/blob/770bb10e8e681ddcc37c08545040a41aa0ed5a2a/lib/insights/api/common/request.rb#L49