### PR TITLE
Handle pundit exceptions better

### DIFF
--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -123,6 +123,11 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
 
         expect(response).to have_http_status(:forbidden)
       end
+
+      it "uses a custom message" do
+        post "#{api_version}/portfolios", :headers => default_headers, :params => valid_attributes
+        expect(first_error_detail).to eq("You are not authorized to create this portfolio")
+      end
     end
   end
 
@@ -145,6 +150,11 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
       it 'fails updating a portfolio' do
         patch "#{api_version}/portfolios/#{portfolio1.id}", :headers => default_headers, :params => updated_attributes
         expect(response).to have_http_status(:forbidden)
+      end
+
+      it "uses a custom message" do
+        patch "#{api_version}/portfolios/#{portfolio1.id}", :headers => default_headers, :params => updated_attributes
+        expect(first_error_detail).to eq("You are not authorized to update this portfolio")
       end
     end
   end


### PR DESCRIPTION
I implemented a change on the common side that allows us to hook into the common `rescue_from` process if we need to. [That PR is here](https://github.com/RedHatInsights/insights-api-common-rails/pull/185).

The Gemfile change is obviously going to break Travis for now, it's more just a placeholder to remind us not to merge this until it gets updated on common and then we can change the version here.

https://projects.engineering.redhat.com/browse/SSP-1336