### PR TITLE
Ensure that events that have errors while processing are ack'd

### DIFF
--- a/lib/kafka_listener.rb
+++ b/lib/kafka_listener.rb
@@ -54,6 +54,10 @@ class KafkaListener
         Rails.logger.error("Message skipped because it does not belong to a valid tenant")
       end
     end
+  rescue => e
+    Rails.logger.error("Error processing event: #{e.message}")
+  ensure
+    event.ack
   end
 
   def default_messaging_options

--- a/spec/lib/approval/event_listener_spec.rb
+++ b/spec/lib/approval/event_listener_spec.rb
@@ -15,6 +15,8 @@ describe Approval::EventListener do
       :persist_ref => described_class::GROUP_REF,
       :max_bytes   => 500_000
     ).and_yield(event)
+
+    allow(event).to receive(:ack)
   end
 
   context 'when event_type is workflow_deleted' do

--- a/spec/lib/topological_inventory/event_listener_spec.rb
+++ b/spec/lib/topological_inventory/event_listener_spec.rb
@@ -15,6 +15,8 @@ describe TopologicalInventory::EventListener do
       :persist_ref => described_class::GROUP_REF,
       :max_bytes   => 500_000
     ).and_yield(event)
+
+    allow(event).to receive(:ack)
   end
 
   context 'when event_type is Task.update' do


### PR DESCRIPTION
Was on a call with @gmcculloug @syncrou @lindgrenj6 and think we solved https://projects.engineering.redhat.com/browse/SSP-1798.

The message on the pod kept getting retried because we weren't acking the event when there was a problem during processing. The minion was spun back up to see if that resolved the retry error, and it did, which made sense because the minion just passes along the task context and acks the event.

So this PR ensures that we aren't stuck in an infinite loop of subscribing and acks the event if there is an issue.