### PR TITLE
Catalog didn't support error state in Approval Request

### DIFF
--- a/app/models/approval_request.rb
+++ b/app/models/approval_request.rb
@@ -1,6 +1,6 @@
 class ApprovalRequest < ApplicationRecord
   acts_as_tenant(:tenant)
-  enum :state => [:undecided, :approved, :denied, :canceled]
+  enum :state => [:undecided, :approved, :denied, :canceled, :error]
 
   belongs_to :order_item
 

--- a/app/services/api/v1x0/catalog/approval_transition.rb
+++ b/app/services/api/v1x0/catalog/approval_transition.rb
@@ -62,8 +62,8 @@ module Api
 
         def mark_errored
           finalize_order
-          @order_item.update_message("error", "Order #{@order_item.order_id} has approval errors")
-          Rails.logger.error("Order #{@order_item.order_id} has failed")
+          @order_item.update_message("error", "Order #{@order_item.order_id} has approval errors. #{reasons}")
+          Rails.logger.error("Order #{@order_item.order_id} has failed. #{reasons}")
         end
 
         def finalize_order
@@ -85,6 +85,11 @@ module Api
 
         def error?
           @approvals.present? && @approvals.any? { |req| req.state == "error" }
+        end
+
+        def reasons
+          return "" unless @approvals.present?
+          @approvals.collect(&:reason).compact.join('.')
         end
       end
     end

--- a/app/services/api/v1x0/catalog/approval_transition.rb
+++ b/app/services/api/v1x0/catalog/approval_transition.rb
@@ -89,7 +89,7 @@ module Api
 
         def reasons
           return "" unless @approvals.present?
-          @approvals.collect(&:reason).compact.join('.')
+          @approvals.collect(&:reason).compact.join('. ')
         end
       end
     end

--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -3181,9 +3181,10 @@
               "undecided",
               "approved",
               "denied",
-              "canceled"
+              "canceled",
+              "error"
             ],
-            "description": "The state of the approval request (approved, denied, undecided, canceled)",
+            "description": "The state of the approval request (approved, denied, undecided, canceled, error)",
             "readOnly": true
           }
         }

--- a/spec/controllers/internal/v1x0/notify_controller_spec.rb
+++ b/spec/controllers/internal/v1x0/notify_controller_spec.rb
@@ -8,9 +8,28 @@ describe Internal::V1x0::NotifyController, :type => [:request, :v1_internal] do
       allow(approval_transition).to receive(:process)
     end
 
-    it "returns a 200" do
-      post "#{api_version}/notify/approval_request/123", :headers => default_headers, :params => {:payload => {:decision => "approved", :request_id => "123"}, :message => "request_finished"}
-      expect(response.status).to eq(200)
+    context "approved decision" do
+      let(:params) do
+        { :payload => {:decision => "approved", :request_id => "123"},
+          :message => 'request_finished' }
+      end
+
+      it "returns a 200" do
+        post "#{api_version}/notify/approval_request/123", :headers => default_headers, :params => params
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "error decision" do
+      let(:params) do
+        { :payload => {:decision => "error", :reason => "Failed to send email", :request_id => "123"},
+          :message => 'request_finished' }
+      end
+
+      it "returns a 200" do
+        post "#{api_version}/notify/approval_request/123", :headers => default_headers, :params => params
+        expect(response.status).to eq(200)
+      end
     end
   end
 

--- a/spec/services/api/v1.0/catalog/approval_transition_spec.rb
+++ b/spec/services/api/v1.0/catalog/approval_transition_spec.rb
@@ -129,14 +129,14 @@ describe Api::V1x0::Catalog::ApprovalTransition do
 
     context "when the approval fails" do
       before do
-        approval.update(:state => "error")
+        approval.update(:state => "error", :reason => 'Error Sending Email')
       end
 
       it "fails the order" do
         order_item_transition.process
         msg = order_item.progress_messages.last
         expect(msg.level).to eq "error"
-        expect(msg.message).to eq "Order #{order.id} has approval errors"
+        expect(msg.message).to match(/Error Sending Email/)
       end
     end
   end

--- a/spec/services/api/v1.0/catalog/approval_transition_spec.rb
+++ b/spec/services/api/v1.0/catalog/approval_transition_spec.rb
@@ -126,5 +126,18 @@ describe Api::V1x0::Catalog::ApprovalTransition do
         expect(msg.message).to eq "Error Submitting Order #{order.id}, #{topo_ex.message}"
       end
     end
+
+    context "when the approval fails" do
+      before do
+        approval.update(:state => "error")
+      end
+
+      it "fails the order" do
+        order_item_transition.process
+        msg = order_item.progress_messages.last
+        expect(msg.level).to eq "error"
+        expect(msg.message).to eq "Order #{order.id} has approval errors"
+      end
+    end
   end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1497

Approval had added an error state
https://github.com/RedHatInsights/approval-api/blob/8153ab2f4fcae6e9e1d9649ac516c4b5842b715b/public/doc/openapi-3-v1.2.json#L1224
Which was never implemented in Catalog


<img width="1067" alt="Screen Shot 2020-05-05 at 12 46 50 PM" src="https://user-images.githubusercontent.com/6452699/81092454-9c9a8180-8ece-11ea-9870-12d73cbc42ab.png">
