### PR TITLE
Evaluate order process during OrderController#submit_order

### DIFF
--- a/app/controllers/api/v1x2.rb
+++ b/app/controllers/api/v1x2.rb
@@ -13,7 +13,6 @@ module Api
     class GraphqlController                   < Api::V1x1::GraphqlController; end
     class IconsController                     < Api::V1x1::IconsController; end
     class OrderItemsController                < Api::V1x1::OrderItemsController; end
-    class OrdersController                    < Api::V1x1::OrdersController; end
     class PortfolioItemsController            < Api::V1x1::PortfolioItemsController; end
     class PortfoliosController                < Api::V1x1::PortfoliosController; end
     class ProgressMessagesController          < Api::V1x1::ProgressMessagesController; end

--- a/app/controllers/api/v1x2/orders_controller.rb
+++ b/app/controllers/api/v1x2/orders_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1x2
+    class OrdersController < Api::V1x1::OrdersController
+      def submit_order
+        @order = Order.find(params.require(:order_id))
+        authorize(@order)
+
+        service_offering_check
+
+        Catalog::EvaluateOrderProcess.new(@order).process
+
+        order = Catalog::CreateRequestForAppliedInventories.new(@order).process.order
+        render :json => order
+      end
+    end
+  end
+end

--- a/app/services/api/v1x2.rb
+++ b/app/services/api/v1x2.rb
@@ -8,7 +8,6 @@ module Api
       class CopyPortfolio                       < Api::V1x1::Catalog::CopyPortfolio; end
       class CopyPortfolioItem                   < Api::V1x1::Catalog::CopyPortfolioItem; end
       class CreateIcon                          < Api::V1x1::Catalog::CreateIcon; end
-      class CreateRequestForAppliedInventories  < Api::V1x1::Catalog::CreateRequestForAppliedInventories; end
       class DuplicateImage                      < Api::V1x1::Catalog::DuplicateImage; end
       class ImportServicePlans                  < Api::V1x1::Catalog::ImportServicePlans; end
       class NextName                            < Api::V1x1::Catalog::NextName; end

