### PR TITLE
Version 1.2 cleanup

### DIFF
--- a/app/controllers/api/v1x0/approval_requests_controller.rb
+++ b/app/controllers/api/v1x0/approval_requests_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1x0
     class ApprovalRequestsController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
+      include Mixins::IndexMixin
 
       def index
         collection(OrderItem.find(params.require(:order_item_id)).approval_requests)

--- a/app/controllers/api/v1x0/graphql_controller.rb
+++ b/app/controllers/api/v1x0/graphql_controller.rb
@@ -3,7 +3,7 @@ require "insights/api/common/graphql"
 module Api
   module V1x0
     class GraphqlController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
+      include Mixins::IndexMixin
 
       def overlay
         {

--- a/app/controllers/api/v1x0/icons_controller.rb
+++ b/app/controllers/api/v1x0/icons_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1x0
     class IconsController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
+      include Mixins::IndexMixin
 
       # Due to the fact form-data is getting uploaded and isn't supported by openapi_parser
       skip_before_action :validate_request, :only => %i[create update]

--- a/app/controllers/api/v1x0/order_items_controller.rb
+++ b/app/controllers/api/v1x0/order_items_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1x0
     class OrderItemsController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
+      include Mixins::IndexMixin
 
       def index
         if params[:order_id]

--- a/app/controllers/api/v1x0/orders_controller.rb
+++ b/app/controllers/api/v1x0/orders_controller.rb
@@ -1,9 +1,9 @@
 module Api
   module V1x0
     class OrdersController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
-      include Api::V1x0::Mixins::ServiceOfferingMixin
-      include Api::V1x0::Mixins::ShowMixin
+      include Mixins::IndexMixin
+      include Mixins::ServiceOfferingMixin
+      include Mixins::ShowMixin
 
       def index
         collection(Order.all)

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1x0
     class PortfolioItemsController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
-      include Api::V1x0::Mixins::ShowMixin
+      include Mixins::IndexMixin
+      include Mixins::ShowMixin
 
       def index
         if params[:portfolio_id]

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1x0
     class PortfoliosController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
-      include Api::V1x0::Mixins::ShowMixin
+      include Mixins::IndexMixin
+      include Mixins::ShowMixin
 
       def index
         collection(Portfolio.all)

--- a/app/controllers/api/v1x0/progress_messages_controller.rb
+++ b/app/controllers/api/v1x0/progress_messages_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1x0
     class ProgressMessagesController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
+      include Mixins::IndexMixin
 
       def index
         collection(OrderItem.find(params.require(:order_item_id)).progress_messages)

--- a/app/controllers/api/v1x0/service_plans_controller.rb
+++ b/app/controllers/api/v1x0/service_plans_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1x0
     class ServicePlansController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
+      include Mixins::IndexMixin
 
       def index
         portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))

--- a/app/controllers/api/v1x0/tags_controller.rb
+++ b/app/controllers/api/v1x0/tags_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1x0
     class TagsController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
+      include Mixins::IndexMixin
       include Insights::API::Common::TaggingMethods
 
       def index

--- a/app/controllers/api/v1x0/tenants_controller.rb
+++ b/app/controllers/api/v1x0/tenants_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1x0
     class TenantsController < ApplicationController
-      include Api::V1x0::Mixins::IndexMixin
+      include Mixins::IndexMixin
 
       def index
         collection(Tenant.scoped_tenants)

--- a/app/controllers/api/v1x1.rb
+++ b/app/controllers/api/v1x1.rb
@@ -18,6 +18,6 @@ module Api
     class TagsController                      < Api::V1x0::TagsController; end
     class TenantsController                   < Api::V1x0::TenantsController; end
 
-    extend_each_subclass Api::V1x1::Mixins::IndexMixin
+    extend_each_subclass Mixins::IndexMixin
   end
 end

--- a/app/controllers/api/v1x1/icons_controller.rb
+++ b/app/controllers/api/v1x1/icons_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1x1
     class IconsController < ApplicationController
-      include Api::V1x1::Mixins::IndexMixin
+      include Mixins::IndexMixin
 
       # Due to the fact form-data is getting uploaded and isn't supported by openapi_parser
       skip_before_action :validate_request, :only => %i[create]

