### PR TITLE
Create rake tasks for metrics

### DIFF
--- a/lib/task_helpers/metrics.rb
+++ b/lib/task_helpers/metrics.rb
@@ -1,0 +1,49 @@
+module TaskHelpers
+  class Metrics
+    class << self
+      def per_tenant
+        column_names = %w[
+          tenant
+          portfolio_count
+          product_count
+          portfolio_share_count
+        ].freeze
+        data = [column_names.collect(&:titleize)]
+
+        Tenant.order(:external_tenant).each do |current_tenant|
+          ActsAsTenant.with_tenant(current_tenant) do
+            next unless tenant_has_data?
+
+            data << column_names.collect { |column_name| send(column_name) }
+          end
+        end
+
+        data
+      end
+
+      def tenant
+        ActsAsTenant.current_tenant.external_tenant
+      end
+
+      def portfolio_count
+        Portfolio.count
+      end
+
+      def portfolio_share_count
+        Portfolio.count do |portfolio|
+          portfolio.metadata['statistics']['shared_groups'] > 0
+        end
+      end
+
+      def product_count
+        PortfolioItem.count
+      end
+
+      private
+
+      def tenant_has_data?
+        !Order.count.zero? || !Portfolio.count.zero?
+      end
+    end
+  end
+end

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -1,0 +1,14 @@
+require 'csv'
+
+namespace :metrics do
+  desc 'Generate metrics per organization'
+  task :tenant => :environment do
+    csv_export(TaskHelpers::Metrics.per_tenant)
+  end
+
+  def csv_export(data)
+    CSV($stdout) do |csv|
+      data.each { |row| csv << row }
+    end
+  end
+end

--- a/spec/lib/tasks/metrics_spec.rb
+++ b/spec/lib/tasks/metrics_spec.rb
@@ -1,0 +1,38 @@
+require 'rake'
+
+describe 'metrics:tenant' do
+  let(:metrics) do
+    [
+      %w[tenant
+         portfolio_count
+         product_count
+         portfolio_share_count].collect(&:titleize),
+      %w[1 2 3 4]
+    ]
+  end
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  it "generates csv metrics for tenant" do
+    expect(TaskHelpers::Metrics).to receive(:per_tenant).and_return(metrics)
+
+    result = with_captured_stdout do
+      Rake::Task['metrics:tenant'].invoke
+    end
+
+    expect(result).to eq(
+      "Tenant,Portfolio Count,Product Count,Portfolio Share Count\n1,2,3,4\n"
+    )
+  end
+
+  def with_captured_stdout
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+end

--- a/spec/lib/tasks_helpers/metrics_spec.rb
+++ b/spec/lib/tasks_helpers/metrics_spec.rb
@@ -1,0 +1,116 @@
+describe 'Metrics' do
+  let(:header) do
+    %w[
+      tenant
+      portfolio_count
+      product_count
+      portfolio_share_count
+    ].collect(&:titleize)
+  end
+
+  let(:tenant) do
+    create(
+      :tenant,
+      :name            => 'tenant_portfolio_shared_context',
+      :external_tenant => 'external_tenant_portfolio_shared'
+    )
+  end
+
+  def create_portfolio
+    portfolio = create(:portfolio)
+    create(:access_control_entry, :aceable => portfolio)
+    portfolio.update_metadata
+  end
+
+  def create_shared_portfolio
+    portfolio = create(:portfolio)
+    create(
+      :access_control_entry,
+      :has_read_and_update_permission,
+      :aceable => portfolio
+    )
+    portfolio.update_metadata
+  end
+
+  def create_portfolio_for_tenant
+    ActsAsTenant.with_tenant(tenant) { create_portfolio }
+  end
+
+  def create_shared_portfolio_for_tenant
+    ActsAsTenant.with_tenant(tenant) { create_shared_portfolio }
+  end
+
+  describe '`.portfolio_count`' do
+    before do
+      create(:portfolio)
+    end
+
+    it 'returns metric' do
+      expect(TaskHelpers::Metrics.portfolio_count).to eq(1)
+    end
+  end
+
+  describe '`.number_of_products`' do
+    before do
+      create(:portfolio_item)
+    end
+
+    it 'returns metric' do
+      expect(TaskHelpers::Metrics.product_count).to eq(1)
+    end
+  end
+
+  describe '`.portfolio_share_count`' do
+    before do
+      create_portfolio
+      create_shared_portfolio
+    end
+
+    it 'returns metrics' do
+      expect(TaskHelpers::Metrics.portfolio_share_count).to eq(1)
+    end
+  end
+
+  describe '`.per_tenant`' do
+    context '#without_data' do
+      it 'returns only header' do
+        expect(TaskHelpers::Metrics.per_tenant).to eq([header])
+      end
+    end
+
+    context '#with_data' do
+      let(:expected_result) do
+        [
+          header,
+          [Tenant.first.external_tenant, 2, 0, 1],
+          [tenant.external_tenant, 3, 0, 2]
+        ]
+      end
+
+      before do
+        create_portfolio
+        create_portfolio_for_tenant
+        create_shared_portfolio
+        create_shared_portfolio_for_tenant
+        create_shared_portfolio_for_tenant
+      end
+
+      context '#with_full_tenants' do
+        it 'returns metrics' do
+          expect(TaskHelpers::Metrics.per_tenant).to eq(expected_result)
+        end
+      end
+
+      context '#with_empty_tenants' do
+        before do
+          create(:tenant, :external_tenant => 'empty_tenant')
+        end
+
+        it 'filters out tenants with no data' do
+          expect(Tenant.count).to eq(3)
+          expect(TaskHelpers::Metrics.per_tenant).to eq(expected_result)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creating the rake task for generating metrics per Organization. Report contains all of the listed info bellow.

1. \# of Portfolios per Organization
2. \# of Products per Organization
3. \# of Portfolios Shared per Organization

command: `bundle exec rake metrics:tenant`

This PR is base on: https://projects.engineering.redhat.com/browse/SSP-1554. 

example output: 
```
Tenant,Portfolio Count,Product Count,Portfolio Share Count
1460290,1,0,0
5378341,1,0,0
540155,1,0,0
5578597,3,3,1
5910538,0,0,0
6046256,2,23,0
```