### PR TITLE
The status controller wasn't being tested

### DIFF
--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -1,29 +1,5 @@
 RSpec.describe StatusController, :type => :request do
-  let(:headers) { {"CONTENT_TYPE" => "application/json"} }
-  let(:json) { JSON.parse(response.body) }
-
-  before do
-    stub_const("ENV", "BYPASS_TENANCY" => true)
-    stub_const("ENV", "DATABASE_URL" => "postgres://admin:smartvm@localhost/insights_api_common_development?pool=5")
-  end
-
-  context "when the application is healthy" do
-    it "returns a 200" do
-      get "/health", :headers => headers
-      expect(response).to have_http_status 200
-    end
-  end
-
-  context "when the application is not healthy" do
-    before do
-      allow(PG::Connection).to receive(:ping)
-        .with(ENV['DATABASE_URL'].split("?").first)
-        .and_return PG::Connection::PQPING_NO_RESPONSE
-    end
-
-    it "returns a 500" do
-      get "/health", :headers => headers
-      expect(response).to have_http_status 500
-    end
+  it "mixes in the insights status API endpoints" do
+    expect(StatusController.ancestors.include?(Insights::API::Common::Status::Api)).to be_truthy
   end
 end

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe StatusController, :type => :request do
+  let(:headers) { {"CONTENT_TYPE" => "application/json"} }
+  let(:json) { JSON.parse(response.body) }
+
+  before do
+    stub_const("ENV", "BYPASS_TENANCY" => true)
+    stub_const("ENV", "DATABASE_URL" => "postgres://admin:smartvm@localhost/insights_api_common_development?pool=5")
+  end
+
+  context "when the application is healthy" do
+    it "returns a 200" do
+      get "/health", :headers => headers
+      expect(response).to have_http_status 200
+    end
+  end
+
+  context "when the application is not healthy" do
+    before do
+      allow(PG::Connection).to receive(:ping)
+        .with(ENV['DATABASE_URL'].split("?").first)
+        .and_return PG::Connection::PQPING_NO_RESPONSE
+    end
+
+    it "returns a 500" do
+      get "/health", :headers => headers
+      expect(response).to have_http_status 500
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/RedHatInsights/catalog-api/blob/master/app/controllers/status_controller.rb
Wasn't being tested

Copied a spec from insights-api-common
https://github.com/RedHatInsights/insights-api-common-rails/blob/master/spec/requests/status_spec.rb
Looking for other ideas to test this, otherwise we have to clone spec
from the common gem