### PR TITLE
Fail the order when an uncaught error is detected

### DIFF
--- a/lib/approval/event_listener.rb
+++ b/lib/approval/event_listener.rb
@@ -30,6 +30,9 @@ module Approval
 
     def update_approval_status(event)
       Catalog::NotifyApprovalRequest.new(event.payload['request_id'], event.payload, event.message).process
+    rescue
+      order_item = ApprovalRequest.find_by(:approval_request_ref => event.payload['request_id'])&.order_item
+      order_item&.mark_failed("Internal Error. Please contact our support team.")
     end
   end
 end

--- a/lib/topological_inventory/event_listener.rb
+++ b/lib/topological_inventory/event_listener.rb
@@ -13,6 +13,9 @@ module TopologicalInventory
       event.payload['task_id'] = event.payload.delete('id')
       topic = OpenStruct.new(:payload => event.payload, :message => event.message)
       Catalog::DetermineTaskRelevancy.new(topic).process
+    rescue
+      order_item = OrderItem.find_by(:topology_task_ref => event.payload['task_id'].to_s)
+      order_item&.mark_failed("Internal Error. Please contact our support team.")
     end
   end
 end


### PR DESCRIPTION
At the top level of an event handler of Kafka messages for any uncaught errors we now try to fail the order so that it will not remain in an unfinished state forever as reported in https://issues.redhat.com/browse/SSP-1904