### PR TITLE
Upgrading the insights-api-common gem to 4.1.4 version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 
 gem 'dhasher'
 gem 'discard', :git => 'https://github.com/jhawthorn/discard', :branch => 'master'
-gem 'insights-api-common', '~> 4.0'
+gem 'insights-api-common', '~> 4.1.4'
 gem 'jbuilder', '~> 2.0'
 gem 'manageiq-loggers', '~> 0.2'
 gem 'manageiq-messaging', '~> 1.0'


### PR DESCRIPTION
Upgrading the insights-api-common gem to 4.1.4 version that no longer allows redirects from major versions on a POST.

This PR is based on https://issues.redhat.com/browse/RHCLOUD-9585.