### PR TITLE
Add 'orderable' field to portfolio_item metadata for #show action

### DIFF
--- a/app/controllers/api/v1x1.rb
+++ b/app/controllers/api/v1x1.rb
@@ -11,7 +11,6 @@ module Api
     class GraphqlController                   < Api::V1x0::GraphqlController; end
     class OrderItemsController                < Api::V1x0::OrderItemsController; end
     class OrdersController                    < Api::V1x0::OrdersController; end
-    class PortfolioItemsController            < Api::V1x0::PortfolioItemsController; end
     class PortfoliosController                < Api::V1x0::PortfoliosController; end
     class ProgressMessagesController          < Api::V1x0::ProgressMessagesController; end
     class ProviderControlParametersController < Api::V1x0::ProviderControlParametersController; end

--- a/app/controllers/api/v1x1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x1/portfolio_items_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1x1
+    class PortfolioItemsController < Api::V1x0::PortfolioItemsController
+      include Api::V1x1::Mixins::IndexMixin
+
+      def show
+        portfolio_item = model.find(params.require(:id))
+        authorize(portfolio_item)
+
+        json = portfolio_item.as_json(:prefixes => _prefixes, :template => action_name)
+        json['metadata']['orderable'] = Catalog::PortfolioItemOrderable.new(portfolio_item).process.result
+        render :json => json
+      end
+    end
+  end
+end

--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -933,7 +933,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowPortfolioItem"
+                  "$ref": "#/components/schemas/PortfolioItem"
                 }
               }
             }
@@ -2927,7 +2927,7 @@
           }
         }
       },
-      "ShowPortfolioItem": {
+      "PortfolioItem": {
         "type": "object",
         "properties": {
           "id": {
@@ -3038,135 +3038,7 @@
             "type": "object",
             "title": "Metadata",
             "description": "JSON Metadata about the portfolio item",
-            "readOnly": true,
-            "example": {
-              "user_capabilities": {
-                "create": true,
-                "update": true,
-                "delete": false
-              },
-              "orderable": true
-            }
-          }
-        }
-      },
-      "PortfolioItem": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
             "readOnly": true
-          },
-          "favorite": {
-            "type": "boolean",
-            "title": "Favorite",
-            "example": "Definition of a favorite portfolio item"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "example": "Name of the portfolio item"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description",
-            "example": "Description of a portfolio item",
-            "nullable": true
-          },
-          "orphan": {
-            "type": "boolean",
-            "readOnly": true,
-            "title": "Orphan",
-            "example": "Boolean if an associated catalog item no longer exists"
-          },
-          "state": {
-            "type": "string",
-            "readOnly": true,
-            "title": "State",
-            "example": "The current state of a portfolio item"
-          },
-          "long_description": {
-            "type": "string",
-            "title": "Long Description",
-            "example": "The longer description of a portfolio item",
-            "nullable": true
-          },
-          "distributor": {
-            "type": "string",
-            "title": "Distributor",
-            "example": "The name of the provider for this Item",
-            "nullable": true
-          },
-          "documentation_url": {
-            "type": "string",
-            "title": "Documentation URL",
-            "example": "The URL for documentation of the portfolio item",
-            "nullable": true
-          },
-          "support_url": {
-            "type": "string",
-            "title": "Support URL",
-            "example": "The URL for finding support for the portfolio item",
-            "nullable": true
-          },
-          "owner": {
-            "type": "string",
-            "title": "Owner",
-            "example": "jdoe",
-            "readOnly": true
-          },
-          "service_offering_source_ref": {
-            "type": "string",
-            "title": "Service Offering Source Ref",
-            "description": "The source reference this product was created from",
-            "readOnly": true,
-            "example": "20"
-          },
-          "service_offering_type": {
-            "type": "string",
-            "title": "Service Offering Type",
-            "description": "The service offering type stored by the Topology Service",
-            "readOnly": true,
-            "example": "job_template"
-          },
-          "portfolio_id": {
-            "type": "string",
-            "title": "Portfolio ID",
-            "description": "ID of a parent portfolio",
-            "readOnly": true,
-            "example": "1"
-          },
-          "icon_id": {
-            "type": "string",
-            "title": "Icon ID",
-            "description": "The Portfolio Item Icon ID",
-            "readOnly": true,
-            "example": "1"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created at",
-            "readOnly": true
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated at",
-            "readOnly": true
-          },
-          "metadata": {
-            "type": "object",
-            "title": "Metadata",
-            "description": "JSON Metadata about the portfolio item",
-            "readOnly": true,
-            "example": {
-              "user_capabilities": {
-                "create": true,
-                "update": true,
-                "delete": false
-              }
-            }
           }
         }
       },

--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -3039,15 +3039,13 @@
             "title": "Metadata",
             "description": "JSON Metadata about the portfolio item",
             "readOnly": true,
-            "properties": {
+            "example": {
               "user_capabilities": {
-                "type": "object",
-                "description": "A list of permissions that the current user has access to on this portfolio item"
+                "create": true,
+                "update": true,
+                "delete": false
               },
-              "orderable": {
-                "type": "boolean",
-                "description": "Whether or not this portfolio item is currently in an orderable state"
-              }
+              "orderable": true
             }
           }
         }
@@ -3162,10 +3160,11 @@
             "title": "Metadata",
             "description": "JSON Metadata about the portfolio item",
             "readOnly": true,
-            "properties": {
+            "example": {
               "user_capabilities": {
-                "type": "object",
-                "description": "A list of permissions that the current user has access to on this portfolio item"
+                "create": true,
+                "update": true,
+                "delete": false
               }
             }
           }

--- a/public/doc/openapi-3-v1.1.json
+++ b/public/doc/openapi-3-v1.1.json
@@ -933,7 +933,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PortfolioItem"
+                  "$ref": "#/components/schemas/ShowPortfolioItem"
                 }
               }
             }