--- a/app/controllers/api/v1x1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x1/mixins/index_mixin.rb
@@ -2,15 +2,7 @@ module Api
   module V1x1
     module Mixins
       module IndexMixin
-        def scoped(relation, pre_authorized)
-          relation = rbac_scope(relation, :pre_authorized => pre_authorized) if Insights::API::Common::RBAC::Access.enabled?
-          if relation.model.respond_to?(:taggable?) && relation.model.taggable?
-            ref_schema = {relation.model.tagging_relation_name => :tag}
-
-            relation = relation.includes(ref_schema).references(ref_schema)
-          end
-          relation
-        end
+        include Api::V1x0::Mixins::IndexMixin
 
         def collection(base_query, pre_authorized: false)
           render :json => Insights::API::Common::PaginatedResponse.new(
@@ -20,34 +12,6 @@ module Api
             :offset     => pagination_offset,
             :sort_by    => query_sort_by
           ).response
-        end
-
-        def rbac_scope(relation, pre_authorized: false)
-          return relation if pre_authorized
-
-          policy_scope(relation)
-        end
-
-        def filtered(base_query)
-          Insights::API::Common::Filter.new(base_query, params[:filter], api_doc_definition).apply
-        end
-
-        private
-
-        def api_doc_definition
-          @api_doc_definition ||= Api::Docs[api_version].definitions[model_name]
-        end
-
-        def api_version
-          @api_version ||= name.split("::")[1].downcase.delete("v").sub("x", ".")
-        end
-
-        def model_name
-          @model_name ||= controller_name.classify
-        end
-
-        def name
-          self.class.to_s
         end
       end
     end

--- a/app/controllers/api/v1x1/mixins/show_mixin.rb
+++ b/app/controllers/api/v1x1/mixins/show_mixin.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1x1
+    module Mixins
+      module ShowMixin
+        include Api::V1x0::Mixins::ShowMixin
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1x1/service_plans_controller.rb
+++ b/app/controllers/api/v1x1/service_plans_controller.rb
@@ -3,7 +3,7 @@ require 'services/api/v1x1'
 module Api
   module V1x1
     class ServicePlansController < Api::V1x0::ServicePlansController
-      include Api::V1x1::Mixins::IndexMixin
+      include Mixins::IndexMixin
 
       def reset
         service_plan = ServicePlan.find(params.require(:service_plan_id))

--- a/app/controllers/api/v1x2.rb
+++ b/app/controllers/api/v1x2.rb
@@ -23,6 +23,6 @@ module Api
     class TagsController                      < Api::V1x1::TagsController; end
     class TenantsController                   < Api::V1x1::TenantsController; end
 
-    extend_each_subclass Api::V1x1::Mixins::IndexMixin
+    extend_each_subclass Mixins::IndexMixin
   end
 end

--- a/app/controllers/api/v1x2.rb
+++ b/app/controllers/api/v1x2.rb
@@ -1,4 +1,4 @@
-require 'services/api/v1x1'
+require 'services/api/v1x2'
 require 'controllers/api/v1x1'
 
 module Api

--- a/app/controllers/api/v1x2/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x2/mixins/index_mixin.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1x2
+    module Mixins
+      module IndexMixin
+        include Api::V1x1::Mixins::IndexMixin
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1x2/mixins/show_mixin.rb
+++ b/app/controllers/api/v1x2/mixins/show_mixin.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1x2
+    module Mixins
+      module ShowMixin
+        include Api::V1x1::Mixins::ShowMixin
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1x2/order_processes_controller.rb
+++ b/app/controllers/api/v1x2/order_processes_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1x2
     class OrderProcessesController < ApplicationController
-      include Api::V1x1::Mixins::IndexMixin
-      include Api::V1x0::Mixins::ShowMixin
+      include Mixins::IndexMixin
+      include Mixins::ShowMixin
 
       def index
         collection(OrderProcess.all)