--- a/app/services/api/v1x2/catalog/add_to_order_via_order_process.rb
+++ b/app/services/api/v1x2/catalog/add_to_order_via_order_process.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1x2
+    module Catalog
+      class AddToOrderViaOrderProcess < Api::V1x0::Catalog::AddToOrder
+        attr_reader :order_item
+
+        private
+
+        def order_item_params
+          @params
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v1x2/catalog/create_request_for_applied_inventories.rb
+++ b/app/services/api/v1x2/catalog/create_request_for_applied_inventories.rb
@@ -1,0 +1,12 @@
+module Api
+  module V1x2
+    module Catalog
+      class CreateRequestForAppliedInventories < Api::V1x1::Catalog::CreateRequestForAppliedInventories
+        def initialize(order)
+          @order = order
+          @item = @order.order_items.where(:process_scope => "applicable").first
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v1x2/catalog/evaluate_order_process.rb
+++ b/app/services/api/v1x2/catalog/evaluate_order_process.rb
@@ -1,0 +1,68 @@
+module Api
+  module V1x2
+    module Catalog
+      class EvaluateOrderProcess
+        def initialize(order)
+          @order = order
+        end
+
+        def process
+          applicable_order_item = @order.order_items.first
+
+          relevant_order_processes = find_relevant_order_processes
+
+          # TODO: Put the order processes in order by their sequence number before
+          # doing this logic
+          @before_sequence_number = 1
+          @after_sequence_number = (relevant_order_processes.length * 2) + 1
+
+          relevant_order_processes.each do |order_process|
+            Catalog::AddToOrderViaOrderProcess.new(before_params(order_process)).process
+            Catalog::AddToOrderViaOrderProcess.new(after_params(order_process)).process
+
+            @before_sequence_number += 1
+            @after_sequence_number -= 1
+          end
+
+          applicable_sequence = (relevant_order_processes.length + 1)
+          applicable_order_item.update(:process_sequence => applicable_sequence, :process_scope => "applicable")
+
+          self
+        end
+
+        private
+
+        def find_relevant_order_processes
+          order_process_ids = TagLink.where(:tag_name => all_tags).pluck(:order_process_id)
+
+          OrderProcess.where(:id => order_process_ids)
+        end
+
+        def all_tags
+          portfolio_item_tags = @order.order_items.first.portfolio_item.tags
+          portfolio_tags = @order.order_items.first.portfolio_item.portfolio.tags
+
+          (portfolio_item_tags + portfolio_tags).uniq.collect(&:to_tag_string)
+        end
+
+        def before_params(order_process)
+          {
+            :order_id          => @order.id,
+            :portfolio_item_id => order_process.before_portfolio_item.id,
+            :process_sequence  => @before_sequence_number,
+            :process_scope     => "before"
+          }
+        end
+
+        def after_params(order_process)
+          {
+            :order_id          => @order.id,
+            :portfolio_item_id => order_process.after_portfolio_item.id,
+            :process_sequence  => @after_sequence_number,
+            :process_scope     => "after"
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/catalog/create_approval_request.rb
+++ b/lib/catalog/create_approval_request.rb
@@ -8,7 +8,10 @@ module Catalog
     end
 
     def process
-      @order.order_items.each do |order_item|
+      # Possibly in the future we may want to create approval requests for
+      # a before or after order item, but currently it is only for the
+      # applicable product.
+      @order.order_items.where(:process_scope => 'applicable').each do |order_item|
         submit_approval_requests(order_item)
       end
 

--- a/lib/catalog/submit_order.rb
+++ b/lib/catalog/submit_order.rb
@@ -10,7 +10,11 @@ module Catalog
 
     def process
       @order = Order.find_by!(:id => @order_id)
-      @order.order_items.each do |order_item|
+
+      # TODO: This will need to be updated to figure out the next order item in the
+      # process sequence to run. For now, we will only submit the 'applicable' order
+      # item.
+      @order.order_items.where(:process_scope => 'applicable').each do |order_item|
         raise ::Catalog::NotAuthorized unless valid_source?(order_item.portfolio_item.service_offering_source_ref)
 
         if ::Catalog::SurveyCompare.any_changed?(order_item.portfolio_item.service_plans)

--- a/spec/factories/order_process.rb
+++ b/spec/factories/order_process.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :order_process, :traits => [:has_tenant] do
-    name { 'order_process_name' }
+    sequence(:name) { |n| "order_process_name_#{n}" }
   end
 end

--- a/spec/lib/catalog/create_approval_request_spec.rb
+++ b/spec/lib/catalog/create_approval_request_spec.rb
@@ -9,7 +9,7 @@ describe Catalog::CreateApprovalRequest, :type => :service do
   end
 
   let(:order) { order_item.order }
-  let!(:order_item) { create(:order_item, :topology_task_ref => "123") }
+  let!(:order_item) { create(:order_item, :topology_task_ref => "123", :process_scope => 'applicable') }
 
   let(:create_request_body_from) { instance_double(Catalog::CreateRequestBodyFrom, :result => request_body_from) }
   let(:request_body_from) { {"test" => "test"}.to_json }

--- a/spec/lib/catalog/submit_order_spec.rb
+++ b/spec/lib/catalog/submit_order_spec.rb
@@ -25,12 +25,6 @@ describe Catalog::SubmitOrder, :type => [:service, :topology, :current_forwardab
   let(:topo_service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => [topo_service_plan]) }
   let(:service_plan_response) { topo_service_plan_response }
 
-  around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com") do
-      example.call
-    end
-  end
-
   include_context "uses an order item with raw service parameters set"
 
   before do

--- a/spec/requests/api/v1.2/orders_controller_spec.rb
+++ b/spec/requests/api/v1.2/orders_controller_spec.rb
@@ -1,0 +1,106 @@
+describe "v1.2 - OrdersCotnroller", :type => [:request, :controller, :v1x2] do
+  let!(:order) { create(:order) }
+  let!(:order_item) { create(:order_item, :order => order) }
+  let!(:order2) { create(:order) }
+  let!(:order_item2) { create(:order_item, :order => order2) }
+  let(:catalog_access) { instance_double(Insights::API::Common::RBAC::Access, :scopes => %w[admin]) }
+  before do
+     allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
+     allow(catalog_access).to receive(:process).and_return(catalog_access)
+  end
+
+  describe "#submit_order" do
+    let(:service_offering_service) { instance_double("Api::V1x0::Catalog::ServiceOffering") }
+    subject { post "#{api_version}/orders/#{order.id}/submit_order", :headers => default_headers }
+
+    before do
+      allow(Api::V1x0::Catalog::ServiceOffering).to receive(:new).with(order).and_return(service_offering_service)
+      allow(service_offering_service).to receive(:process).and_return(service_offering_service)
+      allow(service_offering_service).to receive(:archived).and_return(archived)
+      allow(service_offering_service).to receive(:order).and_return(order)
+    end
+
+    context "when the service offering has not been archived" do
+      let(:archived) { false }
+      let(:svc_object) { instance_double("Catalog::CreateRequestForAppliedInventories") }
+      let(:evaluate_order_process) { instance_double(Api::V1x2::Catalog::EvaluateOrderProcess) }
+
+      before do |example|
+        allow(Api::V1x2::Catalog::EvaluateOrderProcess).to receive(:new).with(order).and_return(evaluate_order_process)
+        allow(evaluate_order_process).to receive(:process)
+        allow(Api::V1x2::Catalog::CreateRequestForAppliedInventories).to receive(:new).with(order).and_return(svc_object)
+        allow(svc_object).to receive(:process).and_return(svc_object)
+        allow(svc_object).to receive(:order).and_return(order)
+        subject unless example.metadata[:subject_inside]
+      end
+
+      it_behaves_like "action that tests authorization", :submit_order?, Order
+
+      it "creates a request for applied inventories", :subject_inside do
+        expect(svc_object).to receive(:process)
+        subject
+      end
+
+      it "returns a 200" do
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns the order in json format" do
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body["state"]).to eq("Created")
+        expect(parsed_body["id"]).to eq(order.id.to_s)
+      end
+    end
+
+    context "when the service offering has been archived" do
+      let(:archived) { true }
+
+      before do |example|
+        subject unless example.metadata[:subject_inside]
+      end
+
+      it_behaves_like "action that tests authorization", :submit_order?, Order
+
+      it "logs the error", :subject_inside do
+        expect(Rails.logger).to receive(:error).with(/Service offering for order #{order.id} has been archived/).twice
+
+        subject
+      end
+
+      it "creates progress messages for the order items" do
+        expect(ProgressMessage.last.message).to match(/has been archived/)
+      end
+
+      it "marks the order as failed" do
+        order.reload
+        expect(order.state).to eq("Failed")
+      end
+
+      it "returns a 400" do
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "when the survey has changed" do
+      let(:archived) { false }
+
+      let!(:order_item) { create(:order_item, :order => order) }
+      let!(:service_plan) { create(:service_plan, :portfolio_item => order.order_items.first.portfolio_item) }
+
+      before do |example|
+        allow(::Catalog::SurveyCompare).to receive(:any_changed?).with(order.order_items.first.portfolio_item.service_plans).and_return(true)
+
+        subject unless example.metadata[:subject_inside]
+      end
+
+      it_behaves_like "action that tests authorization", :submit_order?, Order
+
+      it "returns a 400" do
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(400)
+        expect(first_error_detail).to match(/Catalog::InvalidSurvey/)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1.2/orders_controller_spec.rb
+++ b/spec/requests/api/v1.2/orders_controller_spec.rb
@@ -5,8 +5,8 @@ describe "v1.2 - OrdersCotnroller", :type => [:request, :controller, :v1x2] do
   let!(:order_item2) { create(:order_item, :order => order2) }
   let(:catalog_access) { instance_double(Insights::API::Common::RBAC::Access, :scopes => %w[admin]) }
   before do
-     allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
-     allow(catalog_access).to receive(:process).and_return(catalog_access)
+    allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
+    allow(catalog_access).to receive(:process).and_return(catalog_access)
   end
 
   describe "#submit_order" do

--- a/spec/services/api/v1.2/catalog/add_to_order_via_order_process_spec.rb
+++ b/spec/services/api/v1.2/catalog/add_to_order_via_order_process_spec.rb
@@ -19,13 +19,13 @@ describe Api::V1x2::Catalog::AddToOrderViaOrderProcess, :type => :service do
 
   let(:request) { default_request }
   let(:service_plans_instance) { instance_double(Api::V1x0::Catalog::ServicePlans) }
-  let(:order_item_sanitized_parameters) { instance_double(Api::V1x0::Catalog::OrderItemSanitizedParameters, :sanitized_parameters => {"name" => "fred"}) }
+  let(:order_item_sanitized_parameters) { instance_double(Catalog::OrderItemSanitizedParameters, :sanitized_parameters => {"name" => "fred"}) }
 
   before do
     allow(Api::V1x0::Catalog::ServicePlans).to receive(:new).and_return(service_plans_instance)
     allow(service_plans_instance).to receive(:process).and_return(service_plans_instance)
     allow(service_plans_instance).to receive(:items).and_return([OpenStruct.new(:id => "1")])
-    allow(Api::V1x0::Catalog::OrderItemSanitizedParameters).to receive(:new).with(:order_item => order_item).and_return(order_item_sanitized_parameters)
+    allow(Catalog::OrderItemSanitizedParameters).to receive(:new).with(:order_item => order_item).and_return(order_item_sanitized_parameters)
     allow(order_item_sanitized_parameters).to receive(:process).and_return(order_item_sanitized_parameters)
   end
 

--- a/spec/services/api/v1.2/catalog/add_to_order_via_order_process_spec.rb
+++ b/spec/services/api/v1.2/catalog/add_to_order_via_order_process_spec.rb
@@ -1,0 +1,76 @@
+describe Api::V1x2::Catalog::AddToOrderViaOrderProcess, :type => :service do
+  let(:order) { create(:order) }
+  let(:order_id) { order.id.to_s }
+  let(:order_item) { create(:order_item, :portfolio_item_id => portfolio_item.id) }
+  let(:portfolio_item) { create(:portfolio_item) }
+  let(:portfolio_item_id) { portfolio_item.id.to_s }
+
+  let(:params) do
+    {
+      :order_id                    => order_id,
+      :portfolio_item_id           => portfolio_item_id,
+      :count                       => 1,
+      :service_parameters          => {'name' => 'fred'},
+      :provider_control_parameters => {'age' => 50}
+    }
+  end
+
+  let(:subject) { described_class.new(params).process }
+
+  let(:request) { default_request }
+  let(:service_plans_instance) { instance_double(Api::V1x0::Catalog::ServicePlans) }
+  let(:order_item_sanitized_parameters) { instance_double(Api::V1x0::Catalog::OrderItemSanitizedParameters, :sanitized_parameters => {"name" => "fred"}) }
+
+  before do
+    allow(Api::V1x0::Catalog::ServicePlans).to receive(:new).and_return(service_plans_instance)
+    allow(service_plans_instance).to receive(:process).and_return(service_plans_instance)
+    allow(service_plans_instance).to receive(:items).and_return([OpenStruct.new(:id => "1")])
+    allow(Api::V1x0::Catalog::OrderItemSanitizedParameters).to receive(:new).with(:order_item => order_item).and_return(order_item_sanitized_parameters)
+    allow(order_item_sanitized_parameters).to receive(:process).and_return(order_item_sanitized_parameters)
+  end
+
+  it "add order item" do
+    Insights::API::Common::Request.with_request(request) do
+      expect(subject.order_item.portfolio_item_id).to eq(portfolio_item.id)
+    end
+  end
+
+  context "invalid order" do
+    let(:order_id) { "999" }
+
+    it "invalid order" do
+      expect { described_class.new(params).process }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context "when passing in a x-rh-identity header" do
+    it 'sets the context to the encoded_user_hash' do
+      Insights::API::Common::Request.with_request(request) do
+        expect(subject.order_item.context["headers"]["x-rh-identity"]).to eq encoded_user_hash
+      end
+    end
+
+    it 'can recreate the request from the context' do
+      item = Insights::API::Common::Request.with_request(request) { subject.order_item }
+
+      new_request = item.context.transform_keys(&:to_sym)
+      Insights::API::Common::Request.with_request(new_request) do
+        expect(Insights::API::Common::Request.current.user.username).to eq "jdoe"
+        expect(Insights::API::Common::Request.current.user.email).to eq "jdoe@acme.com"
+      end
+    end
+
+    it "creates a process message with the x-rh-insights-request-id" do
+      progress_message = Insights::API::Common::Request.with_request(request) { subject.order_item.progress_messages.first }
+      expect(progress_message.message).to match('Order item tracking ID (x-rh-insights-request-id): gobbledygook')
+    end
+  end
+
+  context "service_plan_ref_lookup" do
+    it "gets the correct service_plan_ref from topology" do
+      Insights::API::Common::Request.with_request(request) do
+        expect(subject.order_item.service_plan_ref).to eq "1"
+      end
+    end
+  end
+end

--- a/spec/services/api/v1.2/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/api/v1.2/catalog/create_request_for_applied_inventories_spec.rb
@@ -60,4 +60,3 @@ describe Api::V1x2::Catalog::CreateRequestForAppliedInventories, :type => :servi
     end
   end
 end
-

--- a/spec/services/api/v1.2/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/api/v1.2/catalog/create_request_for_applied_inventories_spec.rb
@@ -1,14 +1,8 @@
-describe Api::V1x2::Catalog::CreateRequestForAppliedInventories, :type => :service do
+describe Api::V1x2::Catalog::CreateRequestForAppliedInventories, :type => [:service, :topology] do
   let(:subject) { described_class.new(order_item.order) }
   let(:service_plan_ref) { "991" }
   let!(:order_item) { create(:order_item, :portfolio_item => portfolio_item, :service_parameters => "service_parameters", :service_plan_ref => service_plan_ref, :process_scope => "applicable") }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => 123) }
