### PR TITLE
Add 'before' API endpoint for order processes

### DIFF
--- a/app/controllers/api/v1x2/order_processes_controller.rb
+++ b/app/controllers/api/v1x2/order_processes_controller.rb
@@ -33,12 +33,12 @@ module Api
         head :no_content
       end
 
-      def pre
+      def update_pre
         order_process = OrderProcess.find(params.require(:order_process_id))
         authorize(order_process, :update?)
 
         pre_portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
-        order_process.update(:pre => pre_portfolio_item)
+        order_process.update!(:pre => pre_portfolio_item)
 
         render :json => order_process
       end

--- a/app/controllers/api/v1x2/order_processes_controller.rb
+++ b/app/controllers/api/v1x2/order_processes_controller.rb
@@ -37,8 +37,9 @@ module Api
         order_process = OrderProcess.find(params.require(:order_process_id))
         authorize(order_process, :update?)
 
-        pre_portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
-        order_process.update!(:pre => pre_portfolio_item)
+        order_process = Catalog::OrderProcessAssociator.new(
+          order_process, params.require(:portfolio_item_id), :pre
+        ).process.order_process
 
         render :json => order_process
       end

--- a/app/controllers/api/v1x2/order_processes_controller.rb
+++ b/app/controllers/api/v1x2/order_processes_controller.rb
@@ -33,12 +33,12 @@ module Api
         head :no_content
       end
 
-      def update_pre
+      def update_before_portfolio_item
         order_process = OrderProcess.find(params.require(:order_process_id))
         authorize(order_process, :update?)
 
         order_process = Catalog::OrderProcessAssociator.new(
-          order_process, params.require(:portfolio_item_id), :pre
+          order_process, params.require(:portfolio_item_id), :before_portfolio_item
         ).process.order_process
 
         render :json => order_process

--- a/app/controllers/api/v1x2/order_processes_controller.rb
+++ b/app/controllers/api/v1x2/order_processes_controller.rb
@@ -32,6 +32,16 @@ module Api
 
         head :no_content
       end
+
+      def pre
+        order_process = OrderProcess.find(params.require(:order_process_id))
+        authorize(order_process, :update?)
+
+        pre_portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
+        order_process.update(:pre => pre_portfolio_item)
+
+        render :json => order_process
+      end
     end
   end
 end

--- a/app/models/order_process.rb
+++ b/app/models/order_process.rb
@@ -3,8 +3,8 @@ class OrderProcess < ApplicationRecord
   acts_as_tenant(:tenant)
   acts_as_taggable_on
 
-  belongs_to :pre, :class_name => 'PortfolioItem'
-  # belongs_to :post, :class_name => 'PortfolioItem'
+  belongs_to :before_portfolio_item, :class_name => 'PortfolioItem'
+  # belongs_to :after_portfolio_item, :class_name => 'PortfolioItem'
 
   def metadata
     {:user_capabilities => user_capabilities}

--- a/app/models/order_process.rb
+++ b/app/models/order_process.rb
@@ -3,6 +3,9 @@ class OrderProcess < ApplicationRecord
   acts_as_tenant(:tenant)
   acts_as_taggable_on
 
+  belongs_to :pre, :class_name => 'PortfolioItem'
+  # belongs_to :post, :class_name => 'PortfolioItem'
+
   def metadata
     {:user_capabilities => user_capabilities}
   end

--- a/app/services/api/v1x2/catalog/order_process_associator.rb
+++ b/app/services/api/v1x2/catalog/order_process_associator.rb
@@ -1,0 +1,21 @@
+module Api
+  module V1x2
+    module Catalog
+      class OrderProcessAssociator
+        attr_reader :order_process
+
+        def initialize(order_process, portfolio_item_id, association)
+          @order_process = order_process
+          @portfolio_item = PortfolioItem.find(portfolio_item_id)
+          @association = association
+        end
+
+        def process
+          @order_process.update(@association => @portfolio_item)
+
+          self
+        end
+      end
+    end
+  end
+end

--- a/config/routes/v1x2.rb
+++ b/config/routes/v1x2.rb
@@ -38,7 +38,9 @@ namespace :v1x2, :path => "v1.2" do
     post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
   end
   resources :icons, :only => [:create, :destroy]
-  resources :order_processes, :only => [:create, :destroy, :index, :show, :update], :concerns => [:taggable]
+  resources :order_processes, :only => [:create, :destroy, :index, :show, :update], :concerns => [:taggable] do
+    post :pre, :action => 'pre', :controller => 'order_processes'
+  end
   resources :settings
   resources :tags, :only => [:index]
   resources :tenants, :only => [:index, :show] do

