### PR TITLE
Add process_sequence and process_scope columns for order_items

### DIFF
--- a/db/migrate/20200731045804_add_order_item_process_columns.rb
+++ b/db/migrate/20200731045804_add_order_item_process_columns.rb
@@ -1,0 +1,6 @@
+class AddOrderItemProcessColumns < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_items, :process_sequence, :integer
+    add_column :order_items, :process_scope, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_09_201525) do
+ActiveRecord::Schema.define(version: 2020_07_31_045804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,13 +95,15 @@ ActiveRecord::Schema.define(version: 2020_07_09_201525) do
     t.bigint "portfolio_item_id"
     t.jsonb "service_parameters"
     t.jsonb "provider_control_parameters"
-    t.jsonb "context"
     t.string "owner"
+    t.jsonb "context"
     t.string "external_url"
     t.string "insights_request_id"
     t.datetime "discarded_at"
     t.jsonb "service_parameters_raw"
     t.string "service_instance_ref"
+    t.integer "process_sequence"
+    t.string "process_scope"
     t.index ["discarded_at"], name: "index_order_items_on_discarded_at"
     t.index ["tenant_id"], name: "index_order_items_on_tenant_id"
   end

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -3817,6 +3817,20 @@
             "example": "364498f142194beba576833d7303abe5",
             "description": "The insights request id can be used to collect log data for this order item as its processed by the system",
             "readOnly": true
+          },
+          "process_sequence": {
+            "type": "integer",
+            "title": "Sequence of when the order item is ran",
+            "example": 1,
+            "description": "The sequence that this order item is ran relative to the other order items within the order.",
+            "readOnly": true
+          },
+          "process_scope": {
+            "type": "string",
+            "title": "Scope of when the order item is ran",
+            "example": "before",
+            "description": "Denotes the scope in which the order item will run for the order it belongs to. It can be 'before', 'after', or 'applicable'",
+            "readOnly": true
           }
         }
       },


### PR DESCRIPTION
After starting on the order process evaluation, I realized we need these two columns in place before we can write to them (duh), but that is also the main "evaluation" that is being done, so without them it doesn't make much sense.

https://projects.engineering.redhat.com/browse/SSP-1583

I'm open to naming suggestions as well, I thought about these for a while but if someone has better names I'm all ears. I'm still not completely convinced by `"applicable"` to denote the *actual* thing being ordered and not a "before" or "after", but I wasn't very fond of "pertinent" or "relevant" either.