### PR TITLE
Add pundit authorization for tagging

### DIFF
--- a/app/controllers/api/v1x0/tags_controller.rb
+++ b/app/controllers/api/v1x0/tags_controller.rb
@@ -3,6 +3,7 @@ module Api
     class TagsController < ApplicationController
       include Mixins::IndexMixin
       include Insights::API::Common::TaggingMethods
+      include TaggingMixin
 
       def index
         if params[:portfolio_id]

--- a/app/policies/order_process_policy.rb
+++ b/app/policies/order_process_policy.rb
@@ -23,6 +23,9 @@ class OrderProcessPolicy < ApplicationPolicy
     rbac_access.destroy_access_check
   end
 
+  alias tag? link?
+  alias untag? unlink?
+
   class Scope < Scope
     def resolve
       if access_scopes.include?('admin')

--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -39,6 +39,9 @@ class PortfolioItemPolicy < ApplicationPolicy
       rbac_access.approval_workflow_check
   end
 
+  alias tag? set_approval?
+  alias untag? set_approval?
+
   private
 
   def can_read_and_update_destination?(destination_id)

--- a/app/policies/portfolio_policy.rb
+++ b/app/policies/portfolio_policy.rb
@@ -27,6 +27,9 @@ class PortfolioPolicy < ApplicationPolicy
     rbac_access.update_access_check && rbac_access.approval_workflow_check
   end
 
+  alias tag? set_approval?
+  alias untag? set_approval?
+
   class Scope < Scope
     def resolve
       if access_scopes.include?('admin')

--- a/app/services/concerns/tagging_mixin.rb
+++ b/app/services/concerns/tagging_mixin.rb
@@ -1,0 +1,19 @@
+module TaggingMixin
+  Insights::API::Common::TaggingMethods.class_eval do
+    include TaggingMixin
+  end
+
+  def tag
+    primary_instance = primary_collection_model.find(request_path_parts["primary_collection_id"])
+    authorize(primary_instance)
+
+    super
+  end
+
+  def untag
+    primary_instance = primary_collection_model.find(request_path_parts["primary_collection_id"])
+    authorize(primary_instance)
+
+    super
+  end
+end

--- a/spec/policies/order_process_policy_spec.rb
+++ b/spec/policies/order_process_policy_spec.rb
@@ -51,6 +51,20 @@ describe OrderProcessPolicy do
     end
   end
 
+  describe "#tag?" do
+    it "returns true" do
+      expect(rbac_access).to receive(:link_access_check).and_return(true)
+      expect(subject.tag?).to eq(true)
+    end
+  end
+
+  describe "#untag?" do
+    it "returns true" do
+      expect(rbac_access).to receive(:unlink_access_check).and_return(true)
+      expect(subject.untag?).to eq(true)
+    end
+  end
+
   describe "#user_capabilities" do
     before do
       allow(rbac_access).to receive(:read_access_check).and_return(true)
@@ -68,7 +82,9 @@ describe OrderProcessPolicy do
         "link"    => true,
         "show"    => true,
         "unlink"  => true,
-        "update"  => true
+        "update"  => true,
+        "tag"     => true,
+        "untag"   => true
       )
     end
   end

--- a/spec/policies/portfolio_item_policy_spec.rb
+++ b/spec/policies/portfolio_item_policy_spec.rb
@@ -54,34 +54,36 @@ describe PortfolioItemPolicy do
     end
   end
 
-  describe "#set_approval?" do
-    let(:resource_check) { true }
-    let(:approval_workflow_check) { true }
+  %i[set_approval? tag? untag?].each do |action|
+    describe "##{action}" do
+      let(:resource_check) { true }
+      let(:approval_workflow_check) { true }
 
-    before do
-      allow(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(resource_check)
-      allow(rbac_access).to receive(:approval_workflow_check).and_return(approval_workflow_check)
-    end
-
-    context "when the resource check is false" do
-      let(:resource_check) { false }
-
-      it "returns false" do
-        expect(subject.set_approval?).to eq(false)
+      before do
+        allow(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(resource_check)
+        allow(rbac_access).to receive(:approval_workflow_check).and_return(approval_workflow_check)
       end
-    end
 
-    context "when the approval workflow check is false" do
-      let(:approval_workflow_check) { false }
+      context "when the resource check is false" do
+        let(:resource_check) { false }
 
-      it "returns false" do
-        expect(subject.set_approval?).to eq(false)
+        it "returns false" do
+          expect(subject.send(action)).to eq(false)
+        end
       end
-    end
 
-    context "when the resource check and the approval workflow check are true" do
-      it "returns true" do
-        expect(subject.set_approval?).to eq(true)
+      context "when the approval workflow check is false" do
+        let(:approval_workflow_check) { false }
+
+        it "returns false" do
+          expect(subject.send(action)).to eq(false)
+        end
+      end
+
+      context "when the resource check and the approval workflow check are true" do
+        it "returns true" do
+          expect(subject.send(action)).to eq(true)
+        end
       end
     end
   end
@@ -249,7 +251,9 @@ describe PortfolioItemPolicy do
         "copy"         => true,
         "set_approval" => true,
         "show"         => true,
-        "edit_survey"  => true
+        "edit_survey"  => true,
+        "tag"          => true,
+        "untag"        => true
       })
     end
   end