--- a/config/routes/v1x2.rb
+++ b/config/routes/v1x2.rb
@@ -39,7 +39,7 @@ namespace :v1x2, :path => "v1.2" do
   end
   resources :icons, :only => [:create, :destroy]
   resources :order_processes, :only => [:create, :destroy, :index, :show, :update], :concerns => [:taggable] do
-    post :pre, :action => 'pre', :controller => 'order_processes'
+    patch :pre, :to => 'order_processes#update_pre'
   end
   resources :settings
   resources :tags, :only => [:index]

--- a/config/routes/v1x2.rb
+++ b/config/routes/v1x2.rb
@@ -39,7 +39,7 @@ namespace :v1x2, :path => "v1.2" do
   end
   resources :icons, :only => [:create, :destroy]
   resources :order_processes, :only => [:create, :destroy, :index, :show, :update], :concerns => [:taggable] do
-    patch :pre, :to => 'order_processes#update_pre'
+    patch :before_portfolio_item, :to => 'order_processes#update_before_portfolio_item'
   end
   resources :settings
   resources :tags, :only => [:index]

--- a/db/migrate/20200626043755_add_before_portfolio_item_id_to_order_processes.rb
+++ b/db/migrate/20200626043755_add_before_portfolio_item_id_to_order_processes.rb
@@ -1,0 +1,5 @@
+class AddBeforePortfolioItemIdToOrderProcesses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_processes, :before_portfolio_item_id, :integer
+  end
+end

--- a/db/migrate/20200626043755_add_pre_id_to_order_processes.rb
+++ b/db/migrate/20200626043755_add_pre_id_to_order_processes.rb
@@ -1,5 +1,0 @@
-class AddPreIdToOrderProcesses < ActiveRecord::Migration[5.2]
-  def change
-    add_column :order_processes, :pre_id, :integer
-  end
-end

--- a/db/migrate/20200626043755_add_pre_id_to_order_processes.rb
+++ b/db/migrate/20200626043755_add_pre_id_to_order_processes.rb
@@ -1,0 +1,5 @@
+class AddPreIdToOrderProcesses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_processes, :pre_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_10_185514) do
+ActiveRecord::Schema.define(version: 2020_06_26_043755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,8 +95,8 @@ ActiveRecord::Schema.define(version: 2020_06_10_185514) do
     t.bigint "portfolio_item_id"
     t.jsonb "service_parameters"
     t.jsonb "provider_control_parameters"
-    t.string "owner"
     t.jsonb "context"
+    t.string "owner"
     t.string "external_url"
     t.string "insights_request_id"
     t.datetime "discarded_at"
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 2020_06_10_185514) do
     t.bigint "tenant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "pre_id"
   end
 
   create_table "orders", force: :cascade do |t|
@@ -167,9 +168,9 @@ ActiveRecord::Schema.define(version: 2020_06_10_185514) do
     t.string "distributor"
     t.string "documentation_url"
     t.string "support_url"
-    t.string "service_offering_icon_ref"
     t.datetime "discarded_at"
     t.string "owner"
+    t.string "service_offering_icon_ref"
     t.string "service_offering_type"
     t.bigint "icon_id"
     t.index ["discarded_at"], name: "index_portfolio_items_on_discarded_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_26_043755) do
+ActiveRecord::Schema.define(version: 2020_07_07_095138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,7 +122,7 @@ ActiveRecord::Schema.define(version: 2020_06_26_043755) do
     t.bigint "tenant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "pre_id"
+    t.integer "before_portfolio_item_id"
   end
 
   create_table "orders", force: :cascade do |t|

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -2762,6 +2762,58 @@
         }
       }
     },
