### PR TITLE
Mark discarded portfolio item's orderable to false directly

### DIFF
--- a/app/controllers/api/v1x1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x1/portfolio_items_controller.rb
@@ -11,18 +11,16 @@ module Api
 
       private
 
-      def render_item(item)
+      def render_item(item, is_discarded = false)
         authorize(item)
-        json = prepare_json(item)
+        json = item.as_json(:prefixes => _prefixes, :template => action_name)
+        json['metadata']['orderable'] = if is_discarded
+                                          false
+                                        else
+                                          Catalog::PortfolioItemOrderable.new(item).process.result
+                                        end
 
         render :json => json
-      end
-
-      def prepare_json(item)
-        json = item.as_json(:prefixes => _prefixes, :template => action_name)
-        json['metadata']['orderable'] = Catalog::PortfolioItemOrderable.new(item).process.result
-
-        json
       end
     end
   end

--- a/app/controllers/api/v1x1/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x1/portfolio_items_controller.rb
@@ -13,10 +13,16 @@ module Api
 
       def render_item(item)
         authorize(item)
+        json = prepare_json(item)
 
+        render :json => json
+      end
+
+      def prepare_json(item)
         json = item.as_json(:prefixes => _prefixes, :template => action_name)
         json['metadata']['orderable'] = Catalog::PortfolioItemOrderable.new(item).process.result
-        render :json => json
+
+        json
       end
     end
   end

--- a/app/controllers/api/v1x2/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x2/portfolio_items_controller.rb
@@ -6,24 +6,13 @@ module Api
 
         raise ActiveRecord::RecordNotFound unless portfolio_item
 
-        render_item(portfolio_item)
+        render_item(portfolio_item, portfolio_item == @discarded)
       end
 
       private
 
       def find_in_discarded_items
         @discarded ||= model.with_discarded.discarded.find_by(:id => params.require(:id)) if params[:show_discarded] == "true"
-      end
-
-      def prepare_json(item)
-        json = item.as_json(:prefixes => _prefixes, :template => action_name)
-        json['metadata']['orderable'] = if item == @discarded
-                                          false
-                                        else
-                                          Catalog::PortfolioItemOrderable.new(item).process.result
-                                        end
-
-        json
       end
     end
   end

--- a/app/controllers/api/v1x2/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x2/portfolio_items_controller.rb
@@ -12,7 +12,18 @@ module Api
       private
 
       def find_in_discarded_items
-        model.with_discarded.discarded.find_by(:id => params.require(:id)) if params[:show_discarded] == "true"
+        @discarded ||= model.with_discarded.discarded.find_by(:id => params.require(:id)) if params[:show_discarded] == "true"
+      end
+
+      def prepare_json(item)
+        json = item.as_json(:prefixes => _prefixes, :template => action_name)
+        json['metadata']['orderable'] = if item == @discarded
+                                          false
+                                        else
+                                          Catalog::PortfolioItemOrderable.new(item).process.result
+                                        end
+
+        json
       end
     end
   end

--- a/spec/requests/api/v1.2/portfolio_items_controller_spec.rb
+++ b/spec/requests/api/v1.2/portfolio_items_controller_spec.rb
@@ -32,6 +32,7 @@ describe "v1.2 - PortfolioItemRequests", :type => [:request, :topology, :v1x2] d
         it 'return 200' do
           expect(response).to have_http_status(200)
           expect(json["id"]).to eq portfolio_item_id.to_s
+          expect(json["metadata"]["orderable"]).to eq(false)
         end
       end
 
@@ -41,6 +42,7 @@ describe "v1.2 - PortfolioItemRequests", :type => [:request, :topology, :v1x2] d
         it 'return 200' do
           expect(response).to have_http_status(200)
           expect(json["id"]).to eq portfolio_items.second.id.to_s
+          expect(json["metadata"]["orderable"]).to eq(true)
         end
       end
     end


### PR DESCRIPTION
This PR is the followup for discussion in #803 : when discarded portfolio item is displayed, its `orderable` flag is set to `false` directly.