### PR TITLE
Update iqe plugins on Jenkins file smoke

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -10,7 +10,7 @@ if (env.CHANGE_ID) {
         ocDeployerBuilderPath: "catalog/catalog-api",
         ocDeployerComponentPath: "catalog/catalog-api",
         ocDeployerServiceSets: "catalog,topological-inventory,sources,approval,platform-mq",
-        iqePlugins: ["iqe-self-service-portal-plugin"],
+        iqePlugins: ["self_service_portal"],
         pytestMarker: "catalog_api_smoke",
         // local settings file
         configFileCredentialsId: "catalog-config",


### PR DESCRIPTION
Following changes on Smoke test Jenkins run,
The is a need to update Jenkins Groovy file, Jenkinsfile-smoke.groovy,
with a plugin name instead of a plugin package name.