### PR TITLE
bump travis version to 2.5 & 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.5.5
+- 2.5.7
+- 2.6.5
 addons:
   postgresql: '10'
 env:


### PR DESCRIPTION
cc @eclarizio @syncrou @gmcculloug 

just updating everything to match topo so we're all testing against the same version(s) and potentially upgrade to 2.6 in the future. 