### PR TITLE
Update codeclimate yaml to use manageiq-style rubocop rules

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,9 +2,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:
@@ -27,5 +27,5 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-69
+    channel: rubocop-0-82
     config: ".rubocop_cc.yml"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_base.yml
 - .rubocop_local.yml


### PR DESCRIPTION
https://github.com/ManageIQ/guides/pull/443 Removed our reference to the rubocop.yml files we were using, so we need to update to using the manageiq-style rubocop rules (or make our own, but that can wait)