### PR TITLE
Add pundit authorization to portfolio and portfolio_item restore endpoints

### DIFF
--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -47,8 +47,9 @@ module Api
         render :json => svc.process.new_portfolio_item
       end
 
-      def undestroy
+      def restore
         item = PortfolioItem.with_discarded.discarded.find(params.require(:portfolio_item_id))
+        authorize(item)
         Catalog::SoftDeleteRestore.new(item, params.require(:restore_key)).process
 
         render :json => item

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -36,6 +36,7 @@ module Api
 
       def restore
         portfolio = Portfolio.with_discarded.discarded.find(params.require(:portfolio_id))
+        authorize(portfolio)
         Catalog::SoftDeleteRestore.new(portfolio, params.require(:restore_key)).process
 
         render :json => portfolio

--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -19,6 +19,8 @@ class PortfolioItemPolicy < ApplicationPolicy
     update_portfolio_check
   end
 
+  alias restore? destroy?
+
   def copy?
     destination_id = @user.try(:params).try(:dig, :portfolio_id) || @record.portfolio_id
 

--- a/app/policies/portfolio_policy.rb
+++ b/app/policies/portfolio_policy.rb
@@ -9,6 +9,8 @@ class PortfolioPolicy < ApplicationPolicy
     rbac_access.destroy_access_check
   end
 
+  alias restore? destroy?
+
   def show?
     rbac_access.read_access_check
   end

--- a/config/routes/v1x0.rb
+++ b/config/routes/v1x0.rb
@@ -35,7 +35,7 @@ namespace :v1x0, :path => "v1.0" do
     get :icon, :to => 'icons#raw_icon'
     get :next_name, :action => 'next_name', :controller => 'portfolio_items'
     post :copy, :action => 'copy', :controller => 'portfolio_items'
-    post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
+    post :undelete, :action => 'restore', :controller => 'portfolio_items'
   end
   resources :icons, :only => [:create, :destroy, :show, :update] do
     get :icon_data, :to => 'icons#raw_icon'

--- a/config/routes/v1x1.rb
+++ b/config/routes/v1x1.rb
@@ -35,7 +35,7 @@ namespace :v1x1, :path => "v1.1" do
     get :icon, :to => 'icons#raw_icon'
     get :next_name, :action => 'next_name', :controller => 'portfolio_items'
     post :copy, :action => 'copy', :controller => 'portfolio_items'
-    post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
+    post :undelete, :action => 'restore', :controller => 'portfolio_items'
   end
   resources :icons, :only => [:create, :destroy]
   resources :settings

--- a/config/routes/v1x2.rb
+++ b/config/routes/v1x2.rb
@@ -35,7 +35,7 @@ namespace :v1x2, :path => "v1.2" do
     get :icon, :to => 'icons#raw_icon'
     get :next_name, :action => 'next_name', :controller => 'portfolio_items'
     post :copy, :action => 'copy', :controller => 'portfolio_items'
-    post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
+    post :undelete, :action => 'restore', :controller => 'portfolio_items'
   end
   resources :icons, :only => [:create, :destroy]
   resources :order_processes, :only => [:create, :destroy, :index, :show, :update], :concerns => [:taggable] do

--- a/spec/policies/portfolio_item_policy_spec.rb
+++ b/spec/policies/portfolio_item_policy_spec.rb
@@ -86,10 +86,12 @@ describe PortfolioItemPolicy do
     end
   end
 
-  describe "#destroy?" do
-    it "delegates to the check for update permissions on the portfolio" do
-      expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
-      expect(subject.destroy?).to eq(true)
+  %i[destroy? restore?].each do |method|
+    describe "##{method}" do
+      it "delegates to the check for update permissions on the portfolio" do
+        expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
+        expect(subject.send(method)).to eq(true)
+      end
     end
   end
 
@@ -246,6 +248,7 @@ describe PortfolioItemPolicy do
         "create"       => true,
         "update"       => true,
         "destroy"      => true,
+        "restore"      => true,
         "copy"         => true,
         "set_approval" => true,
         "show"         => true,

--- a/spec/policies/portfolio_policy_spec.rb
+++ b/spec/policies/portfolio_policy_spec.rb
@@ -55,10 +55,12 @@ describe PortfolioPolicy do
     end
   end
 