--- a/app/services/api/v1x2.rb
+++ b/app/services/api/v1x2.rb
@@ -1,0 +1,55 @@
+require 'services/api/v1x1'
+
+module Api
+  module V1x2
+    module Catalog
+      class AddToOrder                          < Api::V1x1::Catalog::AddToOrder; end
+      class ApprovalTransition                  < Api::V1x1::Catalog::ApprovalTransition; end
+      class CancelOrder                         < Api::V1x1::Catalog::CancelOrder; end
+      class CopyPortfolio                       < Api::V1x1::Catalog::CopyPortfolio; end
+      class CopyPortfolioItem                   < Api::V1x1::Catalog::CopyPortfolioItem; end
+      class CreateApprovalRequest               < Api::V1x1::Catalog::CreateApprovalRequest; end
+      class CreateIcon                          < Api::V1x1::Catalog::CreateIcon; end
+      class CreateRequestBodyFrom               < Api::V1x1::Catalog::CreateRequestBodyFrom; end
+      class CreateRequestForAppliedInventories  < Api::V1x1::Catalog::CreateRequestBodyFrom; end
+      class DetermineTaskRelevancy              < Api::V1x1::Catalog::DetermineTaskRelevancy; end
+      class DuplicateImage                      < Api::V1x1::Catalog::DuplicateImage; end
+      class ImportServicePlans                  < Api::V1x1::Catalog::ImportServicePlans; end
+      class NextName                            < Api::V1x1::Catalog::NextName; end
+      class NotifyApprovalRequest               < Api::V1x1::Catalog::NotifyApprovalRequest; end
+      class OrderItemSanitizedParameters        < Api::V1x1::Catalog::OrderItemSanitizedParameters; end
+      class PortfolioItemOrderable              < Api::V1x1::Catalog::PortfolioItemOrderable; end
+      class ProviderControlParameters           < Api::V1x1::Catalog::ProviderControlParameters; end
+      class ServiceOffering                     < Api::V1x1::Catalog::ServiceOffering; end
+      class ServicePlanCompare                  < Api::V1x1::Catalog::ServicePlanCompare; end
+      class ServicePlanJson                     < Api::V1x1::Catalog::ServicePlanJson; end
+      class ServicePlanReset                    < Api::V1x1::Catalog::ServicePlanReset; end
+      class ServicePlans                        < Api::V1x1::Catalog::ServicePlans; end
+      class ShareInfo                           < Api::V1x1::Catalog::ShareInfo; end
+      class ShareResource                       < Api::V1x1::Catalog::ShareResource; end
+      class SoftDelete                          < Api::V1x1::Catalog::SoftDelete; end
+      class SoftDeleteRestore                   < Api::V1x1::Catalog::SoftDeleteRestore; end
+      class SubmitOrder                         < Api::V1x1::Catalog::SubmitOrder; end
+      class TenantSettings                      < Api::V1x1::Catalog::TenantSettings; end
+      class UnshareResource                     < Api::V1x1::Catalog::UnshareResource; end
+      class UpdateIcon                          < Api::V1x1::Catalog::UpdateIcon; end
+      class UpdateOrderItem                     < Api::V1x1::Catalog::UpdateOrderItem; end
+      class ValidateSource                      < Api::V1x1::Catalog::ValidateSource; end
+    end
+
+    module Group
+      class Seed < Api::V1x1::Group::Seed; end
+    end
+
+    module ServiceOffering
+      class AddToPortfolioItem < Api::V1x1::ServiceOffering::AddToPortfolioItem; end
+    end
+
+    module Tags
+      class CollectLocalOrderResources < Api::V1x1::Tags::CollectLocalOrderResources; end
+      module Topology
+        class RemoteInventory < Api::V1x1::Tags::Topology::RemoteInventory; end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1.2/order_processes_controller_spec.rb
+++ b/spec/requests/api/v1.2/order_processes_controller_spec.rb
@@ -1,4 +1,4 @@
-describe "v1.2 - OrderProcesses", :type => [:request, :v1x2] do
+describe "v1.2 - OrderProcesses", :type => [:request, :controller, :v1x2] do
   let!(:order_process)    { create(:order_process) }
   let!(:order_process_id) { order_process.id }
   let(:rbac_access)       { instance_double(Catalog::RBAC::Access) }


### PR DESCRIPTION
This PR is aimed to help clean up some of the namespacing we have all over when the version is meant to be implicitly resolved. It does introduce a bit of cruft and files that don't seem to do anything, but I think it is better to ensure that everything is on the correct version instead of some controllers being v1.1 but actually using v1.0 of a mixin. Trying to figure out when things change going forward would be more difficult if the files don't follow the version patterns.