### PR TITLE
Pass an instance into authorize

### DIFF
--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -9,9 +9,10 @@ module Api
       end
 
       def create
-        authorize(Portfolio)
+        portfolio = authorize(Portfolio.new(writeable_params_for_create))
 
-        portfolio = Portfolio.create!(writeable_params_for_create)
+        portfolio.save!
+        portfolio.reload
         render :json => portfolio
       end
 

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -12,7 +12,6 @@ module Api
         portfolio = authorize(Portfolio.new(writeable_params_for_create))
 
         portfolio.save!
-        portfolio.reload
         render :json => portfolio
       end
 


### PR DESCRIPTION
The Pundit authorize method allows us to pass an instance
which is returned when the authorization is successful. This way
we dont have to pass in a class when doing authorization for a
create call.