### PR TITLE
Refactor DetermineTaskRelevancy to clean up logic

### DIFF
--- a/lib/catalog/create_approval_request.rb
+++ b/lib/catalog/create_approval_request.rb
@@ -2,9 +2,9 @@ module Catalog
   class CreateApprovalRequest
     attr_reader :order
 
-    def initialize(task)
+    def initialize(task, order_item)
       @task = task
-      @order = OrderItem.find_by!(:topology_task_ref => task.id).order
+      @order = order_item.order
     end
 
     def process

--- a/lib/catalog/create_approval_request.rb
+++ b/lib/catalog/create_approval_request.rb
@@ -2,8 +2,9 @@ module Catalog
   class CreateApprovalRequest
     attr_reader :order
 
-    def initialize(task, order_item)
+    def initialize(task, order_item = nil)
       @task = task
+      order_item ||= OrderItem.find_by!(:topology_task_ref => task.id)
       @order = order_item.order
     end
 

--- a/lib/catalog/update_order_item.rb
+++ b/lib/catalog/update_order_item.rb
@@ -1,9 +1,10 @@
 module Catalog
   class UpdateOrderItem
-    def initialize(topic, task, order_item)
+    def initialize(topic, task, order_item = nil)
       @payload    = topic.payload
       @message    = topic.message
       @task       = task
+      order_item ||= OrderItem.find_by!(:topology_task_ref => @task.id)
       @order_item = order_item
     end
 

--- a/lib/catalog/update_order_item.rb
+++ b/lib/catalog/update_order_item.rb
@@ -1,17 +1,14 @@
 module Catalog
   class UpdateOrderItem
-    def initialize(topic, task)
-      @payload = topic.payload
-      @message = topic.message
-      @task    = task
+    def initialize(topic, task, order_item)
+      @payload    = topic.payload
+      @message    = topic.message
+      @task       = task
+      @order_item = order_item
     end
 
     def process
       Rails.logger.info("Processing service order topic message: #{@message} with payload: #{@payload}")
-
-      Rails.logger.info("Searching for OrderItem with a task_ref: #{@payload["task_id"]}")
-      @order_item = find_order_item
-      Rails.logger.info("Found OrderItem: #{@order_item.id}")
 
       @order_item.update_message("info", "Task update message received with payload: #{@payload}")
 
@@ -19,13 +16,6 @@ module Catalog
     end
 
     private
-
-    def find_order_item
-      OrderItem.find_by!(:topology_task_ref => @payload["task_id"])
-    rescue ActiveRecord::RecordNotFound
-      Rails.logger.error("Could not find an OrderItem with topology_task_ref: #{@payload["task_id"]}")
-      raise "Could not find an OrderItem with topology_task_ref: #{@payload["task_id"]}"
-    end
 
     def mark_item_based_on_status
       case @payload["status"]
@@ -43,7 +33,7 @@ module Catalog
     end
 
     def service_instance_id
-      @service_instance_id ||= @task.context.dig(:service_instance, :id) || @order_item.service_instance_ref
+      @service_instance_id ||= @task.context.dig(:service_instance, :id) || @order_item.service_instance_ref.to_s
     end
   end
 end

--- a/spec/lib/catalog/create_approval_request_spec.rb
+++ b/spec/lib/catalog/create_approval_request_spec.rb
@@ -1,5 +1,5 @@
 describe Catalog::CreateApprovalRequest, :type => :service do
-  let(:subject) { described_class.new(task) }
+  let(:subject) { described_class.new(task, order_item) }
   let(:task) { TopologicalInventoryApiClient::Task.new(:id => "123") }
 
   around do |example|
@@ -9,7 +9,7 @@ describe Catalog::CreateApprovalRequest, :type => :service do
   end
 
   let(:order) { order_item.order }
-  let!(:order_item) { create(:order_item, :topology_task_ref => "123", :process_scope => 'applicable') }
+  let!(:order_item) { create(:order_item, :process_scope => 'applicable') }
 
   let(:create_request_body_from) { instance_double(Catalog::CreateRequestBodyFrom, :result => request_body_from) }
   let(:request_body_from) { {"test" => "test"}.to_json }

--- a/spec/lib/catalog/update_order_item_spec.rb
+++ b/spec/lib/catalog/update_order_item_spec.rb
@@ -1,156 +1,102 @@
-describe Catalog::UpdateOrderItem, :type => :service do
-  let(:subject) { described_class.new(topic, task) }
+describe Catalog::UpdateOrderItem, :type => [:topology, :service] do
+  let(:subject) { described_class.new(topic, task, order_item) }
   let(:topic) { Struct.new(:payload, :message).new(payload, "message") }
