### PR TITLE
Permit cache_id in the icons controller raw_icon method

### DIFF
--- a/app/controllers/api/v1x1/icons_controller.rb
+++ b/app/controllers/api/v1x1/icons_controller.rb
@@ -17,7 +17,7 @@ module Api
       end
 
       def raw_icon
-        image = find_icon(params.permit(:icon_id, :portfolio_item_id, :portfolio_id)).image.decoded_image
+        image = find_icon(parse_raw_icon_params).image.decoded_image
         send_data(image,
                   :type        => MimeMagic.by_magic(image).type,
                   :disposition => 'inline')
@@ -39,6 +39,10 @@ module Api
         elsif ids[:portfolio_id].present?
           Icon.find_by!(:restore_to => Portfolio.find(ids[:portfolio_id]))
         end
+      end
+
+      def parse_raw_icon_params
+        params.permit(:icon_id, :portfolio_item_id, :portfolio_id)
       end
     end
   end

--- a/app/controllers/api/v1x2.rb
+++ b/app/controllers/api/v1x2.rb
@@ -11,7 +11,6 @@ module Api
 
     class ApprovalRequestsController          < Api::V1x1::ApprovalRequestsController; end
     class GraphqlController                   < Api::V1x1::GraphqlController; end
-    class IconsController                     < Api::V1x1::IconsController; end
     class OrderItemsController                < Api::V1x1::OrderItemsController; end
     class PortfolioItemsController            < Api::V1x1::PortfolioItemsController; end
     class PortfoliosController                < Api::V1x1::PortfoliosController; end

--- a/app/controllers/api/v1x2/icons_controller.rb
+++ b/app/controllers/api/v1x2/icons_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1x2
+    class IconsController < Api::V1x1::IconsController
+      private
+
+      def parse_raw_icon_params
+        params.permit(:icon_id, :portfolio_item_id, :portfolio_id, :cache_id)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1.2/icons_spec.rb
+++ b/spec/requests/api/v1.2/icons_spec.rb
@@ -1,0 +1,28 @@
+describe "v1.2 - IconsRequests", :type => [:request, :v1x2] do
+  let!(:portfolio_item) { create(:portfolio_item) }
+  let!(:portfolio) { create(:portfolio) }
+
+  let!(:icon) do
+    create(:icon, :image => image, :restore_to => portfolio_item).tap do |icon|
+      icon.restore_to.update!(:icon_id => icon.id)
+    end
+  end
+  let!(:portfolio_icon) do
+    create(:icon, :image => image, :restore_to => portfolio).tap do |icon|
+      icon.restore_to.update!(:icon_id => icon.id)
+    end
+  end
+
+  let(:image) { create(:image) }
+
+  describe "#raw_icon" do
+    context "when the icon exists" do
+      it "returns the icon with cache_id param from /portfolios/{portfolio_id}/icon?cache_id=123" do
+        get "#{api_version}/portfolios/#{portfolio.id}/icon?cache_id=123", :headers => default_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq "image/svg+xml"
+      end
+    end
+  end
+end


### PR DESCRIPTION
this should complete https://github.com/RedHatInsights/catalog-api/pull/793

Turns out, I needed to permit the query parameter inside the controller as well. I was getting an unpermitted parameter error:

```JSON
{
  "errors": [
    {
      "status": "400",
      "detail": "ActionController::UnpermittedParameters: found unpermitted parameter: :cache_id"
    }
  ]
}
```

I should have added the simple test right away.