-
-  around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com") do
-      example.call
-    end
-  end
 
   let(:topology_response) { TopologicalInventoryApiClient::InlineResponse200.new(:task_id => "321") }
   let(:request_body) do

--- a/spec/services/api/v1.2/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/api/v1.2/catalog/create_request_for_applied_inventories_spec.rb
@@ -1,0 +1,63 @@
+describe Api::V1x2::Catalog::CreateRequestForAppliedInventories, :type => :service do
+  let(:subject) { described_class.new(order_item.order) }
+  let(:service_plan_ref) { "991" }
+  let!(:order_item) { create(:order_item, :portfolio_item => portfolio_item, :service_parameters => "service_parameters", :service_plan_ref => service_plan_ref, :process_scope => "applicable") }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => 123) }
+
+  around do |example|
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com") do
+      example.call
+    end
+  end
+
+  let(:topology_response) { TopologicalInventoryApiClient::InlineResponse200.new(:task_id => "321") }
+  let(:request_body) do
+    TopologicalInventoryApiClient::AppliedInventoriesParametersServicePlan.new(
+      :service_parameters => order_item.service_parameters
+    ).to_json
+  end
+
+  before do
+    allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
+    stub_request(:post, topological_url("service_offerings/123/applied_inventories"))
+      .with(:body => request_body)
+      .to_return(:status => 200, :body => topology_response.to_json, :headers => default_headers)
+  end
+
+  describe "#process" do
+    context "when there is not a modified survey" do
+      it "makes a request to compute the applied inventories" do
+        subject.process
+        expect(a_request(:post, topological_url("service_offerings/123/applied_inventories"))
+          .with(:body => request_body)).to have_been_made
+      end
+
+      it "updates the order item topology task ref" do
+        expect(order_item.topology_task_ref).to eq(nil)
+        subject.process
+        order_item.reload
+        expect(order_item.topology_task_ref).to eq("321")
+      end
+
+      it "creates a progress message on the order item" do
+        subject.process
+        progress_message = ProgressMessage.last
+        expect(progress_message.level).to eq("info")
+        expect(progress_message.message).to eq("Waiting for inventories")
+        expect(progress_message.order_item_id).to eq(order_item.id.to_s)
+      end
+    end
+
+    context "when there is a modified survey" do
+      let!(:service_plan) { create(:service_plan, :portfolio_item => portfolio_item) }
+      before { allow(Catalog::SurveyCompare).to receive(:any_changed?).with(portfolio_item.service_plans).and_return(true) }
+
+      context "when the survey does not match topology" do
+        it "raises an error" do
+          expect { subject.process }.to raise_exception(Catalog::InvalidSurvey)
+        end
+      end
+    end
+  end
+end
+

