### PR TITLE
Wrapping transaction around portfolio copy

### DIFF
--- a/app/services/api/v1x0/catalog/copy_portfolio.rb
+++ b/app/services/api/v1x0/catalog/copy_portfolio.rb
@@ -19,14 +19,16 @@ module Api
         private
 
         def make_copy
-          @portfolio.dup.tap do |new_portfolio|
-            new_portfolio.name = @name || ::Catalog::NameAdjust.create_copy_name(@portfolio.name, Portfolio.all.pluck(:name), Portfolio::MAX_NAME_LENGTH)
+          Portfolio.transaction do
+            @portfolio.dup.tap do |new_portfolio|
+              new_portfolio.name = @name || ::Catalog::NameAdjust.create_copy_name(@portfolio.name, Portfolio.all.pluck(:name), Portfolio::MAX_NAME_LENGTH)
 
-            duplicate_icon(@portfolio, new_portfolio) if @portfolio.icon_id.present?
+              duplicate_icon(@portfolio, new_portfolio) if @portfolio.icon_id.present?
 
-            new_portfolio.save!
+              new_portfolio.save!
 
-            copy_portfolio_items(new_portfolio.id)
+              copy_portfolio_items(new_portfolio.id)
+            end
           end
         end
 

--- a/spec/services/api/v1.0/catalog/copy_portfolio_spec.rb
+++ b/spec/services/api/v1.0/catalog/copy_portfolio_spec.rb
@@ -51,5 +51,25 @@ describe Api::V1x0::Catalog::CopyPortfolio, :type => :service do
         expect(new_portfolio.name).to eq "Copy (2) of #{portfolio.name}"
       end
     end
+
+    context "with exception during copy" do
+      let(:copy_portfolio) { described_class.new(:portfolio_id => portfolio.id) }
+      let(:error)          { ::Catalog::OrderUncancelable }
+
+      before do
+        allow(copy_portfolio).to receive(:copy_portfolio_items).and_raise(error)
+        expect { copy_portfolio.process }.to raise_error(error)
+      end
+
+      it 'does not create a new portfolio' do
+        expect(copy_portfolio.new_portfolio).to eq(nil)
+      end
+
+      it 'removes all partial data' do
+        expect(Icon.count).to eq(1)
+        expect(Portfolio.count).to eq(2)
+        expect(PortfolioItem.count).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
Making the portfolio copy logic to behave like a transaction.