### PR TITLE
No need to switch request context as it has done by parent class

### DIFF
--- a/lib/approval/event_listener.rb
+++ b/lib/approval/event_listener.rb
@@ -19,13 +19,8 @@ module Approval
     end
 
     def remove_approval_tag(event)
-      insights_headers = event.headers.slice('x-rh-identity', 'x-rh-insights-request-id')
-      Insights::API::Common::Request.with_request(:headers => insights_headers, :original_url => nil) do |req|
-        ActsAsTenant.with_tenant(Tenant.find_by!(:external_tenant => req.tenant)) do
-          workflow_id = event.payload['workflow_id']
-          Tag.find_by(:name => 'workflows', :namespace => 'approval', :value => workflow_id.to_s)&.destroy
-        end
-      end
+      workflow_id = event.payload['workflow_id']
+      Tag.find_by(:name => 'workflows', :namespace => 'approval', :value => workflow_id.to_s)&.destroy
     end
 
     def update_approval_status(event)


### PR DESCRIPTION
Remove the redundant context switching.

The context has already been switched in https://github.com/RedHatInsights/catalog-api/blob/master/lib/kafka_listener.rb#L41