-  let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:id => "321"}}) }
+  let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:id => service_instance_id}}) }
+  let(:service_instance_id) { "321" }
 
   describe "#process" do
     let(:payload) { {"task_id" => "123", "status" => status, "state" => state, "context" => "payloadcontext"} }
-    let!(:item) { create(:order_item, :topology_task_ref => topology_task_ref) }
-    let(:order) { item.order }
-
-    around do |example|
-      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://topology.example.com") do
-        example.call
-      end
-    end
+    # let(:order_item) { instance_double(OrderItem, :service_instance_ref => 213) }
+    let(:order_item) { create(:order_item, :service_instance_ref => 213) }
 
     before do
-      allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
+      allow(order_item).to receive(:update_message)
+      allow(order_item).to receive(:mark_completed)
+      allow(order_item).to receive(:mark_failed)
     end
 
-    context "when the order item is not findable" do
-      let(:topology_task_ref) { "0" }
+    shared_examples_for "#process info message" do
+      it "updates the order item with an info message" do
+        expect(order_item).to receive(:update_message).with("info", "Task update message received with payload: #{payload}")
+        subject.process
+      end
+    end
+
+    context "when the status of the task is ok" do
       let(:status) { "ok" }
+
+      context "when the state is completed" do
+        let(:state) { "completed" }
+
+        context "when the task has a service instance id" do
+          it_behaves_like "#process info message"
+
+          it "marks the item as completed with the correct service instance id" do
+            expect(order_item).to receive(:mark_completed).with("Order Item Complete", :service_instance_ref => "321")
+            subject.process
+          end
+        end
+
+        context "when the task does not have a service instance id" do
+          let(:service_instance_id) { nil }
+
+          it_behaves_like "#process info message"
+
+          it "marks the item as completed with the correct service instance id" do
+            expect(order_item).to receive(:mark_completed).with("Order Item Complete", :service_instance_ref => "213")
+            subject.process
+          end
+        end
+      end
+
+      context "when the state is running" do
+        let(:state) { "running" }
+        let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:url => "http://tower.com/job/3"}}) }
+
+        it "sends two update messages" do
+          expect(order_item).to receive(:update_message).with("info", "Task update message received with payload: #{payload}")
+          expect(order_item).to receive(:update_message).with("info", "Order Item being processed with context: payloadcontext")
+          subject.process
+        end
+
+        it "updates the order item with the external url" do
+          subject.process
+          order_item.reload
+          expect(order_item.external_url).to eq("http://tower.com/job/3")
+        end
+      end
+    end
+
+    context "when the status of the task is error" do
+      let(:status) { "error" }
       let(:state) { "bar" }
 
-      it "raises an error" do
-        expect { subject.process }.to raise_error("Could not find an OrderItem with topology_task_ref: 123")
+      context "when the task has a service instance id" do
+        it "marks the item as failed with the proper id" do
+          expect(order_item).to receive(:mark_failed).with("Order Item Failed", :service_instance_ref => "321")
+          subject.process
+        end
+
+        it_behaves_like "#process info message"
+      end
+
+      context "when the task does not have a service instance id" do
+        let(:service_instance_id) { nil }
+
+        it "marks the item as failed with the proper id" do
+          expect(order_item).to receive(:mark_failed).with("Order Item Failed", :service_instance_ref => "213")
+          subject.process
+        end
+
+        it_behaves_like "#process info message"
       end
     end
 
-    context "when the order item is findable" do
-      let(:topology_task_ref) { "123" }
-      context "when the status of the task is ok" do
-        let(:status) { "ok" }
+    context "when the status of the task is anything else" do
+      let(:status) { "foo" }
+      let(:state) { "bar" }
 
