### PR TITLE
Refactor common resource check

### DIFF
--- a/app/controllers/api/v1x0/service_plans_controller.rb
+++ b/app/controllers/api/v1x0/service_plans_controller.rb
@@ -14,6 +14,9 @@ module Api
       end
 
       def create
+        portfolio = PortfolioItem.find(params.require(:portfolio_item_id)).portfolio
+        authorize(portfolio, :policy_class => ServicePlanPolicy)
+
         svc = Catalog::ImportServicePlans.new(params.require(:portfolio_item_id))
         render :json => svc.process.json
       end
@@ -41,12 +44,15 @@ module Api
 
       def update_modified
         plan = ServicePlan.find(params.require(:service_plan_id))
+        authorize(plan)
         plan.update!(:modified => params.require(:modified))
 
         render :json => plan.modified
       end
 
       def reset
+        service_plan = ServicePlan.find(params.require(:service_plan_id))
+        authorize(service_plan)
         status = Catalog::ServicePlanReset.new(params.require(:service_plan_id)).process.status
         head status
       end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -41,6 +41,10 @@ class ApplicationPolicy
 
   private
 
+  def update_portfolio_check
+    rbac_access.resource_check("update", portfolio_id, Portfolio)
+  end
+
   def rbac_access
     @rbac_access ||= Catalog::RBAC::Access.new(@user, @record)
   end

--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -4,16 +4,15 @@ class PortfolioItemPolicy < ApplicationPolicy
   end
 
   def create?
-    portfolio_id = @record.class == Portfolio ? @record.id : @record.portfolio_id
-    rbac_access.resource_check('update', portfolio_id, Portfolio)
+    update_portfolio_check
   end
 
   def update?
-    rbac_access.resource_check('update', @record.portfolio_id, Portfolio)
+    update_portfolio_check
   end
 
   def destroy?
-    rbac_access.resource_check('update', @record.portfolio_id, Portfolio)
+    update_portfolio_check
   end
 
   def copy?
@@ -28,11 +27,11 @@ class PortfolioItemPolicy < ApplicationPolicy
   end
 
   def edit_survey?
-    rbac_access.resource_check('update', @record.portfolio_id, Portfolio)
+    update_portfolio_check
   end
 
   def set_approval?
-    rbac_access.resource_check('update', @record.portfolio_id, Portfolio) &&
+    update_portfolio_check &&
       rbac_access.approval_workflow_check
   end
 
@@ -41,6 +40,10 @@ class PortfolioItemPolicy < ApplicationPolicy
   def can_read_and_update_destination?(destination_id)
     rbac_access.resource_check('read', destination_id, Portfolio) &&
       rbac_access.resource_check('update', destination_id, Portfolio)
+  end
+
+  def portfolio_id
+    @record.class == Portfolio ? @record.id : @record.portfolio_id
   end
 
   class Scope < Scope

--- a/app/policies/service_plan_policy.rb
+++ b/app/policies/service_plan_policy.rb
@@ -4,8 +4,14 @@ class ServicePlanPolicy < ApplicationPolicy
   end
 
   def update_modified?
-    rbac_access.resource_check("update", @record.portfolio_item.portfolio_id, Portfolio)
+    update_portfolio_check
   end
 
   alias reset? update_modified?
+
+  private
+
+  def portfolio_id
+    @record.portfolio_item.portfolio_id
+  end
 end

--- a/app/policies/service_plan_policy.rb
+++ b/app/policies/service_plan_policy.rb
@@ -1,0 +1,11 @@
+class ServicePlanPolicy < ApplicationPolicy
+  def create?
+    rbac_access.resource_check("update", @record.id, Portfolio)
+  end
+
+  def update_modified?
+    rbac_access.resource_check("update", @record.portfolio_item.portfolio_id, Portfolio)
+  end
+
+  alias reset? update_modified?
+end