+    "/order_processes/{id}/pre": {
+      "post": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Add Pre product for Order Process",
+        "operationId": "addOrderProcessPre",
+        "description": "Adds a 'pre' product to an Order Process object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "'Pre' product successfully added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrderProcess"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "OrderProcess or PortfolioItem Not Found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderProcessPortfolioItemId"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/order_processes/{id}/tag": {
       "post": {
         "tags": [
@@ -3237,6 +3289,16 @@
             "type": "string",
             "title": "Restore Key",
             "example": "3c1d765c1453916143e517bfc27b57ace3da693c"
+          }
+        }
+      },
+      "OrderProcessPortfolioItemId": {
+        "type": "object",
+        "properties": {
+          "portfolio_item_id": {
+            "type": "string",
+            "title": "Portfolio Item Id",
+            "example": "1234"
           }
         }
       },
@@ -3994,6 +4056,11 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated at",
+            "readOnly": true
+          },
+          "pre_id": {
+            "type": "string",
+            "description": "The ID of the portfolio item associated to the 'pre' step",
             "readOnly": true
           },
           "metadata": {

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -2763,7 +2763,7 @@
       }
     },
     "/order_processes/{id}/pre": {
-      "post": {
+      "patch": {
         "tags": [
           "OrderProcess"
         ],
@@ -2781,10 +2781,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/OrderProcess"
-                  }
+                  "$ref": "#/components/schemas/OrderProcess"
                 }
               }
             }

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -2762,14 +2762,14 @@
         }
       }
     },
