### PR TITLE
Set parameters from schema default values for before/after order_items

### DIFF
--- a/lib/catalog/service_plan_fields.rb
+++ b/lib/catalog/service_plan_fields.rb
@@ -1,0 +1,35 @@
+module Catalog
+  class ServicePlanFields
+    attr_reader :fields
+
+    def initialize(order_item)
+      @order_item = order_item
+    end
+
+    def process
+      @fields = Array(service_plan_schema.with_indifferent_access.dig(:schema, :fields))
+
+      self
+    end
+
+    private
+
+    def service_plan_schema
+      # retrieve the schema in the order of modified, base, and live order
+
+      service_plan = @order_item.portfolio_item.service_plans&.first
+      service_plan&.modified || service_plan&.base || live_service_plan_schema
+    end
+
+    def live_service_plan_schema
+      return {} unless @order_item.service_plan_ref
+
+      TopologicalInventory::Service.call do |api|
+        api.show_service_plan(@order_item.service_plan_ref.to_s).create_json_schema
+      end
+    rescue ::Catalog::TopologyError => e
+      Rails.logger.error("DefaultApi->show_service_plan #{e.message}")
+      raise
+    end
+  end
+end

--- a/spec/lib/catalog/service_plan_fields_spec.rb
+++ b/spec/lib/catalog/service_plan_fields_spec.rb
@@ -1,0 +1,84 @@
+describe Catalog::ServicePlanFields, :type => [:service, :topology, :current_forwardable] do
+  describe "#process" do
+    let(:order) { create(:order) }
+    let(:order_item) { create(:order_item, :order => order, :portfolio_item => portfolio_item) }
+    let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :service_plans => [service_plan]) }
+    let(:portfolio) { create(:portfolio) }
+    let(:task) { TopologicalInventoryApiClient::Task.new(:id => "123", :context => {:applied_inventories => applied_inventories}) }
+    let(:fields) do
+      [{
+        'name'         => "param1",
+        'type'         => "string",
+        'label'        => "Param1",
+        'component'    => "text-field",
+        'helperText'   => "",
+        'isRequired'   => true,
+        'initialValue' => "val1"
+      }, {
+        'name'       => "most_important_var1",
+        'label'      => "secret field 1",
+        'component'  => "textarea-field",
+        'helperText' => ""
+      }]
+    end
+    let(:subject) { described_class.new(order_item) }
+
+    context 'when service_plan has modified' do
+      let(:modified_fields) { [fields[0]] }
+      let(:service_plan) { create(:service_plan, :base => {:schema => {:fields => fields}}, :modified => {:schema => {:fields => modified_fields}}) }
+
+      before do
+        allow(Catalog::SurveyCompare).to receive(:changed?)
+        allow(Catalog::DataDrivenFormValidator).to receive(:valid?)
+      end
+
+      it 'gets fields from modified schema' do
+        expect(subject.process.fields).to eq(modified_fields)
+      end
+    end
+
+    context 'when service_plan has only base' do
+      let(:service_plan) { create(:service_plan, :base => {:schema => {:fields => fields}}, :modified => nil) }
+
+      it 'gets fields from modified schema' do
+        expect(subject.process.fields).to eq(fields)
+      end
+    end
+
+    context 'when portfolio_item has no local service plan' do
+      around do |example|
+        Insights::API::Common::Request.with_request(default_request) { example.call }
+      end
+
+      let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio) }
+      let(:order_item) { create(:order_item, :order => order, :portfolio_item => portfolio_item, :service_plan_ref => '777') }
+
+      let(:service_plan_response) do
+        TopologicalInventoryApiClient::ServicePlan.new(
+          :name               => "Plan A",
+          :id                 => "1",
+          :description        => "Plan A",
+          :create_json_schema => {:schema => {:fields => fields}}
+        )
+      end
+
+      before do
+        stub_request(:get, topological_url("service_plans/777"))
+          .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)
+      end
+
+      it 'gets fields live from topology' do
+        expect(subject.process.fields).to eq(fields)
+      end
+    end
+
+    context 'when portfolio_item has no service plan' do
+      let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio) }
+      let(:order_item) { create(:order_item, :order => order, :portfolio_item => portfolio_item, :service_plan_ref => nil) }
+
+      it 'gets no fields' do
+        expect(subject.process.fields).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-1925

Introduced new service class `ServicePlanFields` to get schema fields from various situations. Used by both `OrderItemSanitizedParameters` and `EvaluateOrderProcess`.