### PR TITLE
Add log message for relevant topology task ref

### DIFF
--- a/app/services/api/v1x0/catalog/create_request_for_applied_inventories.rb
+++ b/app/services/api/v1x0/catalog/create_request_for_applied_inventories.rb
@@ -28,6 +28,7 @@ module Api
             task_id = api.applied_inventories_for_service_offering(service_offering_ref, service_plan).task_id
 
             @item.update(:topology_task_ref => task_id)
+            Rails.logger.info("OrderItem #{@item.id} updated with topology task ref #{task_id}")
           end
         end
 

--- a/lib/catalog/submit_order.rb
+++ b/lib/catalog/submit_order.rb
@@ -40,6 +40,7 @@ module Catalog
       TopologicalInventory::Service.call do |api_instance|
         result = api_instance.order_service_offering(item.portfolio_item.service_offering_ref, parameters(item))
         item.mark_ordered("Ordered", :topology_task_ref => result.task_id)
+        Rails.logger.info("OrderItem #{item.id} ordered with topology task ref #{result.task_id}")
       end
     end
 

--- a/spec/lib/catalog/submit_order_spec.rb
+++ b/spec/lib/catalog/submit_order_spec.rb
@@ -57,6 +57,14 @@ describe Catalog::SubmitOrder, :type => [:service, :topology, :current_forwardab
       it "updates the order item with the task id" do
         expect(submit_order.process.order.order_items.first.topology_task_ref).to eq("100")
       end
+
+      it "logs a message" do
+        # item.mark_ordered ends up calling a separate rails logger so we need to `allow` here.
+        allow(Rails.logger).to receive(:info)
+
+        expect(Rails.logger).to receive(:info).with("OrderItem #{order.order_items.first.id} ordered with topology task ref 100")
+        submit_order.process
+      end
     end
 
     context "when sending extra parameters" do

--- a/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
@@ -39,6 +39,11 @@ describe Api::V1x0::Catalog::CreateRequestForAppliedInventories, :type => :servi
         expect(order_item.topology_task_ref).to eq("321")
       end
 
+      it "logs a message about the order item receiving a new task id" do
+        expect(Rails.logger).to receive(:info).with("OrderItem #{order_item.id} updated with topology task ref 321")
+        subject.process
+      end
+
       it "creates a progress message on the order item" do
         subject.process
         progress_message = ProgressMessage.last


### PR DESCRIPTION
Scrawling the logs in production for the issue encountered on Sept 9th would have been a lot easier if we had this message to reconcile which OrderItem had which task id. The problem is that there are so many tasks coming in that we didn't know which task corresponded to the relevant order item. The only way to check is to log into the box and look in the database via rails console, but since we aren't allowed to do that on ocp4, it was a nightmare.