### PR TITLE
Expose the artifacts column for order items on the openapi

### DIFF
--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -3856,6 +3856,16 @@
             "example": "before",
             "description": "Denotes the scope in which the order item will run for the order it belongs to. It can be 'before', 'after', or 'applicable'",
             "readOnly": true
+          },
+          "artifacts": {
+            "type": "object",
+            "title": "Return values from a product provision",
+            "description": "Contains a key/value object that contains all of the information sent from a product provision",
+            "readOnly": true,
+            "example": {
+              "expose_to_cloud_redhat_com_important_id": 10,
+              "expose_to_cloud_redhat_com_ip_address": "127.0.0.1"
+            }
           }
         }
       },

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -3860,11 +3860,11 @@
           "artifacts": {
             "type": "object",
             "title": "Return values from a product provision",
-            "description": "Contains a key/value object that contains all of the information sent from a product provision",
+            "description": "Contains a prefix-stripped key/value object that contains all of the information exposed from product provisioning. Must be exposed from Tower with prefix 'expose_to_cloud_redhat_com_'",
             "readOnly": true,
             "example": {
-              "expose_to_cloud_redhat_com_important_id": 10,
-              "expose_to_cloud_redhat_com_ip_address": "127.0.0.1"
+              "important_id": 10,
+              "ip_address": "127.0.0.1"
             }
           }
         }


### PR DESCRIPTION
Pretty simple, we need to expose the artifacts for the UI to use them later. For now, the plan is to simply use them in the lifecycle tab as a simple table, but eventually they will be used with more UX/UI design.

https://issues.redhat.com/browse/SSP-1895

(UI related story: https://issues.redhat.com/browse/SSP-1873)

/cc @lgalis 