### PR TITLE
Allow cache_id parameter for portfolio item icons.

### DIFF
--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -557,6 +557,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/PortfolioID"
+          },
+          {
+            "$ref": "#/components/parameters/QueryCacheID"
           }
         ],
         "responses": {
@@ -3239,6 +3242,15 @@
         "in": "path",
         "description": "name of the setting",
         "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "QueryCacheID": {
+        "in": "query",
+        "name": "cache_id",
+        "required": false,
+        "description": "Artificial string to help avoid falsey browser cache. This can occur after changing static resources like images. The browser will return an outdated cached response. Appending different query will result in a new async call, instead of retrieving the resource from the browser cache.",
         "schema": {
           "type": "string"
         }


### PR DESCRIPTION
@eclarizio @gmcculloug I don't know who to assign as a review for this PR. Feel free to change the reviewers.

### Issue
blocks: https://github.com/RedHatInsights/catalog-ui/pull/729
Since the catalog API is not static resource storage, it does not have correct headers for static assets like images to ignore the browser cache. This causes errors when we want to reset the portfolio item icon and then re-load the asset in UI. See recording:
![reset-icon-cache](https://user-images.githubusercontent.com/22619452/90628380-cf6a4a80-e21d-11ea-883b-47c89420e92c.gif)

To describe the gif. When the browser cache is enable (which will be for 99% of users), after resetting the icon, the browser will make a request with the same URL `/portfolio_items/id/icon` as it did before. Since the response is cached, it will return the chahed image, which at that point should not exist and the UI is not updated. You can see that after reset action was invoked there isn't any new network call and the icon is pulled from cache.

If you disable the cache in developer tools, you can see that after the reset action there is a new network request for the image, the response is empty and the UI uses the fallback icon instead.

To get around this issue we can use a simple "hack" and that is adding some query param to the API call. We can use the `icon_id` so we can still use the browser cache to avoid performance hits. Problem is, that there are no query params allowed for the icon endpoint. This change introduces `cache_id` which will allow the UI to control when to use the browser cache.