--- a/spec/services/api/v1.2/catalog/evaluate_order_process_spec.rb
+++ b/spec/services/api/v1.2/catalog/evaluate_order_process_spec.rb
@@ -24,7 +24,7 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
       end
     end
 
-    context "when there is 1 existing tag on the portfolio_item" do
+    context "when there are existing tags" do
       let(:before_params) do
         {
           :order_id          => order.id,
@@ -53,7 +53,6 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
 
       before do
         TagLink.create(:order_process_id => order_process.id, :tag_name => "/catalog/order_processes=#{order_process.id}")
-        portfolio.tag_add("order_processes", :namespace => "catalog", :value => order_process.id)
 
         allow(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new)
           .with(before_params)
@@ -65,26 +64,172 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
         allow(add_to_order_via_order_process).to receive(:process)
       end
 
-      it "applies the process sequence of '2' to the order item" do
-        subject
-        expect(order.order_items.first.process_sequence).to eq(2)
+      context "when there is 1 existing tag on the portfolio" do
+        before do
+          portfolio.tag_add("order_processes", :namespace => "catalog", :value => order_process.id)
+        end
+
+        it "applies the process sequence of '2' to the order item" do
+          subject
+          expect(order.order_items.first.process_sequence).to eq(2)
+        end
+
+        it "applies the process scope of 'applicable' to the order item" do
+          subject
+          expect(order.order_items.first.process_scope).to eq("applicable")
+        end
+
+        it "delegates creation of a 'before' order_item with a process sequence of 1" do
+          expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(before_params)
+
+          subject
+        end
+
+        it "delegates creation of an 'after' order_item with a process sequence of 3" do
+          expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(after_params)
+
+          subject
+        end
       end
 
-      it "applies the process scope of 'applicable' to the order item" do
-        subject
-        expect(order.order_items.first.process_scope).to eq("applicable")
+      context "when there is 1 existing tag on the portfolio_item" do
+        before do
+          portfolio_item.tag_add("order_processes", :namespace => "catalog", :value => order_process.id)
+        end
+
+        it "applies the process sequence of '2' to the order item" do
+          subject
+          expect(order.order_items.first.process_sequence).to eq(2)
+        end
+
+        it "applies the process scope of 'applicable' to the order item" do
+          subject
+          expect(order.order_items.first.process_scope).to eq("applicable")
+        end
+
+        it "delegates creation of a 'before' order_item with a process sequence of 1" do
+          expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(before_params)
+
+          subject
+        end
+
+        it "delegates creation of an 'after' order_item with a process sequence of 3" do
+          expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(after_params)
+
+          subject
+        end
       end
 
-      it "delegates creation of a 'before' order_item with a process sequence of 1" do
-        expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(before_params)
+      context "when both the portfolio_item and portfolio have tags" do
+        context "when the tags are the same" do
+          before do
+            portfolio_item.tag_add("order_processes", :namespace => "catalog", :value => order_process.id)
+            portfolio.tag_add("order_processes", :namespace => "catalog", :value => order_process.id)
+          end
 
-        subject
-      end
+          it "applies the process sequence of '2' to the order item" do
+            subject
+            expect(order.order_items.first.process_sequence).to eq(2)
+          end
 
-      it "delegates creation of an 'after' order_item with a process sequence of 3" do
-        expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(after_params)
+          it "applies the process scope of 'applicable' to the order item" do
+            subject
+            expect(order.order_items.first.process_scope).to eq("applicable")
+          end
 
-        subject
+          it "delegates creation of a 'before' order_item with a process sequence of 1" do
+            expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(before_params)
+
+            subject
+          end
+
+          it "delegates creation of an 'after' order_item with a process sequence of 3" do
+            expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(after_params)
+
+            subject
+          end
+        end
+
+        context "when the tags are different" do
+          let(:before_params) do
+            {
+              :order_id          => order.id,
+              :portfolio_item_id => before_portfolio_item.id,
+              :process_sequence  => 1,
+              :process_scope     => "before"
+            }
+          end
+          let(:before_params2) do
+            {
+              :order_id          => order.id,
+              :portfolio_item_id => before_portfolio_item2.id,
+              :process_sequence  => 2,
+              :process_scope     => "before"
+            }
+          end
+
+          let(:after_params) do
+            {
+              :order_id          => order.id,
+              :portfolio_item_id => after_portfolio_item.id,
+              :process_sequence  => 5,
+              :process_scope     => "after"
+            }
+          end
+          let(:after_params2) do
+            {
+              :order_id          => order.id,
+              :portfolio_item_id => after_portfolio_item2.id,
+              :process_sequence  => 4,
+              :process_scope     => "after"
+            }
+          end
+
+          let(:before_portfolio_item2) { create(:portfolio_item) }
+          let(:after_portfolio_item2) { create(:portfolio_item) }
+          let(:order_process2) do
+            create(:order_process,
+                   :before_portfolio_item => before_portfolio_item2,
+                   :after_portfolio_item  => after_portfolio_item2)
+          end
+
+          before do
+            TagLink.create(:order_process_id => order_process2.id, :tag_name => "/catalog/other=#{order_process2.id}")
+
+            portfolio_item.tag_add("order_processes", :namespace => "catalog", :value => order_process.id)
+            portfolio.tag_add("other", :namespace => "catalog", :value => order_process2.id)
+            allow(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new)
+              .with(before_params2)
+              .and_return(add_to_order_via_order_process)
+            allow(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new)
+              .with(after_params2)
+              .and_return(add_to_order_via_order_process)
+          end
+
+          it "applies the process sequence of '3' to the order item" do
+            subject
+            expect(order.order_items.first.process_sequence).to eq(3)
+          end
+
+          it "applies the process scope of 'applicable' to the order item" do
+            subject
+            expect(order.order_items.first.process_scope).to eq("applicable")
+          end
+
+          it "delegates creation of two 'before' order_items with the appropriate process sequences" do
+            expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(before_params)
+            expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(before_params2)
+
+            subject
+          end
+
+          it "delegates creation of two 'after' order_items with the appropriate process sequences" do
+            expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(after_params)
+            expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(after_params2)
+
+            subject
+          end
+        end
       end
     end
   end

--- a/spec/services/api/v1.2/catalog/evaluate_order_process_spec.rb
+++ b/spec/services/api/v1.2/catalog/evaluate_order_process_spec.rb
@@ -27,19 +27,19 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
     context "when there is 1 existing tag on the portfolio_item" do
       let(:before_params) do
         {
-            :order_id          => order.id,
-            :portfolio_item_id => before_portfolio_item.id,
-            :process_sequence  => 1,
-            :process_scope     => "before"
+          :order_id          => order.id,
+          :portfolio_item_id => before_portfolio_item.id,
+          :process_sequence  => 1,
+          :process_scope     => "before"
         }
       end
 
       let(:after_params) do
         {
-            :order_id          => order.id,
-            :portfolio_item_id => after_portfolio_item.id,
-            :process_sequence  => 3,
-            :process_scope     => "after"
+          :order_id          => order.id,
+          :portfolio_item_id => after_portfolio_item.id,
+          :process_sequence  => 3,
+          :process_scope     => "after"
         }
       end
       let(:before_portfolio_item) { create(:portfolio_item) }

--- a/spec/services/api/v1.2/catalog/evaluate_order_process_spec.rb
+++ b/spec/services/api/v1.2/catalog/evaluate_order_process_spec.rb
@@ -1,0 +1,91 @@
+describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
+  describe "#process" do
+    let(:order) { create(:order) }
+    let!(:order_item) { create(:order_item, :order => order, :portfolio_item => portfolio_item) }
+    let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio) }
+    let(:portfolio) { create(:portfolio) }
+
+    subject { described_class.new(order).process }
+
+    context "when there are no existing tags on the portfolio or portfolio_item" do
+      it "applies the process sequence of '1' to the order item" do
+        subject
+        expect(order.order_items.first.process_sequence).to eq(1)
+      end
+
+      it "applies the proccess scope of 'applicable' to the order item" do
+        subject
+        expect(order.order_items.first.process_scope).to eq("applicable")
+      end
+
+      it "does not add any other order items to the order" do
+        subject
+        expect(order.order_items.count).to eq(1)
+      end
+    end
+
+    context "when there is 1 existing tag on the portfolio_item" do
+      let(:before_params) do
+        {
+            :order_id          => order.id,
+            :portfolio_item_id => before_portfolio_item.id,
+            :process_sequence  => 1,
+            :process_scope     => "before"
+        }
+      end
+
+      let(:after_params) do
+        {
+            :order_id          => order.id,
+            :portfolio_item_id => after_portfolio_item.id,
+            :process_sequence  => 3,
+            :process_scope     => "after"
+        }
+      end
+      let(:before_portfolio_item) { create(:portfolio_item) }
+      let(:after_portfolio_item) { create(:portfolio_item) }
+      let(:order_process) do
+        create(:order_process,
+               :before_portfolio_item => before_portfolio_item,
+               :after_portfolio_item  => after_portfolio_item)
+      end
+      let(:add_to_order_via_order_process) { instance_double(Api::V1x2::Catalog::AddToOrderViaOrderProcess) }
+
+      before do
+        TagLink.create(:order_process_id => order_process.id, :tag_name => "/catalog/order_processes=#{order_process.id}")
+        portfolio.tag_add("order_processes", :namespace => "catalog", :value => order_process.id)
+
+        allow(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new)
+          .with(before_params)
+          .and_return(add_to_order_via_order_process)
+        allow(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new)
+          .with(after_params)
+          .and_return(add_to_order_via_order_process)
+
+        allow(add_to_order_via_order_process).to receive(:process)
+      end
+
+      it "applies the process sequence of '2' to the order item" do
+        subject
+        expect(order.order_items.first.process_sequence).to eq(2)
+      end
+
+      it "applies the process scope of 'applicable' to the order item" do
+        subject
+        expect(order.order_items.first.process_scope).to eq("applicable")
+      end
+
+      it "delegates creation of a 'before' order_item with a process sequence of 1" do
+        expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(before_params)
+
+        subject
+      end
+
+      it "delegates creation of an 'after' order_item with a process sequence of 3" do
+        expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(after_params)
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/support/order_item_with_service_plan_helper.rb
+++ b/spec/support/order_item_with_service_plan_helper.rb
@@ -14,6 +14,7 @@ RSpec.shared_context "uses an order item with raw service parameters set" do
 
     @order_item =
       create(:order_item_with_callback, :portfolio_item              => portfolio_item,
+                                        :process_scope               => 'applicable',
                                         :service_parameters          => service_parameters,
                                         :service_plan_ref            => service_plan_ref,
                                         :provider_control_parameters => provider_control_parameters,


### PR DESCRIPTION
Built on top of #785 for the db columns.

There's still likely work to do here, I added a few `#TODO`s in the code because I'm not certain how to handle the versioning with the internal endpoints, and we're likely moving away from those anyway with the work @bzwei is doing bringing the listeners into the project instead of being in the minions.

I realize this is rather large, but the only real main change is the addition of the `Catalog::EvaluateOrderProcess` class, the rest is mostly versioning moves and small changes to the private/public methods to accomodate the new version.

https://projects.engineering.redhat.com/browse/SSP-1582