### PR TITLE
Added validation for state in order and order items

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,7 +6,7 @@ class Order < ApplicationRecord
   acts_as_tenant(:tenant)
   attribute :state, :string, :default => 'Created'
   validates_inclusion_of :state,
-    :in => ["Created", "Approval Pending", "Ordered", "Failed", "Completed", "Canceled"].freeze,
+    :in => ["Approval Pending", "Canceled", "Completed", "Created", "Failed", "Ordered"].freeze,
     :message => "state %{value} is not included in the list"
 
   default_scope { kept.order(:created_at => :desc) }

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -4,6 +4,10 @@ class Order < ApplicationRecord
   include Api::V1x0::Catalog::DiscardRestore
   destroy_dependencies :order_items
   acts_as_tenant(:tenant)
+  attribute :state, :string, :default => 'Created'
+  validates_inclusion_of :state,
+    :in => ["Created", "Approval Pending", "Ordered", "Failed", "Completed", "Canceled"].freeze,
+    :message => "state %{value} is not included in the list"
 
   default_scope { kept.order(:created_at => :desc) }
 

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -3,6 +3,10 @@ class OrderItem < ApplicationRecord
   include Discard::Model
   include Api::V1x0::Catalog::DiscardRestore
   destroy_dependencies :progress_messages
+  attribute :state, :string, :default => 'Created'
+  validates_inclusion_of :state,
+    :in => ["Created", "Approval Pending", "Ordered", "Failed", "Completed", "Approved", "Denied", "Canceled"].freeze,
+    :message => "state %{value} is not included in the list"
 
   acts_as_tenant(:tenant)
 

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -5,7 +5,7 @@ class OrderItem < ApplicationRecord
   destroy_dependencies :progress_messages
   attribute :state, :string, :default => 'Created'
   validates_inclusion_of :state,
-    :in => ["Created", "Approval Pending", "Ordered", "Failed", "Completed", "Approved", "Denied", "Canceled"].freeze,
+    :in => ["Approval Pending", "Approved", "Canceled", "Completed", "Created", "Denied", "Failed", "Ordered"].freeze,
     :message => "state %{value} is not included in the list"
 
   acts_as_tenant(:tenant)


### PR DESCRIPTION
Based on the comments in 
https://github.com/RedHatInsights/catalog-api/pull/728#discussion_r420296076

Added validation and default value for state attribute in order and order_item.

Had thought of using enum but we have a value of "Approval Pending" so decided to use a list of valid string values.