### PR TITLE
Remove required 'name' from OrderProcess json definition

### DIFF
--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -4295,9 +4295,6 @@
       },
       "OrderProcess": {
         "type": "object",
-        "required": [
-          "name"
-        ],
         "properties": {
           "id": {
             "type": "string",


### PR DESCRIPTION
Remove the required name from the openapi json definition, this is how we handle Portfolios and PortfolioItems, so it makes sense to me to keep it the same for OrderProcesses.

https://issues.redhat.com/browse/SSP-1796