### PR TITLE
Update first service_parameters_raw and then service_parameters

### DIFF
--- a/lib/catalog/order_item_sanitized_parameters.rb
+++ b/lib/catalog/order_item_sanitized_parameters.rb
@@ -15,7 +15,7 @@ module Catalog
 
     def process
       @sanitized_parameters = compute_sanitized_parameters
-      @order_item.save if @params[:do_not_mask_values]
+      update_service_parameters if @params[:do_not_mask_values]
 
       self
     rescue => e
@@ -46,6 +46,10 @@ module Catalog
       return {} if service_plan_does_not_exist?
       return filtered_parameters if @params[:do_not_mask_values]
 
+      mask_values
+    end
+
+    def mask_values
       svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters_raw)
       fields.each_with_object({}) do |field, result|
         value = mask_value?(field) ? MASKED_VALUE : svc_params[field[:name]]
@@ -79,7 +83,7 @@ module Catalog
 
       begin
         convert_type(str_val, field[:type]).tap do |new_val|
-          @order_item.service_parameters[key] = new_val
+          order_item.service_parameters_raw[key] = new_val
         end
       rescue
         Rails.logger.error("Failed to convert #{str_val} to #{field[:type]}. Substitution expression #{value}, worksplace #{workspace}")
@@ -117,6 +121,10 @@ module Catalog
 
     def workspace
       @workspace ||= Catalog::WorkspaceBuilder.new(order_item.order).process.workspace
+    end
+
+    def update_service_parameters
+      order_item.update(:service_parameters => mask_values)
     end
   end
 end

--- a/spec/lib/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/lib/catalog/order_item_sanitized_parameters_spec.rb
@@ -9,10 +9,11 @@ describe Catalog::OrderItemSanitizedParameters, :type => [:service, :topology, :
     let(:order_item) do
       create(
         :order_item,
-        :portfolio_item   => portfolio_item,
-        :service_plan_ref => service_plan_ref,
-        :artifacts        => artifacts,
-        :process_scope    => 'applicable'
+        :portfolio_item     => portfolio_item,
+        :service_plan_ref   => service_plan_ref,
+        :artifacts          => artifacts,
+        :service_parameters => nil,
+        :process_scope      => 'applicable'
       ).tap do |item|
         item.send(:service_parameters_raw=, "name" => "{{applicable.#{item_name}.artifacts.testk}}", "Totally not a pass" => "s3cret")
         item.save


### PR DESCRIPTION
Before and after order_items initially don't have service_parameters set. So we update first service_parameters_raw and then service_parameters with masked values.

https://issues.redhat.com/browse/SSP-1935