--- a/spec/policies/portfolio_policy_spec.rb
+++ b/spec/policies/portfolio_policy_spec.rb
@@ -23,34 +23,36 @@ describe PortfolioPolicy do
     end
   end
 
-  describe "#set_approval?" do
-    let(:update_access_check) { true }
-    let(:approval_workflow_check) { true }
+  %i[set_approval? tag? untag?].each do |action|
+    describe "##{action}" do
+      let(:update_access_check) { true }
+      let(:approval_workflow_check) { true }
 
-    before do
-      allow(rbac_access).to receive(:update_access_check).and_return(update_access_check)
-      allow(rbac_access).to receive(:approval_workflow_check).and_return(approval_workflow_check)
-    end
-
-    context "when the update check is false" do
-      let(:update_access_check) { false }
-
-      it "returns false" do
-        expect(subject.set_approval?).to eq(false)
+      before do
+        allow(rbac_access).to receive(:update_access_check).and_return(update_access_check)
+        allow(rbac_access).to receive(:approval_workflow_check).and_return(approval_workflow_check)
       end
-    end
 
-    context "when the approval workflow check is false" do
-      let(:approval_workflow_check) { false }
+      context "when the update check is false" do
+        let(:update_access_check) { false }
 
-      it "returns false" do
-        expect(subject.set_approval?).to eq(false)
+        it "returns false" do
+          expect(subject.send(action)).to eq(false)
+        end
       end
-    end
 
-    context "when the update check and the approval workflow check are true" do
-      it "returns true" do
-        expect(subject.set_approval?).to eq(true)
+      context "when the approval workflow check is false" do
+        let(:approval_workflow_check) { false }
+
+        it "returns false" do
+          expect(subject.send(action)).to eq(false)
+        end
+      end
+
+      context "when the update check and the approval workflow check are true" do
+        it "returns true" do
+          expect(subject.send(action)).to eq(true)
+        end
       end
     end
   end
@@ -103,7 +105,9 @@ describe PortfolioPolicy do
         "share"        => true,
         "unshare"      => true,
         "show"         => true,
-        "set_approval" => true
+        "set_approval" => true,
+        "tag"          => true,
+        "untag"        => true
       })
     end
   end

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -1,11 +1,12 @@
 describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
   let(:catalog_access) { instance_double(Insights::API::Common::RBAC::Access, :scopes => %w[admin]) }
   before do
-     allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
-     allow(catalog_access).to receive(:process).and_return(catalog_access)
-     allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
-     allow(catalog_access).to receive(:accessible?).with("portfolios", "read").and_return(true)
+    allow(Insights::API::Common::RBAC::Access).to receive(:new).and_return(catalog_access)
+    allow(catalog_access).to receive(:process).and_return(catalog_access)
+    allow(catalog_access).to receive(:accessible?).with("portfolios", "create").and_return(true)
+    allow(catalog_access).to receive(:accessible?).with("portfolios", "read").and_return(true)
   end
+
   let(:service_offering_ref) { "998" }
   let(:service_offering_source_ref) { "568" }
   let(:order) { create(:order) }
@@ -409,7 +410,17 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
     end
   end
 
