### PR TITLE
Increase Portfolio max name length to 512 from 64

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -5,7 +5,7 @@ class Portfolio < ApplicationRecord
   include Aceable
   include UserCapabilities
 
-  MAX_NAME_LENGTH = 64
+  MAX_NAME_LENGTH = 512
 
   destroy_dependencies :portfolio_items
 

--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -2753,7 +2753,7 @@
             "title": "Name",
             "example": "Sample Portfolio",
             "minLength": 1,
-            "maxLength": 64
+            "maxLength": 512
           },
           "description": {
             "type": "string",

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -12,7 +12,7 @@ describe Portfolio do
   context "length restrictions" do
     it "raises validation error" do
       expect do
-        Portfolio.create!(:name => 'a'*65, :tenant => tenant1, :description => 'abc', :owner => 'fred')
+        Portfolio.create!(:name => 'a'*513, :tenant => tenant1, :description => 'abc', :owner => 'fred')
       end.to raise_error(ActiveRecord::RecordInvalid, /Name is too long/)
     end
   end


### PR DESCRIPTION
To stay consistent with https://github.com/RedHatInsights/catalog-api/pull/749, this PR increases the maximum allowable length of portfolio names to 512 characters. The UI will be handling what happens if someone does end up going crazy and actually entering in a name that is that long.

@gmcculloug not much to "review" here, but tagging you anyway 😄 