### PR TITLE
Encode order_item name in workspace

### DIFF
--- a/lib/catalog/workspace_builder.rb
+++ b/lib/catalog/workspace_builder.rb
@@ -20,15 +20,13 @@ module Catalog
     end
 
     def request
-      # assume there is only one applicable
-      applicable = @order.order_items.find_by(:process_scope => 'applicable')
-      {'order_id' => @order.id, 'order_started' => @order.order_request_sent_at, 'order_params' => applicable.service_parameters_raw}
+      {'order_id' => @order.id, 'order_started' => @order.order_request_sent_at}
     end
 
     def collect_order_items
       facts = {'before' => {}, 'applicable' => {}, 'after' => {}}
       @order.order_items.each do |item|
-        facts[item.process_scope][item.portfolio_item.name] = order_item_facts(item)
+        facts[item.process_scope][encode_name(item.portfolio_item.name)] = order_item_facts(item)
       end
 
       facts
@@ -36,6 +34,10 @@ module Catalog
 
     def order_item_facts(order_item)
       {'artifacts' => Hash(order_item.artifacts), 'extra_vars' => Hash(order_item.service_parameters_raw), 'status' => order_item.state}
+    end
+
+    def encode_name(name)
+      name.each_byte.map { |byte| byte.to_s(16) }.join
     end
   end
 end

--- a/spec/lib/catalog/workspace_builder_spec.rb
+++ b/spec/lib/catalog/workspace_builder_spec.rb
@@ -62,9 +62,9 @@ describe Catalog::WorkspaceBuilder do
       ws = subject.process.workspace
       expect(ws['user']).to include("email" => "jdoe@acme.com", "name" => "John Doe")
       expect(ws['request']).to include('order_id' => order.id, 'order_started' => time.utc)
-      expect(ws['before']).to include(portfolio_item_process.name => {'artifacts' => before_facts, 'extra_vars' => before_params, 'status' => 'Created'})
-      expect(ws['after']).to include(portfolio_item_process.name => {'artifacts' => after_facts, 'extra_vars' => after_params, 'status' => 'Created'})
-      expect(ws['applicable']).to include(portfolio_item.name => {'artifacts' => app_facts, 'extra_vars' => order_params, 'status' => 'Created'})
+      expect(ws['before']).to include(subject.send(:encode_name, portfolio_item_process.name) => {'artifacts' => before_facts, 'extra_vars' => before_params, 'status' => 'Created'})
+      expect(ws['after']).to include(subject.send(:encode_name, portfolio_item_process.name) => {'artifacts' => after_facts, 'extra_vars' => after_params, 'status' => 'Created'})
+      expect(ws['applicable']).to include(subject.send(:encode_name, portfolio_item.name) => {'artifacts' => app_facts, 'extra_vars' => order_params, 'status' => 'Created'})
     end
   end
 end


### PR DESCRIPTION
In the workspace we use order_item (portfolio_item)'s name as the key to identify the order_item, but the key accepted by Mustache cannot contain special characters. This PR encodes the order_item name into its hex representation. In the Mustache template the user can continue to use the full name of the portfolio_item. At the substitution time we parse the name and do the same encoding.  

https://issues.redhat.com/browse/SSP-1894
https://issues.redhat.com/browse/SSP-1870

It also fixes https://issues.redhat.com/browse/SSP-1904 by allowing substitution on only string value