### PR TITLE
Ensure PortfolioItemOrderable result is a boolean value

### DIFF
--- a/app/services/api/v1x1/catalog/portfolio_item_orderable.rb
+++ b/app/services/api/v1x1/catalog/portfolio_item_orderable.rb
@@ -6,7 +6,6 @@ module Api
         attr_reader :messages
 
         def initialize(portfolio_item)
-          @result = false
           @portfolio_item = portfolio_item
           @messages = []
         end
@@ -15,6 +14,7 @@ module Api
           fetch_source
           fetch_service_offering
           @result = @service_offering && @source && !archived? && !survey_changed? && source_available?
+          @result = !!@result
           self
         end
 

--- a/spec/services/api/v1.1/catalog/portfolio_item_orderable_spec.rb
+++ b/spec/services/api/v1.1/catalog/portfolio_item_orderable_spec.rb
@@ -32,35 +32,35 @@ describe Api::V1x1::Catalog::PortfolioItemOrderable, :type => [:service, :curren
 
       context "when the nothing has changed without service plans" do
         it "returns true" do
-          expect(subject.process.result).to be_truthy
+          expect(subject.process.result).to be(true)
         end
       end
 
       context "when the nothing has changed with service plans" do
         let(:service_plans) { [create(:service_plan, :portfolio_item => portfolio_item)] }
         it "returns true" do
-          expect(subject.process.result).to be_truthy
+          expect(subject.process.result).to be(true)
         end
       end
 
       context "when the source is not available" do
         let(:availability_status) { 'not available' }
         it "returns false" do
-          expect(subject.process.result).to be_falsey
+          expect(subject.process.result).to be(false)
         end
       end
 
       context "when the survey has changed" do
         let(:survey_changed) { true }
         it "returns false" do
-          expect(subject.process.result).to be_falsey
+          expect(subject.process.result).to be(false)
         end
       end
 
       context "when the service offering has been archived" do
         let(:archived_at) { Time.now }
         it "returns false" do
-          expect(subject.process.result).to be_falsey
+          expect(subject.process.result).to be(false)
         end
       end
     end
@@ -76,7 +76,7 @@ describe Api::V1x1::Catalog::PortfolioItemOrderable, :type => [:service, :curren
       context "when the service offering cannot be retrieved" do
         it "returns false" do
           obj = subject.process
-          expect(obj.result).to be_falsey
+          expect(obj.result).to be(false)
           expect(obj.messages[0]).to match(/Service offering could not be retrieved/)
         end
       end
@@ -93,7 +93,7 @@ describe Api::V1x1::Catalog::PortfolioItemOrderable, :type => [:service, :curren
       context "when the source cannot be retrieved" do
         it "returns false" do
           obj = subject.process
-          expect(obj.result).to be_falsey
+          expect(obj.result).to be(false)
           expect(obj.messages[0]).to match(/Source could not be retrieved/)
         end
       end


### PR DESCRIPTION
Pretty simple fix here, if one of the private methods fails due to an unavailable source or something, it returns `nil`, so even if any of the later methods results in `true`, `nil && true` results in `nil`. So, just forcing the `@result` to be a boolean fixes the issue.

https://projects.engineering.redhat.com/browse/SSP-1777