### PR TITLE
Require order process name

### DIFF
--- a/app/models/order_process.rb
+++ b/app/models/order_process.rb
@@ -7,6 +7,8 @@ class OrderProcess < ApplicationRecord
   belongs_to :after_portfolio_item, :class_name => 'PortfolioItem'
   has_many :tag_links, :dependent => :destroy, :inverse_of => :order_process
 
+  validates :name, :uniqueness => {:scope => :tenant}
+
   def metadata
     {:user_capabilities => user_capabilities}
   end

--- a/app/models/order_process.rb
+++ b/app/models/order_process.rb
@@ -7,7 +7,7 @@ class OrderProcess < ApplicationRecord
   belongs_to :after_portfolio_item, :class_name => 'PortfolioItem'
   has_many :tag_links, :dependent => :destroy, :inverse_of => :order_process
 
-  validates :name, :uniqueness => {:scope => :tenant}
+  validates :name, :presence => true, :uniqueness => {:scope => :tenant}
 
   def metadata
     {:user_capabilities => user_capabilities}

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -4270,6 +4270,9 @@
       },
       "OrderProcess": {
         "type": "object",
+        "required": [
+          "name"
+        ],
         "properties": {
           "id": {
             "type": "string",

--- a/spec/models/order_process_spec.rb
+++ b/spec/models/order_process_spec.rb
@@ -25,29 +25,42 @@ describe OrderProcess do
   end
 
   context "name validation" do
-    let(:order_process1_copy) { create(:order_process, :tenant_id => tenant_id) }
-
-    before do
-      order_process1.update(:name => "dup")
-      order_process1_copy.update(:name => "dup")
-    end
-
-    context "when the tenant is the same" do
-      let(:tenant_id) { tenant1.id }
+    context "when no name is given" do
+      before do
+        order_process1.update(:name => nil)
+      end
 
       it "fails validation" do
-        expect(order_process1).to be_valid
-        expect(order_process1_copy).to_not be_valid
-        expect(order_process1_copy.errors.messages[:name]).to eq(["has already been taken"])
+        expect(order_process1).to_not be_valid
+        expect(order_process1.errors.messages[:name]).to eq(["can't be blank"])
       end
     end
 
-    context "when the tenant is different" do
-      let(:tenant_id) { tenant2.id }
+    context "when there is a duplicate name" do
+      let(:order_process1_copy) { create(:order_process, :tenant_id => tenant_id) }
 
-      it "passes validation" do
-        expect(order_process1).to be_valid
-        expect(order_process1_copy).to be_valid
+      before do
+        order_process1.update(:name => "dup")
+        order_process1_copy.update(:name => "dup")
+      end
+
+      context "when the tenant is the same" do
+        let(:tenant_id) { tenant1.id }
+
+        it "fails validation" do
+          expect(order_process1).to be_valid
+          expect(order_process1_copy).to_not be_valid
+          expect(order_process1_copy.errors.messages[:name]).to eq(["has already been taken"])
+        end
+      end
+
+      context "when the tenant is different" do
+        let(:tenant_id) { tenant2.id }
+
+        it "passes validation" do
+          expect(order_process1).to be_valid
+          expect(order_process1_copy).to be_valid
+        end
       end
     end
   end

--- a/spec/models/order_process_spec.rb
+++ b/spec/models/order_process_spec.rb
@@ -23,4 +23,32 @@ describe OrderProcess do
       end
     end
   end
+
+  context "name validation" do
+    let(:order_process1_copy) { create(:order_process, :tenant_id => tenant_id) }
+
+    before do
+      order_process1.update(:name => "dup")
+      order_process1_copy.update(:name => "dup")
+    end
+
+    context "when the tenant is the same" do
+      let(:tenant_id) { tenant1.id }
+
+      it "fails validation" do
+        expect(order_process1).to be_valid
+        expect(order_process1_copy).to_not be_valid
+        expect(order_process1_copy.errors.messages[:name]).to eq(["has already been taken"])
+      end
+    end
+
+    context "when the tenant is different" do
+      let(:tenant_id) { tenant2.id }
+
+      it "passes validation" do
+        expect(order_process1).to be_valid
+        expect(order_process1_copy).to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
As @bzwei pointed out in #799, we currently don't have presence validation around the name of an OrderProcess, so this PR introduces that.

I built this off of #799 so the spec might look a bit uglier once that is merged since I moved things around.