-        context "when the state is completed" do
-          let(:state) { "completed" }
-          context "#process when it all goes well" do
-            it "creates a progress message about the payload" do
-              subject.process
-              latest_progress_message = ProgressMessage.second_to_last
-              expect(latest_progress_message.level).to eq("info")
-              expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
-            end
-
-            it "updates the completed at time" do
-              fake_now = Time.now.iso8601
-              allow(DateTime).to receive(:now).and_return(fake_now)
-              subject.process
-              item.reload
-              expect(item.completed_at).to eq(fake_now)
-            end
-
-            it "updates the order item to be completed" do
-              subject.process
-              item.reload
-              expect(item.state).to eq("Completed")
-            end
-
-            it "creates a progress message about the completion" do
-              subject.process
-              latest_progress_message = ProgressMessage.last
-              expect(latest_progress_message.level).to eq("info")
-              expect(latest_progress_message.message).to eq("Order Item Complete")
-            end
-
-            it "finalizes the order" do
-              expect(order.state).to_not eq("Completed")
-              subject.process
-              order.reload
-              expect(order.state).to eq("Completed")
-            end
-          end
-        end
-
-        context "when the state is running" do
-          let(:state) { "running" }
-          let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:url => "http://tower.com/job/3"}}) }
-
-          it "creates multiple progress messages" do
-            subject.process
-            payload_progress_message, context_progress_message = ProgressMessage.last(2)
-            expect(payload_progress_message.level).to eq("info")
-            expect(context_progress_message.level).to eq("info")
-            expect(payload_progress_message.message).to eq("Task update message received with payload: #{payload}")
-            expect(context_progress_message.message).to eq("Order Item being processed with context: payloadcontext")
-          end
-
-          it "sets the external url from the payload" do
-            subject.process
-            item.reload
-            expect(item.external_url).to eq("http://tower.com/job/3")
-          end
-        end
-      end
-
-      context "when the status of the task is error" do
-        let(:status) { "error" }
-        let(:state) { "bar" }
-
-        it "creates a progress message about the payload" do
-          subject.process
-          latest_progress_message = ProgressMessage.second_to_last
-          expect(latest_progress_message.level).to eq("info")
-          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
-        end
-
-        it "updates the completed at time" do
-          fake_now = Time.now.iso8601
-          allow(DateTime).to receive(:now).and_return(fake_now)
-          subject.process
-          item.reload
-          expect(item.completed_at).to eq(fake_now)
-        end
-
-        it "sets the service_instance_ref" do
-          subject.process
-          item.reload
-          expect(item.service_instance_ref).to eq("321")
-        end
-
-        it "marks the item as failed" do
-          subject.process
-          item.reload
-          expect(item.state).to eq("Failed")
-        end
-
-        it "creates a progress message about the failure" do
-          subject.process
-          latest_progress_message = ProgressMessage.last
-          expect(latest_progress_message.level).to eq("error")
-          expect(latest_progress_message.message).to eq("Order Item Failed")
-        end
-
-        it "finalizes the order" do
-          expect(order.state).to_not eq("Failed")
-          subject.process
-          order.reload
-          expect(order.state).to eq("Failed")
-        end
-      end
-
-      context "when the status of the task is anything else" do
-        let(:status) { "foo" }
-        let(:state) { "bar" }
-
-        it "creates a progress message about the payload" do
-          subject.process
-          latest_progress_message = ProgressMessage.last
-          expect(latest_progress_message.level).to eq("info")
-          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
-        end
-      end
+      it_behaves_like "#process info message"
     end
   end
 end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -87,6 +87,10 @@ describe OrderItem do
       end
 
       it_behaves_like "#mark_item"
+
+      it "finalizes the order" do
+        expect(order_item.order.state).to eq("Failed")
+      end
     end
 
     context "when there are no message parameters passed in" do


### PR DESCRIPTION
The biggest change in the spec is mostly organization and reducing the amount of integration testing that it was doing.

I decided since we're already doing the `find_by!` on the order item in the `DetermineTaskRelevancy` class, we might as well just pass along that order item to the classes that use it, so that is the reasoning for the changes on them. The spec for the `UpdateOrderItem` was reliant on needing to find the order item, but since it's just being passed in now, it had to change, and I found that it was actually allowing all of the `mark_item` calls to go through which seemed unnecessary since they're all tested on the model anyway (except one I had to add the spec for).

I'll try to sum up the logic change for `DetermineTaskRelevancy` in plain terms since I know it's a lot to attempt to digest with the way things moved around.

So the change that @bzwei just made in #812 was mainly:
`return self unless validate_task`
This would attempt to find the order item via the topology_task_ref and instead of erroring, simply log a message and return. I kept the `find_by!` like how it used to be but instead I catch the `RecordNotFound` error and log the message that way, and then return self in the rescue. We can keep Bill's way if we want to, but I think explicitly handling the exception gives us a little bit better control flow than having to return true/false from that validate_task method.

Next it would try to delegate the task, but only if the state was completed or running. This is a bit confusing because regardless, afterwards it would mark the order as failed if the status was "error". I've changed this to check the status first, because if there's an error, what we do depends on if the task is still running or if it's completed. If it's still running, we simply log the error and do nothing else, because we're not sure if it will finish in an error status. If it's completed, we can still potentially make use of it, for example storing the service instance id, but we still mark the order as failed because now we know there's nothing left we can do.

If the status is not "error", then it is either "warn" or "ok", and we simply look at the context for relevancy. It doesn't really matter if the state is "completed" or "running" (or "pending" or "queued" are the other valid states), because the context is what we care about, and it won't exist until the work has been at least somewhat done.

I think this makes it cleaner overall, but the if/else blocks are not ideal and I'm open to discussion there, and rubocop might yell at me 😆 .

@bzwei @hsong-rh Please Review.