### PR TITLE
Add 'after' API endpoint for order processes

### DIFF
--- a/app/controllers/api/v1x2/order_processes_controller.rb
+++ b/app/controllers/api/v1x2/order_processes_controller.rb
@@ -34,14 +34,26 @@ module Api
       end
 
       def update_before_portfolio_item
+        order_process = update_association(:before_portfolio_item)
+
+        render :json => order_process
+      end
+
+      def update_after_portfolio_item
+        order_process = update_association(:after_portfolio_item)
+
+        render :json => order_process
+      end
+
+      private
+
+      def update_association(association)
         order_process = OrderProcess.find(params.require(:order_process_id))
         authorize(order_process, :update?)
 
-        order_process = Catalog::OrderProcessAssociator.new(
-          order_process, params.require(:portfolio_item_id), :before_portfolio_item
+        Catalog::OrderProcessAssociator.new(
+          order_process, params.require(:portfolio_item_id), association
         ).process.order_process
-
-        render :json => order_process
       end
     end
   end

--- a/app/models/order_process.rb
+++ b/app/models/order_process.rb
@@ -4,7 +4,7 @@ class OrderProcess < ApplicationRecord
   acts_as_taggable_on
 
   belongs_to :before_portfolio_item, :class_name => 'PortfolioItem'
-  # belongs_to :after_portfolio_item, :class_name => 'PortfolioItem'
+  belongs_to :after_portfolio_item, :class_name => 'PortfolioItem'
   has_many :tag_links, :dependent => :destroy, :inverse_of => :order_process
 
   def metadata

--- a/config/routes/v1x2.rb
+++ b/config/routes/v1x2.rb
@@ -40,6 +40,7 @@ namespace :v1x2, :path => "v1.2" do
   resources :icons, :only => [:create, :destroy]
   resources :order_processes, :only => [:create, :destroy, :index, :show, :update], :concerns => [:taggable] do
     patch :before_portfolio_item, :to => 'order_processes#update_before_portfolio_item'
+    patch :after_portfolio_item, :to => 'order_processes#update_after_portfolio_item'
   end
   resources :settings
   resources :tags, :only => [:index]

--- a/db/migrate/20200707095138_add_after_portfolio_item_id_to_order_processes.rb
+++ b/db/migrate/20200707095138_add_after_portfolio_item_id_to_order_processes.rb
@@ -1,0 +1,5 @@
+class AddAfterPortfolioItemIdToOrderProcesses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_processes, :after_portfolio_item_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 2020_07_09_201525) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "before_portfolio_item_id"
+    t.integer "after_portfolio_item_id"
   end
 
   create_table "orders", force: :cascade do |t|

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -2811,6 +2811,55 @@
         }
       }
     },
+    "/order_processes/{id}/after_portfolio_item": {
+      "patch": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Adds an 'after' product for an Order Process",
+        "operationId": "addOrderProcessAfterItem",
+        "description": "Defines the product that will be executed after ordering when using this Order Process",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "'After' product successfully added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderProcess"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "OrderProcess or PortfolioItem Not Found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderProcessPortfolioItemId"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/order_processes/{id}/tag": {
       "post": {
         "tags": [
@@ -4058,6 +4107,11 @@
           "before_portfolio_item_id": {
             "type": "string",
             "description": "The ID of the portfolio item associated to the 'before' step",
+            "readOnly": true
+          },
+          "after_portfolio_item_id": {
+            "type": "string",
+            "description": "The ID of the portfolio item associated to the 'after' step",
             "readOnly": true
           },
           "metadata": {

--- a/spec/services/api/v1.2/order_process_associator_spec.rb
+++ b/spec/services/api/v1.2/order_process_associator_spec.rb
@@ -22,5 +22,14 @@ describe Api::V1x2::Catalog::OrderProcessAssociator do
         expect(updated_process.before_portfolio_item).to eq(portfolio_item)
       end
     end
+
+    context "when the association is :after_portfolio_item" do
+      let(:association) { :after_portfolio_item }
+
+      it "updates the order process 'after_portfolio_item' step" do
+        updated_process = subject.process.order_process
+        expect(updated_process.after_portfolio_item).to eq(portfolio_item)
+      end
+    end
   end
 end


### PR DESCRIPTION
Built on top of #771, wait to merge this until that goes in as it will be smaller and therefore simpler to review.

https://projects.engineering.redhat.com/browse/SSP-1580

~~Also, I just now thought of this, but is this confusing at all due to the http verb `POST`?~~ Using before/after is the preferred terminology now.