--- a/spec/policies/service_plan_policy_spec.rb
+++ b/spec/policies/service_plan_policy_spec.rb
@@ -1,0 +1,41 @@
+describe ServicePlanPolicy do
+  let(:portfolio) { create(:portfolio) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio) }
+  let(:service_plan) { create(:service_plan, :portfolio_item => portfolio_item) }
+
+  let(:user_context) { UserContext.new("current_request", "params") }
+  let(:rbac_access) { instance_double(Catalog::RBAC::Access) }
+
+  subject { described_class.new(user_context, service_plan) }
+
+  before do
+    allow(Catalog::RBAC::Access).to receive(:new).with(user_context, service_plan).and_return(rbac_access)
+  end
+
+  describe "#create?" do
+    subject { described_class.new(user_context, portfolio) }
+
+    before do
+      allow(Catalog::RBAC::Access).to receive(:new).with(user_context, portfolio).and_return(rbac_access)
+    end
+
+    it "delegates to the rbac_access resource check with the portfolio" do
+      expect(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(true)
+      expect(subject.create?).to eq(true)
+    end
+  end
+
+  describe "#update_modified?" do
+    it "delegates to the rbac_access resource check" do
+      expect(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(true)
+      expect(subject.update_modified?).to eq(true)
+    end
+  end
+
+  describe "#reset?" do
+    it "delegates to the rbac_access resource check" do
+      expect(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(true)
+      expect(subject.reset?).to eq(true)
+    end
+  end
+end

--- a/spec/requests/api/v1.0/service_plans_spec.rb
+++ b/spec/requests/api/v1.0/service_plans_spec.rb
@@ -122,8 +122,12 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
 
   describe "#create" do
     context "when there is not a service_plan for the portfolio_item specified" do
-      before do
+      subject do
         post "#{api_version}/service_plans", :headers => default_headers, :params => {:portfolio_item_id => portfolio_item_without_service_plan.id.to_s}
+      end
+
+      before do |example|
+        subject unless example.metadata[:subject_inside]
       end
 
       it "pulls in the service plans" do
@@ -137,6 +141,8 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
       it "returns the base schema in the :create_json_schema field" do
         expect(json.first["create_json_schema"]).to eq JSON.parse(modified_schema)
       end
+
+      it_behaves_like "action that tests authorization", :create?, ServicePlan
     end
 
     context "when a service_plan already exists for the portfolio_item specified" do
@@ -219,8 +225,12 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
   end
 
   describe "#update_modified" do
-    before do
+    subject do
       patch "#{api_version}/service_plans/#{service_plan.id}/modified", :headers => default_headers, :params => params
+    end
+
+    before do |example|
+      subject unless example.metadata[:subject_inside]
     end
 
     context "when patching the modified schema with a valid schema" do
@@ -233,6 +243,8 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
       it "returns the newly modified schema from the service_plan" do
         expect(json).to eq params[:modified]
       end
+
+      it_behaves_like "action that tests authorization", :update_modified?, ServicePlan
     end
 
     context "when patching in a bad schema" do
@@ -251,30 +263,38 @@ describe "v1.0 - ServicePlansRequests", :type => [:request, :v1, :topology] do
       it "fails validation" do
         expect(first_error_detail).to match(/Catalog::InvalidSurvey/)
       end
+
+      it_behaves_like "action that tests authorization", :update_modified?, ServicePlan
     end
   end
 
   describe "#reset" do
+    subject { post "#{api_version}/service_plans/#{service_plan.id}/reset", :headers => default_headers }
+
     context "when there is a modified schema" do
-      before do
-        post "#{api_version}/service_plans/#{service_plan.id}/reset", :headers => default_headers
+      before do |example|
+        subject unless example.metadata[:subject_inside]
       end
 
       it "returns a 200" do
         expect(response).to have_http_status :ok
       end
+
+      it_behaves_like "action that tests authorization", :reset?, ServicePlan
     end
 
     context "when there is not a modified schema" do
-      before do
+      before do |example|
         service_plan.update!(:modified => nil)
+
+        subject unless example.metadata[:subject_inside]
       end
 
       it "returns a 204" do
-        post "#{api_version}/service_plans/#{service_plan.id}/reset", :headers => default_headers
-
         expect(response).to have_http_status :no_content
       end
+
+      it_behaves_like "action that tests authorization", :reset?, ServicePlan
     end
   end
 end


### PR DESCRIPTION
Built on top of #722, so wait to merge until that is in.

This adds a method called `#update_portfolio_check` onto the `ApplicationPolicy` for use by child policies that handles the passing of the parameters and ends up calling the children's implementation of `#portfolio_id` to figure out how to get that piece of information since it differs based on the object.

@mkanoor Please review, will be simpler after #722, of course.