### PR TITLE
Add progress message when a task fails

### DIFF
--- a/lib/catalog/update_order_item.rb
+++ b/lib/catalog/update_order_item.rb
@@ -9,8 +9,6 @@ module Catalog
     end
 
     def process
-      @order_item.update_message("info", "Task update message received with payload: #{@task}")
-
       mark_item_based_on_status
     end
 
@@ -21,8 +19,9 @@ module Catalog
       when "ok"
         case @task.state
         when "completed"
-          @order_item.mark_completed("Order Item Complete", :service_instance_ref => service_instance_id, :artifacts => artifacts)
+          @order_item.mark_completed("Order Item Completed", :service_instance_ref => service_instance_id, :artifacts => artifacts)
         when "running"
+          @order_item.update_message("info", "Order Item Is Running")
           @order_item.update!(:external_url => @task.context.dig(:service_instance, :url))
         end
       when "error"

--- a/spec/lib/catalog/update_order_item_spec.rb
+++ b/spec/lib/catalog/update_order_item_spec.rb
@@ -20,13 +20,6 @@ describe Catalog::UpdateOrderItem, :type => [:topology, :service] do
       allow(order_item).to receive(:mark_failed)
     end
 
-    shared_examples_for "#process info message" do
-      it "updates the order item with an info message" do
-        expect(order_item).to receive(:update_message).with("info", "Task update message received with payload: #{task}")
-        subject.process
-      end
-    end
-
     context "when the status of the task is ok" do
       let(:status) { "ok" }
 
@@ -34,10 +27,8 @@ describe Catalog::UpdateOrderItem, :type => [:topology, :service] do
         let(:state) { "completed" }
 
         context "when the task has a service instance id" do
-          it_behaves_like "#process info message"
-
           it "marks the item as completed with the correct service instance id and artifacts" do
-            expect(order_item).to receive(:mark_completed).with("Order Item Complete", :service_instance_ref => "321", :artifacts => {'k1' => 'v1', 'k2' => 'v2'})
+            expect(order_item).to receive(:mark_completed).with("Order Item Completed", :service_instance_ref => "321", :artifacts => {'k1' => 'v1', 'k2' => 'v2'})
             subject.process
           end
         end
@@ -45,10 +36,8 @@ describe Catalog::UpdateOrderItem, :type => [:topology, :service] do
         context "when the task does not have a service instance id" do
           let(:service_instance_id) { nil }
 
-          it_behaves_like "#process info message"
-
           it "marks the item as completed with the correct service instance id and artifacts" do
-            expect(order_item).to receive(:mark_completed).with("Order Item Complete", :service_instance_ref => "213", :artifacts => {'k1' => 'v1', 'k2' => 'v2'})
+            expect(order_item).to receive(:mark_completed).with("Order Item Completed", :service_instance_ref => "213", :artifacts => {'k1' => 'v1', 'k2' => 'v2'})
             subject.process
           end
         end
@@ -58,8 +47,8 @@ describe Catalog::UpdateOrderItem, :type => [:topology, :service] do
         let(:state) { "running" }
         before { task.context = {:service_instance => {:url => "http://tower.com/job/3"}} }
 
-        it "sends two update messages" do
-          expect(order_item).to receive(:update_message).with("info", "Task update message received with payload: #{task}")
+        it "updates progress messages" do
+          expect(order_item).to receive(:update_message).with("info", "Order Item Is Running")
           subject.process
         end
 
@@ -80,8 +69,6 @@ describe Catalog::UpdateOrderItem, :type => [:topology, :service] do
           expect(order_item).to receive(:mark_failed).with("Order Item Failed", :service_instance_ref => "321")
           subject.process
         end
-
-        it_behaves_like "#process info message"
       end
 
       context "when the task does not have a service instance id" do
@@ -91,16 +78,7 @@ describe Catalog::UpdateOrderItem, :type => [:topology, :service] do
           expect(order_item).to receive(:mark_failed).with("Order Item Failed", :service_instance_ref => "213")
           subject.process
         end
-
-        it_behaves_like "#process info message"
       end
-    end
-
-    context "when the status of the task is anything else" do
-      let(:status) { "foo" }
-      let(:state) { "bar" }
-
-      it_behaves_like "#process info message"
     end
   end
 end

--- a/spec/lib/topological_inventory/event_listener_spec.rb
+++ b/spec/lib/topological_inventory/event_listener_spec.rb
@@ -30,7 +30,7 @@ describe TopologicalInventory::EventListener do
       subject.subscribe
       progress_message = ProgressMessage.last
       expect(progress_message.level).to eq("info")
-      expect(progress_message.message).to match(/Task update message received with payload/)
+      expect(progress_message.message).to eq("Order Item Is Running")
       expect(progress_message.order_item_id).to eq(order_item.id.to_s)
       order_item.reload
       expect(order_item.external_url).to eq("external_url")


### PR DESCRIPTION
When the task comes back from topology is in an error state we fail the order but does not show the error in the progress messages. This PR adds such error to the messages so that the user can see how it fails.

Also remove the call to `process_relevant_context` because there is no need to further process since the order is marked failed anyway.