### PR TITLE
Add OrderProcess#remove_association API endpoint

### DIFF
--- a/app/controllers/api/v1x2/order_processes_controller.rb
+++ b/app/controllers/api/v1x2/order_processes_controller.rb
@@ -45,6 +45,18 @@ module Api
         render :json => order_process
       end
 
+      def remove_association
+        order_process = OrderProcess.find(params.require(:order_process_id))
+        authorize(order_process, :update?)
+
+        order_process = Catalog::OrderProcessDissociator.new(
+          order_process,
+          params.require(:associations_to_remove)
+        ).process.order_process
+
+        render :json => order_process
+      end
+
       private
 
       def update_association(association)

--- a/app/services/api/v1x2/catalog/order_process_dissociator.rb
+++ b/app/services/api/v1x2/catalog/order_process_dissociator.rb
@@ -1,0 +1,32 @@
+module Api
+  module V1x2
+    module Catalog
+      class OrderProcessDissociator
+        ASSOCIATION_MAP = {"before" => :before_portfolio_item, "after" => :after_portfolio_item}.freeze
+
+        attr_reader :order_process
+
+        def initialize(order_process, associations_to_remove)
+          @order_process = order_process
+          @associations_to_remove = associations_to_remove
+        end
+
+        def process
+          map_associations_to_remove.each do |association|
+            @order_process.update(association => nil)
+          end
+
+          self
+        end
+
+        private
+
+        def map_associations_to_remove
+          @associations_to_remove.collect do |association|
+            ASSOCIATION_MAP[association]
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes/v1x2.rb
+++ b/config/routes/v1x2.rb
@@ -41,6 +41,7 @@ namespace :v1x2, :path => "v1.2" do
   resources :order_processes, :only => [:create, :destroy, :index, :show, :update], :concerns => [:taggable] do
     patch :before_portfolio_item, :to => 'order_processes#update_before_portfolio_item'
     patch :after_portfolio_item, :to => 'order_processes#update_after_portfolio_item'
+    post  :remove_association, :to => 'order_processes#remove_association'
   end
   resources :settings
   resources :tags, :only => [:index]

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -2860,6 +2860,55 @@
         }
       }
     },
+    "/order_processes/{id}/remove_association": {
+      "post": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Removes the 'before' and/or 'after' product(s) for an Order Process",
+        "operationId": "removeOrderProcessAssociation",
+        "description": "Removes the association to the product(s) defined in the 'before' and/or 'after' that would be executed when using this Order Process",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Product(s) successfully removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderProcess"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "OrderProcess Not Found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderProcessAssociationsToRemove"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/order_processes/{id}/tag": {
       "post": {
         "tags": [
@@ -3345,6 +3394,23 @@
             "type": "string",
             "title": "Portfolio Item Id",
             "example": "1234"
+          }
+        }
+      },
+      "OrderProcessAssociationsToRemove": {
+        "type": "object",
+        "properties": {
+          "associations_to_remove": {
+            "type": "array",
+            "title": "Association(s) to remove",
+            "items": {
+              "type": "string",
+              "enum": [
+                "before",
+                "after"
+              ]
+            },
+            "example": ["before", "after"]
           }
         }
       },

--- a/spec/services/api/v1.2/order_process_dissociator_spec.rb
+++ b/spec/services/api/v1.2/order_process_dissociator_spec.rb
@@ -1,0 +1,46 @@
+describe Api::V1x2::Catalog::OrderProcessDissociator do
+  describe "#process" do
+    let(:order_process) do
+      create(:order_process,
+             :before_portfolio_item => before_portfolio_item,
+             :after_portfolio_item  => after_portfolio_item)
+    end
+    let(:before_portfolio_item) { create(:portfolio_item) }
+    let(:after_portfolio_item) { create(:portfolio_item) }
+
+    subject { described_class.new(order_process, associations_to_remove).process }
+
+    context "when removing a 'before' association" do
+      let(:associations_to_remove) { ["before"] }
+
+      it "removes the 'before' association but leaves the 'after'" do
+        subject
+        order_process.reload
+        expect(order_process.before_portfolio_item).to eq(nil)
+        expect(order_process.after_portfolio_item).to eq(after_portfolio_item)
+      end
+    end
+
+    context "when removing an 'after' association" do
+      let(:associations_to_remove) { ["after"] }
+
+      it "removes the 'after' association but leaves the 'before'" do
+        subject
+        order_process.reload
+        expect(order_process.after_portfolio_item).to eq(nil)
+        expect(order_process.before_portfolio_item).to eq(before_portfolio_item)
+      end
+    end
+
+    context "when removing both associations" do
+      let(:associations_to_remove) { %w[before after] }
+
+      it "removes both associations" do
+        subject
+        order_process.reload
+        expect(order_process.before_portfolio_item).to eq(nil)
+        expect(order_process.after_portfolio_item).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#771 and #772 exposed the API for adding the before/after portfolio item associations for an order process, but there was no way to remove them. This API endpoint allows the user to pass in an array of `["before"]`, `["after"]`, or `["before", "after"]`, to clear the relevant association(s).

https://projects.engineering.redhat.com/browse/SSP-1666

@gmcculloug Please Review. Also, curious if we should be exposing these actions (the setting of the before/after and the clear) as separate user capabilities, even though they all follow the same rules as the "update" policy. Would be done as a separate PR, of course.