### PR TITLE
Switch context from Kafka message headers

### DIFF
--- a/lib/approval/event_listener.rb
+++ b/lib/approval/event_listener.rb
@@ -11,8 +11,6 @@ module Approval
     private
 
     def process_event(event)
-      Rails.logger.info("Kafka message #{event.message} received with payload: #{event.payload}")
-
       if event.message == EVENT_WORKFLOW_DELETED
         remove_approval_tag(event)
       else

--- a/lib/kafka_listener.rb
+++ b/lib/kafka_listener.rb
@@ -18,7 +18,7 @@ class KafkaListener
         :persist_ref => group_ref,
         :max_bytes   => 500_000
       ) do |event|
-        process_event(event)
+        raw_process(event)
       end
     end
   rescue Kafka::ConnectionError => e
@@ -33,6 +33,28 @@ class KafkaListener
   end
 
   private
+
+  def raw_process(event)
+    Rails.logger.info("Kafka message #{event.message} received with payload: #{event.payload}")
+
+    # reconstruct runtime from message header, skip the message if it is not properly constructed
+    insights_headers = event.headers.slice('x-rh-identity', 'x-rh-insights-request-id')
+    unless insights_headers['x-rh-identity'] && insights_headers['x-rh-insights-request-id']
+      Rails.logger.error("Message skipped because of missing required headers")
+      return
+    end
+
+    Insights::API::Common::Request.with_request(:headers => insights_headers, :original_url => nil) do |req|
+      tenant = Tenant.find_by(:external_tenant => req.tenant)
+      if tenant
+        ActsAsTenant.with_tenant(tenant) do
+          process_event(event)
+        end
+      else
+        Rails.logger.error("Message skipped because it does not belong to a valid tenant")
+      end
+    end
+  end
 
   def default_messaging_options
     {:protocol => :Kafka, :encoding => 'json'}

--- a/lib/topological_inventory/event_listener.rb
+++ b/lib/topological_inventory/event_listener.rb
@@ -10,8 +10,6 @@ module TopologicalInventory
     private
 
     def process_event(event)
-      Rails.logger.info("Kafka message #{event.message} received with payload: #{event.payload}")
-
       event.payload['task_id'] = event.payload.delete('id')
       topic = OpenStruct.new(:payload => event.payload, :message => event.message)
       Api::V1x0::Catalog::DetermineTaskRelevancy.new(topic).process


### PR DESCRIPTION
It was found that the order cannot continue after approval finishes because of lacking proper Insight headers.
We have switched context when processing workflow deleted messages, but not for others. This work move the logic to apply for all messages.