### PR TITLE
Added miss 'count' param in creating order items during order process evaluation

### DIFF
--- a/app/services/api/v1x2/catalog/evaluate_order_process.rb
+++ b/app/services/api/v1x2/catalog/evaluate_order_process.rb
@@ -54,6 +54,7 @@ module Api
           {
             :order_id          => @order.id,
             :portfolio_item_id => order_process.before_portfolio_item.id,
+            :count             => 1,
             :process_sequence  => before_sequence_number,
             :process_scope     => "before"
           }
@@ -63,6 +64,7 @@ module Api
           {
             :order_id          => @order.id,
             :portfolio_item_id => order_process.after_portfolio_item.id,
+            :count             => 1,
             :process_sequence  => after_sequence_number,
             :process_scope     => "after"
           }

--- a/spec/services/api/v1.2/catalog/evaluate_order_process_spec.rb
+++ b/spec/services/api/v1.2/catalog/evaluate_order_process_spec.rb
@@ -29,6 +29,7 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
         {
           :order_id          => order.id,
           :portfolio_item_id => before_portfolio_item.id,
+          :count             => 1,
           :process_sequence  => 1,
           :process_scope     => "before"
         }
@@ -38,6 +39,7 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
         {
           :order_id          => order.id,
           :portfolio_item_id => after_portfolio_item.id,
+          :count             => 1,
           :process_sequence  => 3,
           :process_scope     => "after"
         }
@@ -98,6 +100,7 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
             {
               :order_id          => order.id,
               :portfolio_item_id => after_portfolio_item.id,
+              :count             => 1,
               :process_sequence  => 2,
               :process_scope     => "after"
             }
@@ -205,6 +208,7 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
             {
               :order_id          => order.id,
               :portfolio_item_id => before_portfolio_item.id,
+              :count             => 1,
               :process_sequence  => 1,
               :process_scope     => "before"
             }
@@ -213,6 +217,7 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
             {
               :order_id          => order.id,
               :portfolio_item_id => before_portfolio_item2.id,
+              :count             => 1,
               :process_sequence  => 2,
               :process_scope     => "before"
             }
@@ -222,6 +227,7 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
             {
               :order_id          => order.id,
               :portfolio_item_id => after_portfolio_item.id,
+              :count             => 1,
               :process_sequence  => 5,
               :process_scope     => "after"
             }
@@ -230,6 +236,7 @@ describe Api::V1x2::Catalog::EvaluateOrderProcess, :type => :service do
             {
               :order_id          => order.id,
               :portfolio_item_id => after_portfolio_item2.id,
+              :count             => 1,
               :process_sequence  => 4,
               :process_scope     => "after"
             }


### PR DESCRIPTION
Based on open api spec, `count` is a required param in creating order item.

https://issues.redhat.com/browse/SSP-1898