### PR TITLE
Change readOnly state for external_url, order_id, and RestoreKey

### DIFF
--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -2886,7 +2886,6 @@
         "properties": {
           "restore_key": {
             "type": "string",
-            "readOnly": true,
             "title": "Restore Key",
             "example": "3c1d765c1453916143e517bfc27b57ace3da693c"
           }
@@ -3133,7 +3132,8 @@
           "order_id": {
             "type": "string",
             "title": "Order ID",
-            "description": "The Order that the OrderItem belongs to."
+            "description": "The Order that the OrderItem belongs to.",
+            "readOnly": true
           },
           "created_at": {
             "type": "string",
@@ -3169,7 +3169,8 @@
           "external_url": {
             "type": "string",
             "title": "External url",
-            "description": "The external url of the service instance used with relation to this order item"
+            "description": "The external url of the service instance used with relation to this order item",
+            "readOnly": true
           },
           "insights_request_id": {
             "type": "string",


### PR DESCRIPTION
`external_url` doesn't really make sense to be able to edit, so that should be marked as `readOnly`.
`RestoreKey` kinda needs to be able to be passed in as a field so that the user can, you know, restore things, and it's not being exposed anywhere as a writeable field anyway so it is fine to remove the `readOnly: true` flag.
`order_id` is the only one I'm not 100% sure of, but there is more explanation in the JIRA ticket.

https://projects.engineering.redhat.com/browse/SSP-1549