-  describe "#destroy?" do
-    it "delegates to the rbac access destroy check" do
-      expect(rbac_access).to receive(:destroy_access_check).and_return(true)
-      expect(subject.destroy?).to eq(true)
+  %i[destroy? restore?].each do |method|
+    describe "##{method}" do
+      it "delegates to the rbac access destroy check" do
+        expect(rbac_access).to receive(:destroy_access_check).and_return(true)
+        expect(subject.send(method)).to eq(true)
+      end
     end
   end
 
@@ -99,6 +101,7 @@ describe PortfolioPolicy do
         "create"       => true,
         "update"       => true,
         "destroy"      => true,
+        "restore"      => true,
         "copy"         => true,
         "share"        => true,
         "unshare"      => true,

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -108,12 +108,15 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
   describe 'POST /portfolio_items/{portfolio_item_id}/undelete' do
     let(:undelete) { post "#{api_version}/portfolio_items/#{portfolio_item_id}/undelete", :params => { :restore_key => restore_key }, :headers => default_headers }
     let(:restore_key) { Digest::SHA1.hexdigest(portfolio_item.discarded_at.to_s) }
+    subject { undelete }
 
     context "when restoring a portfolio_item that has been discarded" do
-      before do
+      before do |example|
         portfolio_item.discard
-        undelete
+        subject unless example.metadata[:subject_inside]
       end
+
+      it_behaves_like "action that tests authorization", :restore?, PortfolioItem
 
       it "returns a 200" do
         expect(response).to have_http_status :ok
@@ -128,10 +131,12 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
     context 'when attempting to restore with the wrong restore_key' do
       let(:restore_key) { "MrMaliciousRestoreKey" }
 
-      before do
+      before do |example|
         portfolio_item.discard
-        undelete
+        subject unless example.metadata[:subject_inside]
       end
+
+      it_behaves_like "action that tests authorization", :restore?, PortfolioItem
 
       it "returns a 403" do
         expect(response).to have_http_status(:forbidden)

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -106,9 +106,13 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
   end
 
   describe 'POST /portfolio_items/{portfolio_item_id}/undelete' do
-    let(:undelete) { post "#{api_version}/portfolio_items/#{portfolio_item_id}/undelete", :params => { :restore_key => restore_key }, :headers => default_headers }
+    let(:restore) do
+      post "#{api_version}/portfolio_items/#{portfolio_item_id}/undelete",
+           :params  => {:restore_key => restore_key},
+           :headers => default_headers
+    end
     let(:restore_key) { Digest::SHA1.hexdigest(portfolio_item.discarded_at.to_s) }
-    subject { undelete }
+    subject { restore }
 
     context "when restoring a portfolio_item that has been discarded" do
       before do |example|
@@ -122,7 +126,7 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
         expect(response).to have_http_status :ok
       end
 
-      it "returns the undeleted portfolio_item" do
+      it "returns the restored portfolio_item" do
         expect(json["id"]).to eq portfolio_item_id.to_s
         expect(json["name"]).to eq portfolio_item.name
       end
@@ -145,7 +149,7 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :topology, :v1] do
 
     context 'when attempting to restore a portfolio_item that not been discarded' do
       it "returns a 404" do
-        undelete
+        restore
         expect(response).to have_http_status :not_found
       end
     end

--- a/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
@@ -41,6 +41,7 @@ describe "v1.1 - PortfolioItemRequests", :type => [:request, :topology, :v1x1] d
           "copy"         => true,
           "create"       => true,
           "destroy"      => true,
+          "restore"      => true,
           "update"       => true,
           "edit_survey"  => true,
           "show"         => true,

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -39,6 +39,7 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
           "copy"         => true,
           "create"       => true,
           "destroy"      => true,
+          "restore"      => true,
           "share"        => true,
           "show"         => true,
           "unshare"      => true,


### PR DESCRIPTION
Similar to the tagging PR, we currently don't have any authorization checking for restoring things. Orders and order items also have restore endpoints but they don't have authorization on deletion right now so I didn't think it was a good idea to include them here.

https://projects.engineering.redhat.com/browse/SSP-1638