### PR TITLE
Remove unnecessary stubs after updating to common 4.1

### DIFF
--- a/spec/controllers/api/v1x0/application_controller_spec.rb
+++ b/spec/controllers/api/v1x0/application_controller_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe ApplicationController, :type => [:request, :v1] do
      allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
      allow(catalog_access).to receive(:process).and_return(catalog_access)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
-
-     #TODO: Remove these calls as it is stubbing out for user_capabilities,
-     # which should not be getting called on this version of the API
-     # When common gem gets updated, these can be removed.
-     allow(catalog_access).to receive(:admin_scope?).with("portfolios", "update").and_return(true)
-     allow(catalog_access).to receive(:accessible?).and_return(true)
   end
 
   context "with tenancy enforcement" do

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -5,11 +5,6 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
      allow(catalog_access).to receive(:process).and_return(catalog_access)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "read").and_return(true)
-
-     #TODO: Remove this call as it is stubbing out for user_capabilities,
-     # which should not be getting called on this version of the API
-     # When common gem gets updated, this can be removed.
-     allow(catalog_access).to receive(:accessible?).and_return(true)
   end
   let(:service_offering_ref) { "998" }
   let(:service_offering_source_ref) { "568" }

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -10,12 +10,6 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
      allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
      allow(catalog_access).to receive(:process).and_return(catalog_access)
      allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
-
-     #TODO: Remove these calls as it is stubbing out for user_capabilities,
-     # which should not be getting called on this version of the API
-     # When common gem gets updated, these can be removed.
-     allow(catalog_access).to receive(:admin_scope?).with("portfolios", "update").and_return(true)
-     allow(catalog_access).to receive(:accessible?).and_return(true)
   end
 
   describe "GET /portfolios/:portfolio_id" do


### PR DESCRIPTION
Just some easy clean-up now that the insights gem has been updated to version 4.1