-  it_behaves_like "controller that supports tagging endpoints" do
-    let(:object_instance) { portfolio_item }
+  context "tagging endpoints" do
+    let(:rbac_access) { instance_double(Catalog::RBAC::Access) }
+
+    before do
+      allow(Catalog::RBAC::Access).to receive(:new).and_return(rbac_access)
+      allow(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(true)
+      allow(rbac_access).to receive(:approval_workflow_check).and_return(true)
+    end
+
+    it_behaves_like "controller that supports tagging endpoints" do
+      let(:object_instance) { portfolio_item }
+    end
   end
 end

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -383,7 +383,17 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
     end
   end
 
-  it_behaves_like "controller that supports tagging endpoints" do
-    let(:object_instance) { portfolio }
+  context "tagging endpoints" do
+    let(:rbac_access) { instance_double(Catalog::RBAC::Access) }
+
+    before do
+      allow(Catalog::RBAC::Access).to receive(:new).and_return(rbac_access)
+      allow(rbac_access).to receive(:update_access_check).and_return(true)
+      allow(rbac_access).to receive(:approval_workflow_check).and_return(true)
+    end
+
+    it_behaves_like "controller that supports tagging endpoints" do
+      let(:object_instance) { portfolio }
+    end
   end
 end

--- a/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
@@ -44,7 +44,9 @@ describe "v1.1 - PortfolioItemRequests", :type => [:request, :topology, :v1x1] d
           "update"       => true,
           "edit_survey"  => true,
           "show"         => true,
-          "set_approval" => true
+          "set_approval" => true,
+          "tag"          => true,
+          "untag"        => true
         )
         expect(json["metadata"]["orderable"]).to eq(true)
       end

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -43,7 +43,9 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
           "show"         => true,
           "unshare"      => true,
           "update"       => true,
-          "set_approval" => true
+          "set_approval" => true,
+          "tag"          => true,
+          "untag"        => true
         )
       end
 
@@ -271,5 +273,9 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
         expect(first_error_detail).to match(/OpenAPIParser::InvalidUUIDFormat/)
       end
     end
+  end
+
+  it_behaves_like "controller that supports tagging endpoints" do
+    let(:object_instance) { portfolio }
   end
 end

--- a/spec/requests/api/v1.2/order_processes_controller_spec.rb
+++ b/spec/requests/api/v1.2/order_processes_controller_spec.rb
@@ -34,7 +34,9 @@ describe "v1.2 - OrderProcesses", :type => [:request, :controller, :v1x2] do
           "show"    => true,
           "unlink"  => true,
           "update"  => true,
-          "destroy" => true
+          "destroy" => true,
+          "tag"     => true,
+          "untag"   => true
         )
       end
     end

--- a/spec/support/authorize_shared_examples.rb
+++ b/spec/support/authorize_shared_examples.rb
@@ -1,8 +1,8 @@
 RSpec.shared_examples "action that tests authorization" do |action, object|
-  let(:object_policy) { instance_double("#{object}Policy") }
+  let(:object_policy) { instance_double("#{object || object_class}Policy") }
 
-  it "delegates to the #{object}Policy with the #{action} action", :subject_inside do
-    expect("#{object}Policy".constantize).to receive(:new).and_return(object_policy)
+  it "delegates to the correct Policy with the #{action} action", :subject_inside do
+    expect("#{object || object_class}Policy".constantize).to receive(:new).and_return(object_policy)
     expect(object_policy).to receive(action)
 
     subject

--- a/spec/support/tagging_shared_examples.rb
+++ b/spec/support/tagging_shared_examples.rb
@@ -20,6 +20,12 @@ shared_examples_for "controller that supports tagging endpoints" do
         expect(json.first["tag"]).to eq Tag.new(params).to_tag_string
         expect(response).to have_http_status(201)
       end
+
+      subject { post "#{base_url}/tag", :headers => default_headers, :params => tag_params }
+
+      it_behaves_like "action that tests authorization", :tag?, nil do
+        let(:object_class) { object_instance.class }
+      end
     end
 
     shared_examples_for "bad_tags" do
@@ -113,7 +119,12 @@ shared_examples_for "controller that supports tagging endpoints" do
 
       let(:endpoint) { "untag" }
       it_behaves_like "bad_tags"
-      it_behaves_like "good_tags"
+
+      subject { post "#{base_url}/untag", :headers => default_headers, :params => params }
+
+      it_behaves_like "action that tests authorization", :untag?, nil do
+        let(:object_class) { object_instance.class }
+      end
     end
   end
 end


### PR DESCRIPTION
Currently we have no authorization checks for tagging/untagging portfolios/portfolio items/order processes. This is an attempt to add them to all three, although that may be slightly out of the scope of the linked JIRA ticket as that only specifies portfolios.

However, since all three controllers share the `taggable` concern, they all end up going through the same code and therefore I needed to at least implement the `#tag?` and `#untag?` methods in the respective policies, and just putting `true` seemed wrong since it would just be introducing a bug that we'd fix in another PR.

https://projects.engineering.redhat.com/browse/SSP-1632

@hsong-rh @mkanoor Please Review. I'm not super thrilled about how I overrode the `tag` and `untag` module methods, but I couldn't think of a better way to do this aside from making the change directly in the common gem, and that felt wrong for common to require knowledge about pundit.