### PR TITLE
Fixed wrong params order in creating approval request

### DIFF
--- a/lib/catalog/determine_task_relevancy.rb
+++ b/lib/catalog/determine_task_relevancy.rb
@@ -45,7 +45,7 @@ module Catalog
         EvaluateOrderProcess.new(@task, @order_item.order, tag_resources).process
 
         Rails.logger.info("Creating approval request for task id #{@task.id}")
-        CreateApprovalRequest.new(@task, @order_item, tag_resources).process
+        CreateApprovalRequest.new(@task, tag_resources, @order_item).process
       else
         Rails.logger.info("Incoming task has no current relevant delegation")
       end

--- a/spec/lib/catalog/determine_task_relevancy_spec.rb
+++ b/spec/lib/catalog/determine_task_relevancy_spec.rb
@@ -41,7 +41,7 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
       before do
         allow(Catalog::UpdateOrderItem).to receive(:new).with(an_instance_of(TopologicalInventoryApiClient::Task), order_item).and_return(update_order_item)
         allow(update_order_item).to receive(:process)
-        allow(Catalog::CreateApprovalRequest).to receive(:new).with(an_instance_of(TopologicalInventoryApiClient::Task), order_item, tag_resources).and_return(create_approval_request)
+        allow(Catalog::CreateApprovalRequest).to receive(:new).with(an_instance_of(TopologicalInventoryApiClient::Task), tag_resources, order_item).and_return(create_approval_request)
         allow(create_approval_request).to receive(:process)
         allow(Catalog::EvaluateOrderProcess).to receive(:new).with(an_instance_of(TopologicalInventoryApiClient::Task), order, tag_resources).and_return(evaluate_order_process)
         allow(evaluate_order_process).to receive(:process)


### PR DESCRIPTION
The wrong params order was introduced when solving rubocop complaints, now fix it to the right way.