### PR TITLE
Store substituted service parameters

### DIFF
--- a/lib/catalog/order_item_sanitized_parameters.rb
+++ b/lib/catalog/order_item_sanitized_parameters.rb
@@ -15,6 +15,7 @@ module Catalog
 
     def process
       @sanitized_parameters = compute_sanitized_parameters
+      @order_item.save if @params[:do_not_mask_values]
 
       self
     rescue => e
@@ -91,7 +92,9 @@ module Catalog
       end
 
       begin
-        convert_type(str_val, field[:type])
+        convert_type(str_val, field[:type]).tap do |new_val|
+          @order_item.service_parameters[key] = new_val
+        end
       rescue
         Rails.logger.error("Failed to convert #{str_val} to #{field[:type]}. Substitution expression #{value}, worksplace #{workspace}")
         raise

--- a/spec/lib/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/lib/catalog/order_item_sanitized_parameters_spec.rb
@@ -97,6 +97,8 @@ describe Catalog::OrderItemSanitizedParameters, :type => [:service, :topology, :
           context 'when substitution data type is string' do
             it 'includes a string in the parameters' do
               expect(result).to match_array %w[testv s3cret]
+              order_item.reload
+              expect(order_item.service_parameters).to include('name' => 'testv')
             end
           end
 


### PR DESCRIPTION
After substitution is completed the new values are now persisted in place.