@@ -2927,7 +2927,7 @@
           }
         }
       },
-      "PortfolioItem": {
+      "ShowPortfolioItem": {
         "type": "object",
         "properties": {
           "id": {
@@ -3038,7 +3038,136 @@
             "type": "object",
             "title": "Metadata",
             "description": "JSON Metadata about the portfolio item",
+            "readOnly": true,
+            "properties": {
+              "user_capabilities": {
+                "type": "object",
+                "description": "A list of permissions that the current user has access to on this portfolio item"
+              },
+              "orderable": {
+                "type": "boolean",
+                "description": "Whether or not this portfolio item is currently in an orderable state"
+              }
+            }
+          }
+        }
+      },
+      "PortfolioItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
             "readOnly": true
+          },
+          "favorite": {
+            "type": "boolean",
+            "title": "Favorite",
+            "example": "Definition of a favorite portfolio item"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "example": "Name of the portfolio item"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "example": "Description of a portfolio item",
+            "nullable": true
+          },
+          "orphan": {
+            "type": "boolean",
+            "readOnly": true,
+            "title": "Orphan",
+            "example": "Boolean if an associated catalog item no longer exists"
+          },
+          "state": {
+            "type": "string",
+            "readOnly": true,
+            "title": "State",
+            "example": "The current state of a portfolio item"
+          },
+          "long_description": {
+            "type": "string",
+            "title": "Long Description",
+            "example": "The longer description of a portfolio item",
+            "nullable": true
+          },
+          "distributor": {
+            "type": "string",
+            "title": "Distributor",
+            "example": "The name of the provider for this Item",
+            "nullable": true
+          },
+          "documentation_url": {
+            "type": "string",
+            "title": "Documentation URL",
+            "example": "The URL for documentation of the portfolio item",
+            "nullable": true
+          },
+          "support_url": {
+            "type": "string",
+            "title": "Support URL",
+            "example": "The URL for finding support for the portfolio item",
+            "nullable": true
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner",
+            "example": "jdoe",
+            "readOnly": true
+          },
+          "service_offering_source_ref": {
+            "type": "string",
+            "title": "Service Offering Source Ref",
+            "description": "The source reference this product was created from",
+            "readOnly": true,
+            "example": "20"
+          },
+          "service_offering_type": {
+            "type": "string",
+            "title": "Service Offering Type",
+            "description": "The service offering type stored by the Topology Service",
+            "readOnly": true,
+            "example": "job_template"
+          },
+          "portfolio_id": {
+            "type": "string",
+            "title": "Portfolio ID",
+            "description": "ID of a parent portfolio",
+            "readOnly": true,
+            "example": "1"
+          },
+          "icon_id": {
+            "type": "string",
+            "title": "Icon ID",
+            "description": "The Portfolio Item Icon ID",
+            "readOnly": true,
+            "example": "1"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created at",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated at",
+            "readOnly": true
+          },
+          "metadata": {
+            "type": "object",
+            "title": "Metadata",
+            "description": "JSON Metadata about the portfolio item",
+            "readOnly": true,
+            "properties": {
+              "user_capabilities": {
+                "type": "object",
+                "description": "A list of permissions that the current user has access to on this portfolio item"
+              }
+            }
           }
         }
       },

--- a/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
@@ -15,8 +15,11 @@ describe "v1.1 - PortfolioItemRequests", :type => [:request, :topology, :v1x1] d
 
   describe "GET /portfolio_items/:portfolio_item_id #show" do
     subject { get "#{api_version}/portfolio_items/#{portfolio_item_id}", :headers => default_headers }
+    let(:portfolio_item_orderable) { instance_double(Api::V1x1::Catalog::PortfolioItemOrderable, :result => true) }
 
     before do |example|
+      allow(Api::V1x1::Catalog::PortfolioItemOrderable).to receive(:new).with(portfolio_item).and_return(portfolio_item_orderable)
+      allow(portfolio_item_orderable).to receive(:process).and_return(portfolio_item_orderable)
       subject unless example.metadata[:subject_inside]
     end
 
@@ -43,6 +46,7 @@ describe "v1.1 - PortfolioItemRequests", :type => [:request, :topology, :v1x1] d
           "show"         => true,
           "set_approval" => true
         )
+        expect(json["metadata"]["orderable"]).to eq(true)
       end
 
        it_behaves_like "action that tests authorization", :show?, PortfolioItem


### PR DESCRIPTION
This PR will add the 'orderable' field to portfolio_item's metadata, but only for the #show action.

I originally wanted to have this handled in the common gem, similar to how we currently handle the serialization where it compares against what the openapi JSON says are the correct properties to evaluate against. However, I think with the nesting and need for extensive testing due to how complicated you can make an openapi JSON schema, I opted for the simpler route of putting the property directly into the metadata in the controller action.

The only kinda complicated and unintuitive thing here is that when we do something like:
```
render :json => portfolio_item
```
This is actually implicitly calling `portfolio_item.as_json(:prefixes => _prefixes, :template => action_name)`. So that is why line 10 includes those.

I'm not in love with the implementation, but I don't really see a great way of doing it from the model perspective since it has no idea what action is coming in, and really I don't know if it should care. Maybe if this turns into something that is calculated in a background process and updated to the database, we can put it on the model, but for now I think it makes sense to keep it bound to the controller.

Also, I really hate that we have to essentially duplicate the `PortfolioItem` schema component in the openapi json, but the python client generator doesn't support `allOf` to be able to use it to simplify and pare it down.

Related to both https://projects.engineering.redhat.com/browse/SSP-1288 and https://projects.engineering.redhat.com/browse/SSP-1476

@gmcculloug @mkanoor Please Review.