### PR TITLE
Update order_item status before submitting

### DIFF
--- a/lib/catalog/approval_transition.rb
+++ b/lib/catalog/approval_transition.rb
@@ -38,9 +38,9 @@ module Catalog
     end
 
     def submit_order
+      finalize_order
       @order_item.update_message("info", "Submitting Order #{@order_item.order_id} for provisioning ")
       Catalog::SubmitNextOrderItem.new(@order_item.order_id).process
-      finalize_order
     rescue ::Catalog::TopologyError => e
       Rails.logger.error("Error Submitting Order #{@order_item.order_id}, #{e.message}")
       @order_item.update_message("error", "Error Submitting Order #{@order_item.order_id}, #{e.message}")

--- a/spec/lib/catalog/approval_transition_spec.rb
+++ b/spec/lib/catalog/approval_transition_spec.rb
@@ -31,12 +31,15 @@ describe Catalog::ApprovalTransition do
       end
 
       it "returns the state as approved" do
-        expect(order_item_transition.process.state).to eq "Approved"
+        expect(order_item_transition.process.state).to eq("Approved")
       end
 
       it "calls out to Catalog::SubmitNextOrderItem" do
         expect(so).to receive(:new).with(order.id)
-        expect(submit_order).to receive(:process).once
+        expect(submit_order).to receive(:process).once do
+          order_item.reload
+          expect(order_item.state).to eq("Approved")
+        end
         order_item_transition.process
       end
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-1876

We need to change the order_item's state to `Approved` before submitting; otherwise there is no item ready for ordering.