### PR TITLE
Changed error messages to debug

### DIFF
--- a/app/policies/order_policy.rb
+++ b/app/policies/order_policy.rb
@@ -18,7 +18,7 @@ class OrderPolicy < ApplicationPolicy
       elsif access_scopes.include?('user')
         scope.by_owner
       else
-        Rails.logger.debug("Error in scope search for #{scope.table_name}")
+        Rails.logger.debug("Scope search for #{scope.table_name}")
         Rails.logger.debug("Scope does not include admin, group, or user. List of scopes: #{access_scopes}")
         raise Catalog::NotAuthorized, "Not Authorized for #{scope.table_name}"
       end

--- a/app/policies/order_policy.rb
+++ b/app/policies/order_policy.rb
@@ -18,8 +18,8 @@ class OrderPolicy < ApplicationPolicy
       elsif access_scopes.include?('user')
         scope.by_owner
       else
-        Rails.logger.error("Error in scope search for #{scope.table_name}")
-        Rails.logger.error("Scope does not include admin, group, or user. List of scopes: #{access_scopes}")
+        Rails.logger.debug("Error in scope search for #{scope.table_name}")
+        Rails.logger.debug("Scope does not include admin, group, or user. List of scopes: #{access_scopes}")
         raise Catalog::NotAuthorized, "Not Authorized for #{scope.table_name}"
       end
     end

--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -60,7 +60,7 @@ class PortfolioItemPolicy < ApplicationPolicy
       elsif access_scopes.include?('user')
         scope.by_owner
       else
-        Rails.logger.debug("Error in scope search for #{scope.table_name}")
+        Rails.logger.debug("Scope search for #{scope.table_name}")
         Rails.logger.debug("Scope does not include admin, group, or user. List of scopes: #{access_scopes}")
         raise Catalog::NotAuthorized, "Not Authorized for #{scope.table_name}"
       end

--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -60,8 +60,8 @@ class PortfolioItemPolicy < ApplicationPolicy
       elsif access_scopes.include?('user')
         scope.by_owner
       else
-        Rails.logger.error("Error in scope search for #{scope.table_name}")
-        Rails.logger.error("Scope does not include admin, group, or user. List of scopes: #{access_scopes}")
+        Rails.logger.debug("Error in scope search for #{scope.table_name}")
+        Rails.logger.debug("Scope does not include admin, group, or user. List of scopes: #{access_scopes}")
         raise Catalog::NotAuthorized, "Not Authorized for #{scope.table_name}"
       end
     end

--- a/app/policies/portfolio_policy.rb
+++ b/app/policies/portfolio_policy.rb
@@ -37,8 +37,8 @@ class PortfolioPolicy < ApplicationPolicy
       elsif access_scopes.include?('user')
         scope.by_owner
       else
-        Rails.logger.error("Error in scope search for #{scope.table_name}")
-        Rails.logger.error("Scope does not include admin, group, or user. List of scopes: #{access_scopes}")
+        Rails.logger.debug("Error in scope search for #{scope.table_name}")
+        Rails.logger.debug("Scope does not include admin, group, or user. List of scopes: #{access_scopes}")
         raise Catalog::NotAuthorized, "Not Authorized for #{scope.table_name}"
       end
     end

--- a/app/policies/portfolio_policy.rb
+++ b/app/policies/portfolio_policy.rb
@@ -37,7 +37,7 @@ class PortfolioPolicy < ApplicationPolicy
       elsif access_scopes.include?('user')
         scope.by_owner
       else
-        Rails.logger.debug("Error in scope search for #{scope.table_name}")
+        Rails.logger.debug("Scope search for #{scope.table_name}")
         Rails.logger.debug("Scope does not include admin, group, or user. List of scopes: #{access_scopes}")
         raise Catalog::NotAuthorized, "Not Authorized for #{scope.table_name}"
       end

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -33,7 +33,7 @@ module Catalog
         elsif scopes.include?("user")
           @record.owner == @user_context.request.user.username
         else
-          Rails.logger.debug("Error in resource checking for verb: #{verb}, object id: #{id}, object class: #{@record.class}, class to check scopes against: #{klass}")
+          Rails.logger.debug("Resource checking for verb: #{verb}, object id: #{id}, object class: #{@record.class}, class to check scopes against: #{klass}")
           Rails.logger.debug("Scope does not include admin, group, or user. List of scopes: #{scopes}")
           false
         end

--- a/lib/catalog/rbac/access.rb
+++ b/lib/catalog/rbac/access.rb
@@ -33,8 +33,8 @@ module Catalog
         elsif scopes.include?("user")
           @record.owner == @user_context.request.user.username
         else
-          Rails.logger.error("Error in resource checking for verb: #{verb}, object id: #{id}, object class: #{@record.class}, class to check scopes against: #{klass}")
-          Rails.logger.error("Scope does not include admin, group, or user. List of scopes: #{scopes}")
+          Rails.logger.debug("Error in resource checking for verb: #{verb}, object id: #{id}, object class: #{@record.class}, class to check scopes against: #{klass}")
+          Rails.logger.debug("Scope does not include admin, group, or user. List of scopes: #{scopes}")
           false
         end
       end

--- a/spec/lib/catalog/rbac/access_spec.rb
+++ b/spec/lib/catalog/rbac/access_spec.rb
@@ -121,8 +121,10 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
         let(:scopes) { [] }
 
         it "logs messages" do
-          expect(Rails.logger).to receive(:debug).thrice
+          allow(Rails.logger).to receive(:debug)
           subject.send(method, *arguments)
+
+          expect(Rails.logger).to have_received(:debug).with(/Scope does not include admin, group, or user/)
         end
 
         it "returns false" do

--- a/spec/lib/catalog/rbac/access_spec.rb
+++ b/spec/lib/catalog/rbac/access_spec.rb
@@ -121,7 +121,7 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
         let(:scopes) { [] }
 
         it "logs messages" do
-          expect(Rails.logger).to receive(:debug).twice
+          expect(Rails.logger).to receive(:debug).thrice
           subject.send(method, *arguments)
         end
 

--- a/spec/lib/catalog/rbac/access_spec.rb
+++ b/spec/lib/catalog/rbac/access_spec.rb
@@ -121,7 +121,7 @@ describe Catalog::RBAC::Access, :type => [:current_forwardable] do
         let(:scopes) { [] }
 
         it "logs messages" do
-          expect(Rails.logger).to receive(:error).twice
+          expect(Rails.logger).to receive(:debug).twice
           subject.send(method, *arguments)
         end
 


### PR DESCRIPTION
We used to have error messages generated when a user didn't have delete permissions
This floods the log with error messages like this
```
"@timestamp":"2020-05-05T16:48:14.496496 ","hostname":"catalog-api-89-46qw4","pid":27,"tid":"2ad140472304","level":"err","message      ":"Error in resource checking for verb: delete, object id: 120, object class: Portfolio, class to check scopes against: Portfolio"      ,"request_id":"5f4ff3cc15394f1a94c6e098fe3fcd7a"
```

This PR converts these error messages to debug so they would be only visible in Development