### PR TITLE
Make sure task_id is string type

### DIFF
--- a/lib/catalog/determine_task_relevancy.rb
+++ b/lib/catalog/determine_task_relevancy.rb
@@ -6,7 +6,7 @@ module Catalog
 
     def process
       @task = TopologicalInventoryApiClient::Task.new(
-        :id      => @topic.payload["task_id"],
+        :id      => @topic.payload["task_id"].to_s,
         :state   => @topic.payload["state"],
         :status  => @topic.payload["status"],
         :context => @topic.payload["context"].try(&:with_indifferent_access)

--- a/spec/lib/catalog/determine_task_relevancy_spec.rb
+++ b/spec/lib/catalog/determine_task_relevancy_spec.rb
@@ -2,7 +2,7 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
   let(:subject) { described_class.new(topic) }
   let(:topic) do
     OpenStruct.new(
-      :payload => {"task_id" => "123", "status" => status, "state" => state, "context" => payload_context},
+      :payload => {"task_id" => 123, "status" => status, "state" => state, "context" => payload_context},
       :message => "message"
     )
   end
@@ -62,7 +62,7 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
       let(:status) { "ok" }
 
       context "when the task context has a key path of [:service_instance][:id]" do
-        let(:payload_context) { {"service_instance" => {"id" => "321"}} }
+        let(:payload_context) { {"service_instance" => {"id" => 321}} }
         let(:update_order_item) { instance_double("Api::V1x0::Catalog::UpdateOrderItem") }
 
         before do


### PR DESCRIPTION
It is discovered the the task_id and other ids in the Kafka message sent by topological inventory are numerical values, while calling TopologicalInventory API client requires string value. The error message is like `ArgumentError: invalid value for "id", must conform to the pattern (?-mix:^\d+$).`

This fix ensures the conversion. 