### PR TITLE
Pin puma to not upgrade to 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'mimemagic', '~> 0.3.3'
 gem 'more_core_extensions', '~>3.5'
 gem 'pg', '~> 1.0', :require => false
 gem 'prometheus-client', '~> 0.8.0'
-gem 'puma', '>= 4.3.5'
+gem 'puma', '~> 4', '>= 4.3.5'
 gem 'pundit'
 gem 'rack-cors', '>= 1.0.4'
 gem 'rest-client', '>= 1.8.0'


### PR DESCRIPTION
Seeing the new pod `CrashLoopBackOff` due to the fact that apparently puma 5.0 was released recently and this is the first version we've pushed up with the new updates. 

Just pinning it to anything 4.x.x but above 4.3.5

cc @gmcculloug @eclarizio @syncrou 