### PR TITLE
Add more usage metrics to report

### DIFF
--- a/lib/task_helpers/metrics.rb
+++ b/lib/task_helpers/metrics.rb
@@ -7,6 +7,18 @@ module TaskHelpers
           portfolio_count
           product_count
           portfolio_share_count
+          product_source_count
+          most_recent_portfolio_create_date
+          most_recent_product_create_date
+          most_recent_order_create_date
+          total_orders
+          order_count_last_30_days
+          order_count_31_to_60_days_ago
+          order_count_61_to_90_days_ago
+          portfolio_creators
+          unique_order_usernames
+          discarded_portfolios
+          discarded_products
         ].freeze
         data = [column_names.collect(&:titleize)]
 
@@ -35,14 +47,84 @@ module TaskHelpers
         end
       end
 
+      def product_source_count
+        PortfolioItem.pluck(:service_offering_source_ref).uniq.count # rubocop:disable Rails/UniqBeforePluck
+      end
+
       def product_count
         PortfolioItem.count
+      end
+
+      def portfolio_creators
+        Portfolio.with_discarded.pluck(:owner).uniq.join(", ")
+      end
+
+      def unique_order_usernames
+        Order.pluck(:owner).uniq.count # rubocop:disable Rails/UniqBeforePluck
+      end
+
+      def most_recent_portfolio_create_date
+        iso_date(Portfolio.reorder(:created_at).last&.created_at)
+      end
+
+      def most_recent_product_create_date
+        iso_date(PortfolioItem.reorder(:created_at).last&.created_at)
+      end
+
+      def most_recent_order_create_date
+        iso_date(Order.reorder(:created_at).last&.created_at)
+      end
+
+      def total_orders
+        Order.count
+      end
+
+      def order_count_last_30_days
+        Order.where(:created_at => last_30_days).count
+      end
+
+      def order_count_31_to_60_days_ago
+        Order.where(:created_at => last_60_days).count
+      end
+
+      def order_count_61_to_90_days_ago
+        Order.where(:created_at => last_90_days).count
+      end
+
+      def discarded_portfolios
+        Portfolio.with_discarded.discarded.count
+      end
+
+      def discarded_products
+        PortfolioItem.with_discarded.discarded.count
       end
 
       private
 
       def tenant_has_data?
         !Order.count.zero? || !Portfolio.count.zero?
+      end
+
+      def last_30_days
+        date_range(0, 30)
+      end
+
+      def last_60_days
+        date_range(31, 60)
+      end
+
+      def last_90_days
+        date_range(61, 90)
+      end
+
+      def date_range(start_days, end_days)
+        end_days.days.ago.to_date..start_days.days.ago.to_date
+      end
+
+      def iso_date(date_time)
+        return nil if date_time.nil?
+
+        date_time.to_date.iso8601
       end
     end
   end

--- a/spec/lib/tasks_helpers/metrics_spec.rb
+++ b/spec/lib/tasks_helpers/metrics_spec.rb
@@ -5,6 +5,18 @@ describe 'Metrics' do
       portfolio_count
       product_count
       portfolio_share_count
+      product_source_count
+      most_recent_portfolio_create_date
+      most_recent_product_create_date
+      most_recent_order_create_date
+      total_orders
+      order_count_last_30_days
+      order_count_31_to_60_days_ago
+      order_count_61_to_90_days_ago
+      portfolio_creators
+      unique_order_usernames
+      discarded_portfolios
+      discarded_products
     ].collect(&:titleize)
   end
 
@@ -80,10 +92,11 @@ describe 'Metrics' do
 
     context '#with_data' do
       let(:expected_result) do
+        date_string = Date.today.iso8601
         [
           header,
-          [Tenant.first.external_tenant, 2, 0, 1],
-          [tenant.external_tenant, 3, 0, 2]
+          [Tenant.first.external_tenant, 2, 0, 1, 0, date_string, nil, nil, 0, 0, 0, 0, "jdoe", 0, 0, 0],
+          [tenant.external_tenant,       3, 0, 2, 0, date_string, nil, nil, 0, 0, 0, 0, "jdoe", 0, 0, 0]
         ]
       end
 


### PR DESCRIPTION
Adding several more usage metrics:

- product_source_count
- most_recent_portfolio_create_date
- most_recent_product_create_date
- most_recent_order_create_date
- total_orders
- order_count_last_30_days
- order_count_31_to_60_days_ago
- order_count_61_to_90_days_ago
- portfolio_creators
- unique_order_usernames
- discarded_portfolios
- discarded_products