### PR TITLE
Fixed to refresh statistics metadata properly

### DIFF
--- a/app/models/concerns/metadata/ancillary.rb
+++ b/app/models/concerns/metadata/ancillary.rb
@@ -16,8 +16,6 @@ module Metadata
         build_ancillary_metadata
       end
 
-      update_ancillary_metadata
-
       ancillary_metadata.save! unless new_record?
     end
   end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -25,7 +25,7 @@ class Portfolio < ApplicationRecord
   end
 
   def metadata
-    ancillary_metadata.metadata_attributes.merge('user_capabilities' => user_capabilities)
+    ancillary_metadata.metadata_attributes.merge('user_capabilities' => user_capabilities, 'statistics' => statistics_metadata)
   end
 
   private

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -30,10 +30,6 @@ class Portfolio < ApplicationRecord
 
   private
 
-  def update_ancillary_metadata
-    ancillary_metadata.statistics = statistics_metadata
-  end
-
   def statistics_metadata
     {
       'approval_processes' => tags.where(:namespace => 'approval', :name => 'workflows').count,

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -26,7 +26,7 @@ class PortfolioItem < ApplicationRecord
   validates :name, :presence => true, :length => {:maximum => MAX_NAME_LENGTH}
 
   def metadata
-    ancillary_metadata.metadata_attributes.merge('user_capabilities' => user_capabilities)
+    ancillary_metadata.metadata_attributes.merge('user_capabilities' => user_capabilities, 'statistics' => statistics_metadata)
   end
 
   private

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -35,10 +35,6 @@ class PortfolioItem < ApplicationRecord
     portfolio.update_metadata
   end
 
-  def update_ancillary_metadata
-    ancillary_metadata.statistics = statistics_metadata
-  end
-
   def statistics_metadata
     {
       'approval_processes' => tags.where(:namespace => 'approval', :name => 'workflows').count

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -79,7 +79,6 @@ describe PortfolioItem do
       subject.tag_add('workflows', :namespace => 'approval', :value => '123')
       subject.tag_add('workflows', :namespace => 'approval', :value => '456')
       subject.tag_add('order_processes', :namespace => 'approval', :value => '789')
-      subject.update_metadata
     end
 
     it 'adds staticsitcs' do

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -201,7 +201,6 @@ describe Portfolio do
     context 'with an access_control_entry with permissions' do
       before do
         create(:access_control_entry, :has_read_permission, :aceable => subject)
-        subject.update_metadata
       end
 
       it 'returns statistics with shared_groups value of 1' do
@@ -212,7 +211,6 @@ describe Portfolio do
     context 'with an access_control_entry without permissions' do
       before do
         create(:access_control_entry, :aceable => subject)
-        subject.update_metadata
       end
 
       it 'returns statistics with shared_groups value of zero' do
@@ -225,7 +223,6 @@ describe Portfolio do
         subject.tag_add('workflows', :namespace => 'approval', :value => '123')
         subject.tag_add('workflows', :namespace => 'approval', :value => '456')
         subject.tag_add('order_processes', :namespace => 'approval', :value => '789')
-        subject.update_metadata
       end
 
       it 'returns statistics with approval_processes value of two' do

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -151,7 +151,6 @@ describe Portfolio do
     context 'ancillary_metadata instance does not exist' do
       it 'creates ancillary_metadata instance but does not save it' do
         expect(subject).to receive(:build_ancillary_metadata).and_call_original
-        expect(subject).to receive(:update_ancillary_metadata)
 
         subject.update_metadata
         expect(subject.ancillary_metadata.persisted?).to be false
@@ -162,7 +161,6 @@ describe Portfolio do
       subject { portfolio }
 
       it 'updates and saves ancillary_metadata' do
-        expect(subject).to receive(:update_ancillary_metadata)
         expect(subject.ancillary_metadata).to receive(:save!)
 
         subject.update_metadata
@@ -172,7 +170,7 @@ describe Portfolio do
         before { subject.destroy }
 
         it 'returns without updating ancillary_metadata' do
-          expect(subject).to_not receive(:update_ancillary_metadata)
+          expect(subject.ancillary_metadata).not_to receive(:save!)
 
           portfolio.update_metadata
         end

--- a/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolio_items_controller_spec.rb
@@ -25,7 +25,6 @@ describe "v1.1 - PortfolioItemRequests", :type => [:request, :topology, :v1x1] d
       portfolio_item.tag_add('workflows', :namespace => 'approval', :value => '123')
       portfolio_item.tag_add('order_processes', :namespace => 'approval', :value => '456')
 
-      portfolio_item.update_metadata
       subject unless example.metadata[:subject_inside]
     end
 

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -23,7 +23,6 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
       portfolio.tag_add('workflows', :namespace => 'approval', :value => '123')
       portfolio.tag_add('order_processes', :namespace => 'approval', :value => '456')
 
-      portfolio.update_metadata
       get "#{api_version}/portfolios/#{portfolio_id}", :headers => default_headers
     end
 


### PR DESCRIPTION
The `statistics_metadata` is only called by `update_metadata` in callbacks, which causes incorrect metadata in normal case.  This PR moves the call into `metadata` so it's updated properly.

https://issues.redhat.com/browse/SSP-1917