-    "/order_processes/{id}/pre": {
+    "/order_processes/{id}/before_portfolio_item": {
       "patch": {
         "tags": [
           "OrderProcess"
         ],
-        "summary": "Add Pre product for Order Process",
-        "operationId": "addOrderProcessPre",
-        "description": "Adds a 'pre' product to an Order Process object",
+        "summary": "Adds a 'before' product for an Order Process",
+        "operationId": "addOrderProcessBeforeItem",
+        "description": "Defines the product that will be executed before ordering when using this Order Process",
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
@@ -2777,7 +2777,7 @@
         ],
         "responses": {
           "201": {
-            "description": "'Pre' product successfully added",
+            "description": "'Before' product successfully added",
             "content": {
               "application/json": {
                 "schema": {
@@ -4055,9 +4055,9 @@
             "title": "Updated at",
             "readOnly": true
           },
-          "pre_id": {
+          "before_portfolio_item_id": {
             "type": "string",
-            "description": "The ID of the portfolio item associated to the 'pre' step",
+            "description": "The ID of the portfolio item associated to the 'before' step",
             "readOnly": true
           },
           "metadata": {

--- a/spec/requests/api/v1.2/order_processes_controller_spec.rb
+++ b/spec/requests/api/v1.2/order_processes_controller_spec.rb
@@ -107,11 +107,11 @@ describe "v1.2 - OrderProcesses", :type => [:request, :controller, :v1x2] do
     end
   end
 
-  describe "POST /order_processes/:id/pre #pre" do
+  describe "PATCH /order_processes/:id/pre #pre" do
     let(:valid_attributes) { {:portfolio_item_id => pre_portfolio_item_id} }
 
     subject do
-      post "#{api_version}/order_processes/#{order_process_id}/pre", :headers => default_headers, :params => valid_attributes
+      patch "#{api_version}/order_processes/#{order_process_id}/pre", :headers => default_headers, :params => valid_attributes
     end
 
     context "with valid attributes" do

--- a/spec/requests/api/v1.2/order_processes_controller_spec.rb
+++ b/spec/requests/api/v1.2/order_processes_controller_spec.rb
@@ -117,21 +117,20 @@ describe "v1.2 - OrderProcesses", :type => [:request, :controller, :v1x2] do
     it_behaves_like "action that tests authorization", :update?, OrderProcess
   end
 
-  describe "PATCH /order_processes/:id/pre #pre" do
+  describe "PATCH /order_processes/:id/before_portfolio_item #before_portfolio_item" do
     let(:order_process_associator) { instance_double(Api::V1x2::Catalog::OrderProcessAssociator) }
-    let!(:pre_portfolio_item) { create(:portfolio_item) }
-    let(:pre_portfolio_item_id) { pre_portfolio_item.id.to_s }
-    let(:valid_attributes) { {:portfolio_item_id => pre_portfolio_item_id} }
+    let!(:before_portfolio_item) { create(:portfolio_item) }
+    let(:before_portfolio_item_id) { before_portfolio_item.id.to_s }
+    let(:valid_attributes) { {:portfolio_item_id => before_portfolio_item_id} }
 
     subject do
-      patch "#{api_version}/order_processes/#{order_process_id}/pre", :headers => default_headers, :params => valid_attributes
+      patch "#{api_version}/order_processes/#{order_process_id}/before_portfolio_item", :headers => default_headers, :params => valid_attributes
     end
 
     context "with valid attributes" do
-
       before do
         allow(Api::V1x2::Catalog::OrderProcessAssociator).to receive(:new)
-          .with(order_process, pre_portfolio_item_id, :pre)
+          .with(order_process, before_portfolio_item_id, :before_portfolio_item)
           .and_return(order_process_associator)
         allow(order_process_associator).to receive(:process).and_return(order_process_associator)
         allow(order_process_associator).to receive(:order_process).and_return(order_process)
@@ -162,7 +161,7 @@ describe "v1.2 - OrderProcesses", :type => [:request, :controller, :v1x2] do
 
     context "when the order process does not exist" do
       subject do
-        patch "#{api_version}/order_processes/#{order_process_id + 1}/pre", :headers => default_headers
+        patch "#{api_version}/order_processes/#{order_process_id + 1}/before_portfolio_item", :headers => default_headers
       end
 
       it "returns a 404" do

--- a/spec/requests/api/v1.2/order_processes_controller_spec.rb
+++ b/spec/requests/api/v1.2/order_processes_controller_spec.rb
@@ -107,6 +107,47 @@ describe "v1.2 - OrderProcesses", :type => [:request, :controller, :v1x2] do
     end
   end
 
+  describe "POST /order_processes/:id/pre #pre" do
+    let(:valid_attributes) { {:portfolio_item_id => pre_portfolio_item_id} }
+
+    subject do
+      post "#{api_version}/order_processes/#{order_process_id}/pre", :headers => default_headers, :params => valid_attributes
+    end
+
+    context "with valid attributes" do
+      let!(:pre_portfolio_item) { create(:portfolio_item) }
+      let(:pre_portfolio_item_id) { pre_portfolio_item.id.to_s }
+
+      it "updates an OrderProcess" do
+        subject
+        expect(response).to have_http_status(200)
+        expect(json["pre_id"]).to eq(pre_portfolio_item.id.to_s)
+        updated_order_process = OrderProcess.find(order_process_id)
+        expect(updated_order_process.pre).to eq(pre_portfolio_item)
+      end
+
+      context "with no update permission" do
+        before do
+          allow(rbac_access).to receive(:update_access_check).and_return(false)
+        end
+
+        it "returns 403" do
+          subject
+          expect(response).to have_http_status(403)
+        end
+      end
+    end
+
+    context "when no portfolio item exists with the given id" do
+      let(:pre_portfolio_item_id) { "1234" }
+
+      it "returns a 404" do
+        subject
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
   describe "DELETE /order_processes #destroy" do
     it "allows to delete order process" do
       delete "#{api_version}/order_processes/#{order_process_id}", :headers => default_headers

--- a/spec/services/api/v1.2/order_process_associator_spec.rb
+++ b/spec/services/api/v1.2/order_process_associator_spec.rb
@@ -7,19 +7,19 @@ describe Api::V1x2::Catalog::OrderProcessAssociator do
 
     context "when the portfolio item cannot be found" do
       subject { described_class.new(order_process, portfolio_item.id + 1, association) }
-      let(:association) { :pre }
+      let(:association) { :before_portfolio_item }
 
       it "raises an error" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
-    context "when the association is :pre" do
-      let(:association) { :pre }
+    context "when the association is :before_portfolio_item" do
+      let(:association) { :before_portfolio_item }
 
-      it "updates the order process 'pre' step" do
+      it "updates the order process 'before_portfolio_item' step" do
         updated_process = subject.process.order_process
-        expect(updated_process.pre).to eq(portfolio_item)
+        expect(updated_process.before_portfolio_item).to eq(portfolio_item)
       end
     end
   end

--- a/spec/services/api/v1.2/order_process_associator_spec.rb
+++ b/spec/services/api/v1.2/order_process_associator_spec.rb
@@ -1,0 +1,26 @@
+describe Api::V1x2::Catalog::OrderProcessAssociator do
+  describe "#process" do
+    subject { described_class.new(order_process, portfolio_item.id, association) }
+
+    let(:order_process) { create(:order_process) }
+    let(:portfolio_item) { create(:portfolio_item) }
+
+    context "when the portfolio item cannot be found" do
+      subject { described_class.new(order_process, portfolio_item.id + 1, association) }
+      let(:association) { :pre }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when the association is :pre" do
+      let(:association) { :pre }
+
+      it "updates the order process 'pre' step" do
+        updated_process = subject.process.order_process
+        expect(updated_process.pre).to eq(portfolio_item)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the ~~`#pre`~~ `before_portfolio_item` endpoint to the OrderProcess API, and thus should make adding the ~~`#post`~~ `after_portfolio_item` relatively straightforward.

https://projects.engineering.redhat.com/browse/SSP-1579