### PR TITLE
Added showDiscarded flag into /portfolio_items/:id query parameters to show discarded product

### DIFF
--- a/app/controllers/api/v1x1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x1/portfolio_items_controller.rb
@@ -5,10 +5,17 @@ module Api
 
       def show
         portfolio_item = model.find(params.require(:id))
-        authorize(portfolio_item)
 
-        json = portfolio_item.as_json(:prefixes => _prefixes, :template => action_name)
-        json['metadata']['orderable'] = Catalog::PortfolioItemOrderable.new(portfolio_item).process.result
+        render_item(portfolio_item)
+      end
+
+      private
+
+      def render_item(item)
+        authorize(item)
+
+        json = item.as_json(:prefixes => _prefixes, :template => action_name)
+        json['metadata']['orderable'] = Catalog::PortfolioItemOrderable.new(item).process.result
         render :json => json
       end
     end

--- a/app/controllers/api/v1x2.rb
+++ b/app/controllers/api/v1x2.rb
@@ -13,7 +13,6 @@ module Api
     class GraphqlController                   < Api::V1x1::GraphqlController; end
     class IconsController                     < Api::V1x1::IconsController; end
     class OrderItemsController                < Api::V1x1::OrderItemsController; end
-    class PortfolioItemsController            < Api::V1x1::PortfolioItemsController; end
     class PortfoliosController                < Api::V1x1::PortfoliosController; end
     class ProgressMessagesController          < Api::V1x1::ProgressMessagesController; end
     class ProviderControlParametersController < Api::V1x1::ProviderControlParametersController; end

--- a/app/controllers/api/v1x2/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x2/portfolio_items_controller.rb
@@ -2,17 +2,17 @@ module Api
   module V1x2
     class PortfolioItemsController < Api::V1x1::PortfolioItemsController
       def show
-        portfolio_item = if params[:showDiscarded] == "true"
-                           model.with_discarded.discarded.find(params.require(:id))
-                         else
-                           model.find(params.require(:id))
-                         end
+        portfolio_item = model.find_by(:id => params.require(:id)) || find_in_discarded_items
 
-        authorize(portfolio_item)
+        raise ActiveRecord::RecordNotFound unless portfolio_item
 
-        json = portfolio_item.as_json(:prefixes => _prefixes, :template => action_name)
-        json['metadata']['orderable'] = Catalog::PortfolioItemOrderable.new(portfolio_item).process.result
-        render :json => json
+        render_item(portfolio_item)
+      end
+
+      private
+
+      def find_in_discarded_items
+        model.with_discarded.discarded.find_by(:id => params.require(:id)) if params[:show_discarded] == "true"
       end
     end
   end

--- a/app/controllers/api/v1x2/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x2/portfolio_items_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1x2
+    class PortfolioItemsController < Api::V1x1::PortfolioItemsController
+      def show
+        portfolio_item = if params[:showDiscarded] == "true"
+                           model.with_discarded.discarded.find(params.require(:id))
+                         else
+                           model.find(params.require(:id))
+                         end
+
+        authorize(portfolio_item)
+
+        json = portfolio_item.as_json(:prefixes => _prefixes, :template => action_name)
+        json['metadata']['orderable'] = Catalog::PortfolioItemOrderable.new(portfolio_item).process.result
+        render :json => json
+      end
+    end
+  end
+end

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -3330,7 +3330,7 @@
       },
       "ShowDiscarded": {
         "in": "query",
-        "name": "showDiscarded",
+        "name": "show_discarded",
         "required": false,
         "description": "Whether or not to display the discarded result.",
         "schema": {

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -932,6 +932,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
+          },
+          {
+            "$ref": "#/components/parameters/ShowDiscarded"
           }
         ],
         "responses": {
@@ -3323,6 +3326,16 @@
         "required": false,
         "schema": {
           "type": "string"
+        }
+      },
+      "ShowDiscarded": {
+        "in": "query",
+        "name": "showDiscarded",
+        "required": false,
+        "description": "Whether or not to display the discarded result.",
+        "schema": {
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/spec/requests/api/v1.2/portfolio_items_controller_spec.rb
+++ b/spec/requests/api/v1.2/portfolio_items_controller_spec.rb
@@ -1,0 +1,43 @@
+describe "v1.2 - PortfolioItemRequests", :type => [:request, :topology, :v1x2] do
+  let!(:portfolio) { create(:portfolio) }
+  let(:portfolio_id) { portfolio.id.to_s }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio_id) }
+  let(:portfolio_item_id) { portfolio_item.id.to_s }
+  let(:rbac_access) { instance_double(Catalog::RBAC::Access) }
+
+  before do
+    allow(Catalog::RBAC::Access).to receive(:new).and_return(rbac_access)
+    allow(rbac_access).to receive(:resource_check).with('read', portfolio.id, Portfolio).and_return(true)
+    allow(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
+    allow(rbac_access).to receive(:permission_check).with('read', Portfolio).and_return(true)
+    allow(rbac_access).to receive(:approval_workflow_check).and_return(true)
+  end
+
+  describe "GET /portfolio_items/:portfolio_item_id #show with showDiscarded query" do
+    let(:portfolio_item_orderable) { instance_double(Api::V1x1::Catalog::PortfolioItemOrderable, :result => true) }
+
+    before do
+      allow(Api::V1x1::Catalog::PortfolioItemOrderable).to receive(:new).with(portfolio_item).and_return(portfolio_item_orderable)
+      allow(portfolio_item_orderable).to receive(:process).and_return(portfolio_item_orderable)
+      delete "#{api_version}/portfolio_items/#{portfolio_item_id}", :headers => default_headers
+      get "#{api_version}/portfolio_items/#{portfolio_item_id}", :params => params, :headers => default_headers
+    end
+
+    context 'when showDiscarded is true' do
+      let(:params) { {:showDiscarded => true} }
+
+      it 'return 200' do
+        expect(response).to have_http_status(200)
+        expect(json["id"]).to eq portfolio_item_id
+      end
+    end
+
+    context 'when showDiscarded is false' do
+      let(:params) { {:showDiscarded => false} }
+
+      it 'return 404' do
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added `showDiscarded` flag into `/portfolio_items/:id` query parameter, so it can display the discarded product when flag is set to `true`.

https://projects.engineering.redhat.com/browse/SSP-1706