### PR TITLE
Change schema and API to enable Order to have progress messages

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -48,6 +48,10 @@ module Api
         def name
           self.class.to_s
         end
+
+        def permitted_params
+          super + [:messageable_type, :messageable_id]
+        end
       end
     end
   end

--- a/app/controllers/api/v1x2/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x2/mixins/index_mixin.rb
@@ -5,8 +5,7 @@ module Api
         include Api::V1x1::Mixins::IndexMixin
 
         def permitted_params
-          check_if_openapi_enabled
-          api_doc_definition.all_attributes + [:limit, :offset, :sort_by, :object_type, :object_id, :app_name] + [subcollection_foreign_key]
+          super + [:object_type, :object_id, :app_name]
         end
       end
     end

--- a/app/controllers/api/v1x3.rb
+++ b/app/controllers/api/v1x3.rb
@@ -1,0 +1,28 @@
+require 'services/api/v1x3'
+require 'controllers/api/v1x2'
+
+module Api
+  module V1x3
+    class RootController < ApplicationController
+      def openapi
+        render :json => Api::Docs["1.3"]
+      end
+    end
+
+    class ApprovalRequestsController          < Api::V1x2::ApprovalRequestsController; end
+    class GraphqlController                   < Api::V1x2::GraphqlController; end
+    class IconsController                     < Api::V1x2::IconsController; end
+    class OrderItemsController                < Api::V1x2::OrderItemsController; end
+    class OrderProcessesController            < Api::V1x2::OrderProcessesController; end
+    class OrdersController                    < Api::V1x2::OrdersController; end
+    class PortfoliosController                < Api::V1x2::PortfoliosController; end
+    class PortfolioItemsController            < Api::V1x2::PortfolioItemsController; end
+    class ProviderControlParametersController < Api::V1x2::ProviderControlParametersController; end
+    class ServicePlansController              < Api::V1x2::ServicePlansController; end
+    class SettingsController                  < Api::V1x2::SettingsController; end
+    class TagsController                      < Api::V1x2::TagsController; end
+    class TenantsController                   < Api::V1x2::TenantsController; end
+
+    extend_each_subclass Mixins::IndexMixin
+  end
+end

--- a/app/controllers/api/v1x3/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x3/mixins/index_mixin.rb
@@ -1,0 +1,14 @@
+module Api
+  module V1x3
+    module Mixins
+      module IndexMixin
+        include Api::V1x2::Mixins::IndexMixin
+
+        def permitted_params
+          check_if_openapi_enabled
+          api_doc_definition.all_attributes + [:limit, :offset, :sort_by, :object_type, :object_id, :app_name, :source_type] + [subcollection_foreign_key]
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1x3/mixins/show_mixin.rb
+++ b/app/controllers/api/v1x3/mixins/show_mixin.rb
@@ -1,8 +1,8 @@
 module Api
   module V1x3
     module Mixins
-      module IndexMixin
-        include Api::V1x2::Mixins::IndexMixin
+      module ShowMixin
+        include Api::V1x2::Mixins::ShowMixin
       end
     end
   end

--- a/app/controllers/api/v1x3/progress_messages_controller.rb
+++ b/app/controllers/api/v1x3/progress_messages_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1x3
+    class ProgressMessagesController < ApplicationController
+      include Mixins::IndexMixin
+
+      SOURCE_TYPES = {"Order" => "order_id", "OrderItem" => "order_item_id"}.freeze
+
+      def index
+        source_type = params[:source_type] || "OrderItem"
+
+        # The source_type should also match with request path
+        raise Catalog::InvalidParameter unless SOURCE_TYPES.include?(source_type) && request.path.include?(source_type.constantize.table_name)
+
+        collection(source_type.constantize.find(params.require(SOURCE_TYPES[source_type])).progress_messages)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1x3/progress_messages_controller.rb
+++ b/app/controllers/api/v1x3/progress_messages_controller.rb
@@ -3,15 +3,11 @@ module Api
     class ProgressMessagesController < ApplicationController
       include Mixins::IndexMixin
 
-      SOURCE_TYPES = {"Order" => "order_id", "OrderItem" => "order_item_id"}.freeze
-
       def index
-        source_type = params[:source_type] || "OrderItem"
+        klass = safe_params_for_list.require(:messageable_type).constantize
+        id    = safe_params_for_list.require(:messageable_id)
 
-        # The source_type should also match with request path
-        raise Catalog::InvalidParameter unless SOURCE_TYPES.include?(source_type) && request.path.include?(source_type.constantize.table_name)
-
-        collection(source_type.constantize.find(params.require(SOURCE_TYPES[source_type])).progress_messages)
+        collection(klass.find(id).progress_messages)
       end
     end
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,13 +7,13 @@ class Order < ApplicationRecord
   acts_as_tenant(:tenant)
   attribute :state, :string, :default => 'Created'
   validates_inclusion_of :state,
-    :in => ["Approval Pending", "Canceled", "Completed", "Created", "Failed", "Ordered"].freeze,
-    :message => "state %{value} is not included in the list"
+                         :in      => ["Approval Pending", "Canceled", "Completed", "Created", "Failed", "Ordered"].freeze,
+                         :message => "state %{value} is not included in the list"
 
   default_scope { kept.order(:created_at => :desc) }
 
   has_many :order_items, -> { order(:process_sequence) }, :dependent => :destroy, :inverse_of => :order
-  has_many :progress_messages, :dependent => :destroy
+  has_many :progress_messages, :as => :messageable, :dependent => :destroy, :inverse_of => :messageable
 
   before_create :set_defaults
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,7 @@ class Order < ApplicationRecord
   include Discard::Model
   include Api::V1x0::Catalog::DiscardRestore
   destroy_dependencies :order_items
+  destroy_dependencies :progress_messages
   acts_as_tenant(:tenant)
   attribute :state, :string, :default => 'Created'
   validates_inclusion_of :state,
@@ -12,10 +13,16 @@ class Order < ApplicationRecord
   default_scope { kept.order(:created_at => :desc) }
 
   has_many :order_items, -> { order(:process_sequence) }, :dependent => :destroy, :inverse_of => :order
+  has_many :progress_messages, :dependent => :destroy
 
   before_create :set_defaults
 
   def set_defaults
     self.state = "Created"
+  end
+
+  def update_message(level, message)
+    progress_messages << ProgressMessage.new(:level => level, :message => message, :tenant_id => tenant_id)
+    touch
   end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -18,8 +18,8 @@ class OrderItem < ApplicationRecord
 
   belongs_to :order, :inverse_of => :order_items
   belongs_to :portfolio_item
-  has_many :progress_messages, :dependent => :destroy
   has_many :approval_requests, :dependent => :destroy
+  has_many :progress_messages, :as => :messageable, :dependent => :destroy, :inverse_of => :messageable
 
   before_create :set_defaults
   before_save :sanitize_parameters, :if => :will_save_change_to_service_parameters?

--- a/app/models/progress_message.rb
+++ b/app/models/progress_message.rb
@@ -12,6 +12,8 @@ class ProgressMessage < ApplicationRecord
       .where("orders.owner = ?", Insights::API::Common::Request.current.user.username)
   }
 
+  belongs_to :messageable, :polymorphic => true
+
   def set_defaults
     self.received_at = DateTime.now
   end

--- a/app/services/api/v1x3.rb
+++ b/app/services/api/v1x3.rb
@@ -1,0 +1,47 @@
+require 'services/api/v1x2'
+
+module Api
+  module V1x3
+    module Catalog
+      class AddToOrder                          < Api::V1x2::Catalog::AddToOrder; end
+      class AddToOrderViaOrderProcess           < Api::V1x2::Catalog::AddToOrderViaOrderProcess; end
+      class CancelOrder                         < Api::V1x2::Catalog::CancelOrder; end
+      class CopyPortfolio                       < Api::V1x2::Catalog::CopyPortfolio; end
+      class CopyPortfolioItem                   < Api::V1x2::Catalog::CopyPortfolioItem; end
+      class CreateIcon                          < Api::V1x2::Catalog::CreateIcon; end
+      class CreateRequestForAppliedInventories  < Api::V1x2::Catalog::CreateRequestForAppliedInventories; end
+      class DuplicateImage                      < Api::V1x2::Catalog::DuplicateImage; end
+      class GetLinkedOrderProcess               < Api::V1x2::Catalog::GetLinkedOrderProcess; end
+      class ImportServicePlans                  < Api::V1x2::Catalog::ImportServicePlans; end
+      class LinkToOrderProcess                  < Api::V1x2::Catalog::LinkToOrderProcess; end
+      class NextName                            < Api::V1x2::Catalog::NextName; end
+      class OrderProcessAssociator              < Api::V1x2::Catalog::OrderProcessAssociator; end
+      class OrderProcessDissociator             < Api::V1x2::Catalog::OrderProcessDissociator; end
+      class PortfolioItemOrderable              < Api::V1x2::Catalog::PortfolioItemOrderable; end
+      class ProviderControlParameters           < Api::V1x2::Catalog::ProviderControlParameters; end
+      class ServiceOffering                     < Api::V1x2::Catalog::ServiceOffering; end
+      class ServicePlanCompare                  < Api::V1x2::Catalog::ServicePlanCompare; end
+      class ServicePlanJson                     < Api::V1x2::Catalog::ServicePlanJson; end
+      class ServicePlanReset                    < Api::V1x2::Catalog::ServicePlanReset; end
+      class ServicePlans                        < Api::V1x2::Catalog::ServicePlans; end
+      class ShareInfo                           < Api::V1x2::Catalog::ShareInfo; end
+      class ShareResource                       < Api::V1x2::Catalog::ShareResource; end
+      class SoftDelete                          < Api::V1x2::Catalog::SoftDelete; end
+      class SoftDeleteRestore                   < Api::V1x2::Catalog::SoftDeleteRestore; end
+      class TaggingService                      < Api::V1x2::Catalog::TaggingService; end
+      class TenantSettings                      < Api::V1x2::Catalog::TenantSettings; end
+      class UnlinkFromOrderProcess              < Api::V1x2::Catalog::UnlinkFromOrderProcess; end
+      class UnshareResource                     < Api::V1x2::Catalog::UnshareResource; end
+      class UpdateIcon                          < Api::V1x2::Catalog::UpdateIcon; end
+      class ValidateSource                      < Api::V1x2::Catalog::ValidateSource; end
+    end
+
+    module Group
+      class Seed < Api::V1x2::Group::Seed; end
+    end
+
+    module ServiceOffering
+      class AddToPortfolioItem < Api::V1x2::ServiceOffering::AddToPortfolioItem; end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,11 +9,12 @@ Rails.application.routes.draw do
     prefix = File.join(ENV["PATH_PREFIX"], ENV["APP_NAME"]).gsub(/^\/+|\/+$/, "")
   end
   scope :as => :api, :module => "api", :path => prefix do
-    routing_helper.redirect_major_version("v1.2", prefix)
+    routing_helper.redirect_major_version("v1.3", prefix)
 
     draw(:v1x0)
     draw(:v1x1)
     draw(:v1x2)
+    draw(:v1x3)
   end
   draw(:public)
 end

--- a/config/routes/v1x3.rb
+++ b/config/routes/v1x3.rb
@@ -1,0 +1,62 @@
+namespace :v1x3, :path => "v1.3" do
+  concern :taggable do
+    post      :tag,   :to => "tags#tag"
+    post      :untag, :to => "tags#untag"
+    resources :tags,  :controller => :tags, :only => [:index]
+  end
+
+  get "/openapi.json", :to => "root#openapi"
+  post "/graphql" => "graphql#query"
+  post '/orders/:order_id/submit_order', :to => "orders#submit_order", :as => 'order_submit_order'
+  patch '/orders/:order_id/cancel', :to => "orders#cancel_order", :as => 'order_cancel'
+  resources :orders,                :only => [:create, :index, :show, :destroy] do
+    resources :order_items, :only => [:create, :index, :show]
+    resources :progress_messages, :only => [:index]
+
+    post :restore, :to => "orders#restore"
+  end
+  resources :order_items, :only => [:index, :show, :destroy] do
+    resources :progress_messages, :only => [:index]
+    resources :approval_requests, :only => [:index]
+
+    post :restore, :to => "order_items#restore"
+  end
+  post '/portfolios/:portfolio_id/share', :to => "portfolios#share", :as => 'share'
+  post '/portfolios/:portfolio_id/unshare', :to => "portfolios#unshare", :as => 'unshare'
+  get '/portfolios/:portfolio_id/share_info', :to => "portfolios#share_info", :as => 'share_info'
+  resources :portfolios, :only => [:create, :destroy, :index, :show, :update], :concerns => [:taggable] do
+    resources :portfolio_items, :only => [:index]
+    post :copy, :to => "portfolios#copy"
+    post :undelete, :to => "portfolios#restore"
+    get :icon, :to => 'icons#raw_icon'
+  end
+  resources :portfolio_items, :only => [:create, :destroy, :index, :show, :update], :concerns => [:taggable] do
+    resources :provider_control_parameters, :only => [:index]
+    resources :service_plans,               :only => [:index]
+    get :icon, :to => 'icons#raw_icon'
+    get :next_name, :action => 'next_name', :controller => 'portfolio_items'
+    post :copy, :action => 'copy', :controller => 'portfolio_items'
+    post :undelete, :action => 'restore', :controller => 'portfolio_items'
+  end
+  resources :icons, :only => [:create, :destroy]
+  resources :order_processes, :only => [:create, :destroy, :index, :show, :update] do
+    patch :before_portfolio_item, :to => 'order_processes#update_before_portfolio_item'
+    patch :after_portfolio_item, :to => 'order_processes#update_after_portfolio_item'
+    post  :remove_association, :to => 'order_processes#remove_association'
+  end
+
+  post '/order_processes/:id/link', :to => "order_processes#link", :as => 'link'
+  post '/order_processes/:id/unlink', :to => "order_processes#unlink", :as => 'unlink'
+
+  resources :settings
+  resources :tags, :only => [:index]
+  resources :tenants, :only => [:index, :show] do
+    post 'seed', :to => 'tenants#seed'
+  end
+  resources :service_plans, :only => [:create, :show] do
+    get 'base', :to => 'service_plans#base'
+    get 'modified', :to => 'service_plans#modified'
+    patch 'modified', :to => 'service_plans#update_modified'
+    post :reset, :to => 'service_plans#reset'
+  end
+end

--- a/db/migrate/20201104141452_add_order_id_to_progress_messages.rb
+++ b/db/migrate/20201104141452_add_order_id_to_progress_messages.rb
@@ -1,5 +1,0 @@
-class AddOrderIdToProgressMessages < ActiveRecord::Migration[5.2]
-  def change
-    add_column :progress_messages, :order_id, :string
-  end
-end

--- a/db/migrate/20201104141452_add_order_id_to_progress_messages.rb
+++ b/db/migrate/20201104141452_add_order_id_to_progress_messages.rb
@@ -1,0 +1,5 @@
+class AddOrderIdToProgressMessages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :progress_messages, :order_id, :string
+  end
+end

--- a/db/migrate/20201105150627_add_messageable_to_progress_messages.rb
+++ b/db/migrate/20201105150627_add_messageable_to_progress_messages.rb
@@ -1,0 +1,30 @@
+class AddMessageableToProgressMessages < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :progress_messages, :messageable, :polymorphic => true
+
+    ProgressMessage.all.each do |message|
+      message.update(
+        :messageable_type => "OrderItem",
+        :messageable_id   => message.order_item_id
+      )
+    end
+
+    # Leave for future to remove
+    # remove_column :progress_messages, :order_item_id, :string
+  end
+
+  def down
+    # add_column :progress_messages, :order_item_id, :string
+
+    ProgressMessage.all.each do |message|
+      case message.messageable_type
+      when "OrderItem"
+        message.update!(:order_item_id => message.messageable_id)
+      when "Order"
+        message.delete
+      end
+    end
+
+    remove_reference :progress_messages, :messageable, :polymorphic => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_04_141452) do
+ActiveRecord::Schema.define(version: 2020_11_05_150627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -214,8 +214,10 @@ ActiveRecord::Schema.define(version: 2020_11_04_141452) do
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
     t.datetime "discarded_at"
-    t.string "order_id"
+    t.string "messageable_type"
+    t.bigint "messageable_id"
     t.index ["discarded_at"], name: "index_progress_messages_on_discarded_at"
+    t.index ["messageable_type", "messageable_id"], name: "index_progress_messages_on_messageable_type_and_messageable_id"
     t.index ["tenant_id"], name: "index_progress_messages_on_tenant_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_05_135352) do
+ActiveRecord::Schema.define(version: 2020_11_04_141452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -214,6 +214,7 @@ ActiveRecord::Schema.define(version: 2020_11_05_135352) do
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
     t.datetime "discarded_at"
+    t.string "order_id"
     t.index ["discarded_at"], name: "index_progress_messages_on_discarded_at"
     t.index ["tenant_id"], name: "index_progress_messages_on_tenant_id"
   end

--- a/public/doc/openapi-3-v1.3.json
+++ b/public/doc/openapi-3-v1.3.json
@@ -1689,7 +1689,7 @@
         }
       }
     },
-    "/orders/{id}/progress_messages": {
+    "/orders/{order_id}/progress_messages": {
       "get": {
         "tags": [
           "Order"
@@ -1700,9 +1700,6 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/OrderID"
-          },
-          {
-            "$ref": "#/components/parameters/SourceType"
           },
           {
             "$ref": "#/components/parameters/QueryLimit"
@@ -1906,9 +1903,6 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/OrderItemID"
-          },
-          {
-            "$ref": "#/components/parameters/SourceType"
           },
           {
             "$ref": "#/components/parameters/QueryLimit"
@@ -3249,16 +3243,6 @@
           "type": "boolean",
           "default": false
         }
-      },
-      "SourceType": {
-        "in": "query",
-        "name": "source_type",
-        "required": false,
-        "description": "Type of the progress messages source (could be either Order or OrderItem).",
-        "schema": {
-          "type": "string",
-          "default": "OrderItem"
-        }
       }
     },
     "responses": {
@@ -3678,6 +3662,12 @@
             "type": "string",
             "readOnly": true
           },
+          "name": {
+            "type": "string",
+            "readOnly": true,
+            "title": "Name",
+            "description": "Name of the Portfolio Item or Order Process"
+          },
           "count": {
             "type": "integer",
             "default": 1,
@@ -3776,7 +3766,7 @@
             "type": "string",
             "title": "Scope of when the order item is ran",
             "example": "before",
-            "description": "Denotes the scope in which the order item will run for the order it belongs to. It can be 'before', 'after', or 'applicable'",
+            "description": "Denotes the scope in which the order item will run for the order it belongs to. It can be 'before', 'after', or 'product'",
             "readOnly": true
           },
           "artifacts": {

--- a/public/doc/openapi-3-v1.3.json
+++ b/public/doc/openapi-3-v1.3.json
@@ -1,0 +1,4450 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "This API gets and orders catalog items from different cloud sources.",
+    "version": "1.3.0",
+    "title": "Catalog API",
+    "contact": {
+      "email": "support@redhat.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "security": [
+    {
+      "BasicAuth": [
+
+      ]
+    }
+  ],
+  "tags": [
+    {
+      "name": "Portfolio",
+      "description": "Portfolio API calls"
+    },
+    {
+      "name": "PortfolioItem",
+      "description": "Portfolio Item API calls"
+    },
+    {
+      "name": "Order",
+      "description": "Order API calls"
+    },
+    {
+      "name": "OrderItem",
+      "description": "OrderItem API calls"
+    },
+    {
+      "name": "OrderProcess",
+      "description": "OrderProcess API calls"
+    }
+  ],
+  "paths": {
+    "/graphql": {
+      "post": {
+        "summary": "Perform a GraphQL Query",
+        "operationId": "postGraphQL",
+        "description": "Performs a GraphQL Query",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GraphQLRequest"
+              }
+            }
+          },
+          "description": "GraphQL Query Request",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "GraphQL Query Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GraphQLResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "summary": "Return this API document in JSON format",
+        "operationId": "getDocumentation",
+        "responses": {
+          "200": {
+            "description": "The API document for this version of the API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/portfolios": {
+      "get": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "List portfolios",
+        "operationId": "listPortfolios",
+        "description": "Gets a list of portfolios.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a list of portfolios. An empty list indicate either undefined portfolios in the system or inaccessibility to the caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfoliosCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Add a new portfolio",
+        "operationId": "createPortfolio",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Portfolio",
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          },
+          "description": "Parameters needed to add a Portfolio",
+          "required": true
+        },
+        "description": "Adds a portfolio.",
+        "responses": {
+          "200": {
+            "description": "Successfully added the new portfolio.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Portfolio"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/portfolios/{id}": {
+      "get": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Get a specific portfolio",
+        "operationId": "showPortfolio",
+        "description": "Gets the portfolio specified by the portfolio ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio matching the portfolio ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Portfolio"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio not found."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Edit an existing portfolio",
+        "operationId": "updatePortfolio",
+        "description": "Returns the edited portfolio.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Portfolio"
+              }
+            }
+          },
+          "description": "Parameters needed to update a Portfolio",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Portfolio successfully edited.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Portfolio"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Delete an existing portfolio",
+        "operationId": "destroyPortfolio",
+        "description": "Deletes the portfolio specified by the ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio Deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Failed to discard child portfolio items."
+          },
+          "404": {
+            "description": "Portfolio Not Found."
+          }
+        }
+      }
+    },
+    "/portfolios/{portfolio_id}/portfolio_items": {
+      "get": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Get all portfolio items from a specific portfolio",
+        "operationId": "fetchPortfolioItemsWithPortfolio",
+        "description": "Gets all portfilio items in the portfolio specified by the given ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioID"
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a list of portfolio items. An empty list is returned if the portfolio is not connected to any portfolio items.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItemsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio not found"
+          }
+        }
+      }
+    },
+    "/portfolios/{portfolio_id}/share": {
+      "post": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Share a portfolio with one or more groups with specific permission",
+        "operationId": "sharePortfolio",
+        "description": "Share a Portfolio with one or more groups with specific permissions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SharePolicy"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully shared the portfolio"
+          },
+          "400": {
+            "description": "One or more of the RBAC groups was not found"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "The Portfolio Object was not found."
+          }
+        }
+      }
+    },
+    "/portfolios/{portfolio_id}/unshare": {
+      "post": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Unshare a portfolio from one or more groups with specific permission",
+        "operationId": "unsharePortfolio",
+        "description": "Unshare a Portfolio with one or more groups with specific permissions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnsharePolicy"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully unshared portfolio"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "The Portfolio Object or the one or more of the groups was not found."
+          }
+        }
+      }
+    },
+    "/portfolios/{portfolio_id}/share_info": {
+      "get": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Fetch share information about this portfolio, the response would include a collection of groups and permissions with each group",
+        "operationId": "share_info",
+        "description": "Fetch share information about a portfolio",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns an array of group uuid, name and permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ShareInfo"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "The Portfolio object not found"
+          }
+        }
+      }
+    },
+    "/portfolios/{portfolio_id}/copy": {
+      "post": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Make a copy of the Portfolio",
+        "operationId": "postCopyPortfolio",
+        "description": "Make a copy of the Portfolio.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The new Portfolio",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Portfolio"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio  not found"
+          },
+          "500": {
+            "description": "Failed to copy Portfolio"
+          }
+        }
+      }
+    },
+    "/portfolios/{id}/undelete": {
+      "post": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Undelete specific portfolio",
+        "operationId": "unDeletePortfolio",
+        "description": "Undeletes the portfolio specified by the portfolio ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The undeleted portfolio",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Portfolio"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio not found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestoreKey"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/portfolios/{portfolio_id}/icon": {
+      "get": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Fetches the specified portfolio's icon image",
+        "operationId": "showPortfolioIcon",
+        "description": "Fetch the specified portfolio's icon image.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioID"
+          },
+          {
+            "$ref": "#/components/parameters/QueryCacheID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio Icon",
+            "content": {
+              "image/svg+xml": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No icon present on Portfolio"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/portfolios/{id}/tags": {
+      "get": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "List Tags for Portfolio",
+        "operationId": "listPortfolioTags",
+        "description": "Returns an array of Tag objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tags collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio Not Found."
+          }
+        }
+      }
+    },
+    "/portfolios/{id}/tag": {
+      "post": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Add Tag for Portfolio",
+        "operationId": "addPortfolioTag",
+        "description": "Adds a single tag to Portfolio object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Tag successfully added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Tag"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio Not Found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/portfolios/{id}/untag": {
+      "post": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "Remove Tags from Portfolio",
+        "description": "Remove Tags from Portfolio",
+        "operationId": "removePortfolioTags",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tag Deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/tenants": {
+      "get": {
+        "tags": [
+          "Tenant"
+        ],
+        "summary": "List Tenants",
+        "operationId": "listTenants",
+        "description": "Get a list of tenants.",
+        "responses": {
+          "200": {
+            "description": "Returns a list of tenants.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/tenants/{tenant_id}": {
+      "get": {
+        "tags": [
+          "Tenant"
+        ],
+        "summary": "Get a specific Tenant",
+        "operationId": "showTenant",
+        "description": "Gets the tenant specified by the tenant id.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TenantID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tenant matching the tenant ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Tenant"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Tenant not found."
+          }
+        }
+      }
+    },
+    "/tenants/{tenant_id}/seed": {
+      "post": {
+        "tags": [
+          "Tenant"
+        ],
+        "summary": "Seed Tenant Groups",
+        "operationId": "tenantSeed",
+        "description": "Run a task to seed the Tenant Groups required for an org admin to onboard additional users.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TenantID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The tenant was seeded"
+          },
+          "204": {
+            "description": "No content"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/portfolio_items": {
+      "get": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "List all portfolio items",
+        "operationId": "listPortfolioItems",
+        "description": "Gets a list of portfolio items.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned a list of portfolio items.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItemsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Add a new portfolio item",
+        "operationId": "createPortfolioItem",
+        "description": "Adds a name and description for a portfolio item and returns the newly created portfolio item.",
+        "responses": {
+          "200": {
+            "description": "The newly created portfolio item.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItem",
+                  "required": [
+                    "name",
+                    "service_offering_source_ref"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Offering not found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePortfolioItem"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/portfolio_items/{id}": {
+      "get": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Gets a specific portfolio item",
+        "operationId": "showPortfolioItem",
+        "description": "Gets a specific portfolio item based on the portfolio item ID passed",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          },
+          {
+            "$ref": "#/components/parameters/ShowDiscarded"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio item specified by the given ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "The portfolio item ID was not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Delete an existing portfolio item",
+        "operationId": "destroyPortfolioItem",
+        "description": "Deletes the portfolio item based on portfolio item ID passed",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio item deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreKey"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Portfolio item not found."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Edit an existing portfolio item",
+        "description": "Edits portfolio item specified by the given ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PortfolioItem"
+              }
+            }
+          },
+          "description": "Parameters needed to update a Portfolio Item",
+          "required": true
+        },
+        "operationId": "updatePortfolioItem",
+        "responses": {
+          "200": {
+            "description": "Return the updated portfolio item object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "The portfolio item ID was not found"
+          }
+        }
+      }
+    },
+    "/portfolio_items/{portfolio_item_id}/service_plans": {
+      "get": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Gets all service plans for a specific portfolio item; requires a connection to the topology service.",
+        "operationId": "listServicePlans",
+        "description": "Gets all service plans for a portfolio item.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All Service Plans",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ServicePlan"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio item not found"
+          },
+          "500": {
+            "description": "Could not access the Topology Service"
+          }
+        }
+      }
+    },
+    "/portfolio_items/{portfolio_item_id}/provider_control_parameters": {
+      "get": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Gets the provider control parameters for this portfolio item; requires control paramaters provided when provisioning the portfolio item.",
+        "operationId": "listProviderControlParameters",
+        "description": "Gets the provider control parameters for a portfolio item.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return provider control parameters JSON object.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderControlParameters"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio item not found"
+          },
+          "500": {
+            "description": "Could not access the Topology Service"
+          }
+        }
+      }
+    },
+    "/portfolio_items/{portfolio_item_id}/undelete": {
+      "post": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Undelete a specified Portfolio Item",
+        "operationId": "unDeletePortfolioItem",
+        "description": "If a record has been discarded, this operation will undelete it so it can be requested normally.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The undeleted Portfolio Item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio Item not found"
+          },
+          "500": {
+            "description": "Failed to undelete Portfolio Item"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestoreKey"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/portfolio_items/{id}/tags": {
+      "get": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "List Tags for Portfolio Items",
+        "operationId": "listPortfolioItemTags",
+        "description": "Returns an array of Tag objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tags collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio Item Not Found."
+          }
+        }
+      }
+    },
+    "/portfolio_items/{id}/tag": {
+      "post": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Add Tag for Portfolio Item",
+        "operationId": "addPortfolioItemTag",
+        "description": "Adds a single tag to a Portfolio Item object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Tag successfully added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Tag"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio Not Found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/portfolio_items/{id}/untag": {
+      "post": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Remove Tags from Portfolio Item",
+        "description": "Remove Tags from Portfolio Item",
+        "operationId": "removePortfolioItemTags",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tag Deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/orders": {
+      "get": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Get a list of orders",
+        "operationId": "listOrders",
+        "description": "Gets a list of orders associated with the logged in user.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of orders.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrdersCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Create a new order",
+        "operationId": "createOrder",
+        "description": "Creates a new order.",
+        "responses": {
+          "200": {
+            "description": "Returns a newly created order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/orders/{id}": {
+      "get": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Get a specific order",
+        "operationId": "showOrder",
+        "description": "Get a specific order based on the order ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order specified by the given ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "The Order ID was not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Delete an existing Order",
+        "operationId": "destroyOrder",
+        "description": "Deletes the Order based on order ID passed",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreKey"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Order not found."
+          }
+        }
+      }
+    },
+    "/orders/{order_id}/order_items": {
+      "get": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Gets a list of items in a given order",
+        "operationId": "listOrderItemsFromOrder",
+        "description": "Gets a list of items associated with an order.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderID"
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a OrderItemsCollection object with an embedded array of OrderIem objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderItemsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Add an order item to an order in pending state",
+        "operationId": "addToOrder",
+        "description": "Adds an order item to an order in pending state",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully added an item to order",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Order not found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderItem"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/orders/{order_id}/order_items/{id}": {
+      "get": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Gets an individual order item from a given order",
+        "operationId": "showOrderItemFromOrder",
+        "description": "Gets an order item associated with an order.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderID"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a single OrderIem object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Either the order or the order item could not be found."
+          }
+        }
+      }
+    },
+    "/orders/{order_id}/submit_order": {
+      "post": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Submit a given order",
+        "operationId": "submitOrder",
+        "description": "Returns an updated order.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated order object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/orders/{order_id}/cancel": {
+      "patch": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Cancels a given order",
+        "operationId": "cancelOrder",
+        "description": "Returns an updated order.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated order object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/orders/{id}/restore": {
+      "post": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Restore specific Order",
+        "operationId": "restoreOrder",
+        "description": "Restores the order specified by the order ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The restored order",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Order not found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestoreKey"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/orders/{id}/progress_messages": {
+      "get": {
+        "tags": [
+          "Order"
+        ],
+        "summary": "Gets a list of progress messages in an order",
+        "operationId": "listOrderProgressMessages",
+        "description": "Gets a list of progress messages associated with an order. As the order is being processed the provider can update the progress messages.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderID"
+          },
+          {
+            "$ref": "#/components/parameters/SourceType"
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a ProgressMessagesCollection object with an embedded array of ProgressMessage objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProgressMessagesCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/order_items": {
+      "get": {
+        "tags": [
+          "OrderItem"
+        ],
+        "summary": "List Order Items",
+        "operationId": "listOrderItems",
+        "description": "Gets a list of order items.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a list of order items. An empty list indicate either undefined orders in the system or inaccessibility to the caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderItemsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/order_items/{id}": {
+      "get": {
+        "tags": [
+          "OrderItem"
+        ],
+        "summary": "Gets a specific order item",
+        "operationId": "showOrderItem",
+        "description": "Gets a specific order item based on the order item ID passed",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order item specified by the given ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "The Order item ID was not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "OrderItem"
+        ],
+        "summary": "Delete an existing OrderItem",
+        "operationId": "destroyOrderItem",
+        "description": "Deletes the order item  based on order item ID passed",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order item deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreKey"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Order item not found."
+          }
+        }
+      }
+    },
+    "/order_items/{id}/restore": {
+      "post": {
+        "tags": [
+          "OrderItem"
+        ],
+        "summary": "Restore specific Order item",
+        "operationId": "restoreOrderItem",
+        "description": "Restores the order item specified by the order item ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The restored order item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Order item not found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestoreKey"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/order_items/{order_item_id}/progress_messages": {
+      "get": {
+        "tags": [
+          "OrderItem"
+        ],
+        "summary": "Gets a list of progress messages in an item",
+        "operationId": "listOrderItemProgressMessages",
+        "description": "Gets a list of progress messages associated with an order item. As the item is being processed the provider can update the progress messages.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderItemID"
+          },
+          {
+            "$ref": "#/components/parameters/SourceType"
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a ProgressMessagesCollection object with an embedded array of ProgressMessage objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProgressMessagesCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Order item not found"
+          }
+        }
+      }
+    },
+    "/order_items/{order_item_id}/approval_requests": {
+      "get": {
+        "tags": [
+          "OrderItem"
+        ],
+        "summary": "Gets a list of approval requests for an item",
+        "operationId": "listApprovalRequests",
+        "description": "Gets a list of approval request associated with an order item. As the item is being approved one can check the status of the approvals.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderItemID"
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a ApprovalRequestCollection object with an embedded array of ProgressMessage objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalRequestsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Order item not found"
+          }
+        }
+      }
+    },
+    "/portfolio_items/{portfolio_item_id}/icon": {
+      "get": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Fetches the specified portfolio item's icon image",
+        "operationId": "showPortfolioItemIcon",
+        "description": "Fetch the specified portfolio item's icon image.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio Item Icon",
+            "content": {
+              "image/svg+xml": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No icon present on Portfolio Item"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/portfolio_items/{portfolio_item_id}/copy": {
+      "post": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Make a copy of the Portfolio Item",
+        "operationId": "postCopyPortfolioItem",
+        "description": "Make a copy of the Portfolio Item.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The new Portfolio Item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Portfolio not found"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio Item not found"
+          },
+          "500": {
+            "description": "Failed to copy Portfolio Item"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CopyPortfolioItem"
+              }
+            }
+          },
+          "required": false
+        }
+      }
+    },
+    "/icons": {
+      "post": {
+        "tags": [
+          "Icon"
+        ],
+        "summary": "Create an Icon",
+        "operationId": "createIcon",
+        "description": "Creates an Icon from the specified parameters",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateIcon"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The newly created Icon",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/icons/{id}": {
+      "delete": {
+        "tags": [
+          "Icon"
+        ],
+        "summary": "Delete an existing Icon",
+        "operationId": "destroyIcon",
+        "description": "Deletes the icon based on the icon ID passed",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Icon deleted."
+          },
+          "404": {
+            "description": "Icon not found."
+          }
+        }
+      }
+    },
+    "/portfolio_items/{portfolio_item_id}/next_name": {
+      "get": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Get the next name for a the Portfolio Item prior to a copy operation",
+        "operationId": "getPortfolioItemNextName",
+        "description": "Get the next name for a the Portfolio Item prior to a copy operation",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          },
+          {
+            "$ref": "#/components/parameters/DestinationPortfolioID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Portfolio Item next name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItemNextName"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio Item not found"
+          }
+        }
+      }
+    },
+    "/settings": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "List Tenant Settings",
+        "description": "List Tenant Settings",
+        "operationId": "listSettings",
+        "responses": {
+          "200": {
+            "description": "The current tenant settings and schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantSettings"
+                },
+                "example": "{\n  \"current\": {\n    \"default_workflow\": \"2\",\n    \"icon\": \"<svg rel='stylesheet'>thing</svg>\"\n  },\n  \"schema\": {}\n}\n"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Create Tenant Setting",
+        "description": "Create Tenant Setting",
+        "operationId": "createSetting",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Setting"
+              }
+            }
+          },
+          "description": "Json encoded key/value pair to create a new setting",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully added the new setting.",
+            "content": {
+              "application/json": {
+                "example": "{ \n  \"default_workflow\": \"2\" \n} \n"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/settings/{name}": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Get a specific Tenant Setting",
+        "description": "Get a specific Tenant Setting",
+        "operationId": "showSetting",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SettingName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested Tenant Setting",
+            "content": {
+              "application/json": {
+                "example": "{ \n  \"default_workflow\": \"2\" \n} \n"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Update a Tenant Setting",
+        "description": "Update a Tenant Setting",
+        "operationId": "updateSetting",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SettingName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated Tenant Setting",
+            "content": {
+              "application/json": {
+                "example": "{ \n  \"default_workflow\": \"2\" \n} \n"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Delete a Tenant Setting",
+        "description": "Delete a Tenant Setting",
+        "operationId": "destroySetting",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SettingName"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tenant Setting successfully deleted."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/tags": {
+      "get": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "List Tags",
+        "description": "List Tags",
+        "operationId": "listTags",
+        "responses": {
+          "200": {
+            "description": "Index of Tags",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/service_plans": {
+      "post": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Create Service Plan",
+        "operationId": "createServicePlan",
+        "description": "Returns the new Service Plan",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportServicePlan"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Service Plan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ServicePlan"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      }
+    },
+    "/service_plans/{id}": {
+      "get": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Show Service Plan",
+        "operationId": "showServicePlan",
+        "description": "Returns the specified Service Plan",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service Plan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePlan"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          }
+        }
+      }
+    },
+    "/service_plans/{id}/base": {
+      "get": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Show Service Plan Base Schema",
+        "operationId": "showServicePlanBase",
+        "description": "Returns the specified Service Plan's base schema",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service Plan Base Schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePlan"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          }
+        }
+      }
+    },
+    "/service_plans/{id}/modified": {
+      "get": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Show Service Plan modified Schema",
+        "operationId": "showServicePlanModified",
+        "description": "Returns the specified Service Plan's modified schema",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service Plan Modified Schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePlan"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No modified schema present for service_plan."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Patch Service Plan Modified Schema",
+        "operationId": "patchServicePlanModified",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchModifiedServicePlan"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service Plan Modified Schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          }
+        }
+      }
+    },
+    "/service_plans/{id}/reset": {
+      "post": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Reset Service Plan Modified schema",
+        "operationId": "resetServicePlanModified",
+        "description": "Resets the Service Plan's Modified schema and returns the new one if it has been reset",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Modified schema for service_plan has been reset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ServicePlan"
+                  }
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No modified schema present for service_plan."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          }
+        }
+      }
+    },
+    "/order_processes": {
+      "get": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "List OrderProcesses",
+        "operationId": "listOrderProcesses",
+        "description": "Gets a list of order processes. Optionally select order processes linked to a resource object whose app_name, object_type and object_id are specified by query parameters.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ApplicationName"
+          },
+          {
+            "$ref": "#/components/parameters/ObjectId"
+          },
+          {
+            "$ref": "#/components/parameters/ObjectType"
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a list of order processes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderProcessCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Add a new order process",
+        "operationId": "createOrderProcess",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderProcess",
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          },
+          "description": "Parameters needed to add an OrderProcess",
+          "required": true
+        },
+        "description": "Adds an order process.",
+        "responses": {
+          "200": {
+            "description": "Successfully added the new order process.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderProcess"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/order_processes/{id}": {
+      "get": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Get a specific order process",
+        "operationId": "showOrderProcess",
+        "description": "Gets the order process specified by the order process ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OrderProcess matching the order process ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderProcess"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio not found."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Edit an existing order process",
+        "operationId": "updateOrderProcess",
+        "description": "Returns the edited order process.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderProcess"
+              }
+            }
+          },
+          "description": "Parameters needed to update a OrderProcess",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OrderProcess successfully edited.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderProcess"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Delete an existing order process",
+        "operationId": "destroyOrderProcess",
+        "description": "Deletes the order process specified by the ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OrderProcess successfully deleted."
+          },
+          "400": {
+            "description": "Failed to delete order process."
+          },
+          "404": {
+            "description": "OrderProcess Not Found."
+          }
+        }
+      }
+    },
+    "/order_processes/{id}/before_portfolio_item": {
+      "patch": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Adds a 'before' product for an Order Process",
+        "operationId": "addOrderProcessBeforeItem",
+        "description": "Defines the product that will be executed before ordering when using this Order Process",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "'Before' product successfully added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderProcess"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "OrderProcess or PortfolioItem Not Found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderProcessPortfolioItemId"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/order_processes/{id}/after_portfolio_item": {
+      "patch": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Adds an 'after' product for an Order Process",
+        "operationId": "addOrderProcessAfterItem",
+        "description": "Defines the product that will be executed after ordering when using this Order Process",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "'After' product successfully added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderProcess"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "OrderProcess or PortfolioItem Not Found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderProcessPortfolioItemId"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/order_processes/{id}/remove_association": {
+      "post": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Removes the 'before' and/or 'after' product(s) for an Order Process",
+        "operationId": "removeOrderProcessAssociation",
+        "description": "Removes the association to the product(s) defined in the 'before' and/or 'after' that would be executed when using this Order Process",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Product(s) successfully removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderProcess"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "OrderProcess Not Found."
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderProcessAssociationsToRemove"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/order_processes/{id}/link": {
+      "post": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Links a tag to an order process",
+        "operationId": "linkTagToOrderProcess",
+        "description": "Links a tag to an order process",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tags successfully linked"
+            },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+            },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+            },
+          "404": {
+            "description": "OrderProcess Not Found."
+            }
+          },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceObject"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/order_processes/{id}/unlink": {
+      "post": {
+        "tags": [
+          "OrderProcess"
+        ],
+        "summary": "Unlinks a tag from an order process",
+        "operationId": "unlinkTagFromOrderProcess",
+        "description": "Unlinks a tag from an order process",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tags successfully unlinked"
+            },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+            },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+            },
+          "404": {
+            "description": "OrderProcess Not Found."
+            }
+          },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceObject"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://cloud.redhat.com/{basePath}",
+      "description": "Production Server",
+      "variables": {
+        "basePath": {
+          "default": "/api/catalog/v1.3"
+        }
+      }
+    },
+    {
+      "url": "http://localhost:{port}/{basePath}",
+      "description": "Development Server",
+      "variables": {
+        "port": {
+          "default": "3000"
+        },
+        "basePath": {
+          "default": "/api/catalog/v1.3"
+        }
+      }
+    }
+  ],
+  "components": {
+    "parameters": {
+      "ID": {
+        "name": "id",
+        "in": "path",
+        "description": "ID of the resource",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      "TenantID": {
+        "name": "tenant_id",
+        "in": "path",
+        "description": "ID of the resource",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      "PortfolioID": {
+        "name": "portfolio_id",
+        "in": "path",
+        "description": "The Portfolio ID",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      "PortfolioItemID": {
+        "name": "portfolio_item_id",
+        "in": "path",
+        "description": "The Portfolio Item ID",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      "OrderID": {
+        "name": "order_id",
+        "in": "path",
+        "description": "The Order ID",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      "OrderItemID": {
+        "name": "order_item_id",
+        "in": "path",
+        "description": "The Order Item ID",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      "DestinationPortfolioID": {
+        "in": "query",
+        "name": "destination_portfolio_id",
+        "description": "The destination portfolio to compare names against",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      "SettingName": {
+        "name": "name",
+        "in": "path",
+        "description": "name of the setting",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "QueryCacheID": {
+        "in": "query",
+        "name": "cache_id",
+        "required": false,
+        "description": "Artificial string to help avoid falsey browser cache. This can occur after changing static resources like images. The browser will return an outdated cached response. Appending different query will result in a new async call, instead of retrieving the resource from the browser cache.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "QueryLimit": {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "description": "The numbers of items to return per page.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100
+        }
+      },
+      "QueryOffset": {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "description": "The number of items to skip before starting to collect the result set.",
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "QueryFilter": {
+        "in": "query",
+        "name": "filter",
+        "description": "Filter for querying collections.",
+        "required": false,
+        "style": "deepObject",
+        "explode": true,
+        "schema": {
+          "type": "object"
+        }
+      },
+      "QuerySortBy": {
+        "in": "query",
+        "name": "sort_by",
+        "description": "Field to sort collection by.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ApplicationName": {
+        "in": "query",
+        "name": "app_name",
+        "description": "Name of the application.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ObjectId": {
+        "in": "query",
+        "name": "object_id",
+        "description": "Id of the resource object.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ObjectType": {
+        "in": "query",
+        "name": "object_type",
+        "description": "Type of the resource object.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ShowDiscarded": {
+        "in": "query",
+        "name": "show_discarded",
+        "required": false,
+        "description": "Whether or not to display the discarded result.",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "SourceType": {
+        "in": "query",
+        "name": "source_type",
+        "required": false,
+        "description": "Type of the progress messages source (could be either Order or OrderItem).",
+        "schema": {
+          "type": "string",
+          "default": "OrderItem"
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "$ref": "#/components/schemas/ApiErrorCollection"
+      },
+      "Conflict": {
+        "$ref": "#/components/schemas/ApiErrorCollection"
+      },
+      "Forbidden": {
+        "$ref": "#/components/schemas/ApiErrorCollection"
+      },
+      "NotModified": {
+        "$ref": "#/components/schemas/ApiErrorCollection"
+      },
+      "Unauthorized": {
+        "$ref": "#/components/schemas/ApiErrorCollection"
+      }
+    },
+    "requestBodies": {
+      "Portfolio": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Portfolio"
+            }
+          }
+        },
+        "required": true
+      }
+    },
+    "securitySchemes": {
+      "BasicAuth": {
+        "type": "http",
+        "description": "The userid/password is needed when accessing this API externally",
+        "scheme": "basic"
+      }
+    },
+    "schemas": {
+      "Portfolio": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "example": "Sample Portfolio",
+            "minLength": 1,
+            "maxLength": 512
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "example": "This is a sample description for a portfolio.",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": false,
+            "example": false
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner",
+            "example": "jdoe",
+            "readOnly": true
+          },
+          "icon_id": {
+            "type": "string",
+            "title": "Icon ID",
+            "description": "The Portfolio Icon ID",
+            "readOnly": true,
+            "example": "1"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created at",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated at",
+            "readOnly": true
+          },
+          "metadata": {
+            "type": "object",
+            "title": "Metadata",
+            "description": "JSON Metadata about the portfolio",
+            "readOnly": true
+          }
+        }
+      },
+      "CreatePortfolioItem": {
+        "type": "object",
+        "required": [
+          "portfolio_id"
+        ],
+        "properties": {
+          "portfolio_id": {
+            "type": "string",
+            "title": "Portfolio ID",
+            "description": "The Portfolio this portfolio item should belong to",
+            "example": "1"
+          },
+          "service_offering_ref": {
+            "type": "string",
+            "title": "Service Offering Ref",
+            "description": "The service offering ref should be retrieved from a call to the Topology Service.",
+            "example": "177"
+          }
+        }
+      },
+      "CreateIcon": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "The binary image contents, maximum size is 250KB",
+            "format": "binary"
+          },
+          "portfolio_id": {
+            "type": "string",
+            "title": "Portfolio ID",
+            "description": "The Portfolio this Icon belongs to",
+            "example": "1"
+          },
+          "portfolio_item_id": {
+            "type": "string",
+            "title": "Portfolio Item ID",
+            "description": "The Portfolio Item this Icon belongs to",
+            "example": "1"
+          }
+        }
+      },
+      "PatchModifiedServicePlan": {
+        "type": "object",
+        "properties": {
+          "modified": {
+            "type": "object",
+            "title": "Modified Schema",
+            "description": "the new modified schema for the service plan"
+          }
+        }
+      },
+      "ImportServicePlan": {
+        "type": "object",
+        "properties": {
+          "portfolio_item_id": {
+            "type": "string",
+            "title": "Portfolio Item ID",
+            "description": "The Portfolio Item to import the service plans for.",
+            "example": "177"
+          }
+        }
+      },
+      "CopyPortfolioItem": {
+        "type": "object",
+        "properties": {
+          "portfolio_id": {
+            "type": "string",
+            "title": "Portfolio ID",
+            "example": "2",
+            "description": "The portfolio to place the new copy of the Portfolio Item in"
+          },
+          "portfolio_item_name": {
+            "type": "string",
+            "title": "Portfolio Item Name",
+            "example": "nginx copy",
+            "description": "The name of the copied portfolio item"
+          }
+        }
+      },
+      "RestoreKey": {
+        "type": "object",
+        "properties": {
+          "restore_key": {
+            "type": "string",
+            "title": "Restore Key",
+            "example": "3c1d765c1453916143e517bfc27b57ace3da693c"
+          }
+        }
+      },
+      "OrderProcessPortfolioItemId": {
+        "type": "object",
+        "properties": {
+          "portfolio_item_id": {
+            "type": "string",
+            "title": "Portfolio Item Id",
+            "example": "1234"
+          }
+        }
+      },
+      "OrderProcessAssociationsToRemove": {
+        "type": "object",
+        "properties": {
+          "associations_to_remove": {
+            "type": "array",
+            "title": "Association(s) to remove",
+            "items": {
+              "type": "string",
+              "enum": [
+                "before",
+                "after"
+              ]
+            },
+            "example": ["before", "after"]
+          }
+        }
+      },
+      "PortfolioItemNextName": {
+        "type": "object",
+        "properties": {
+          "next_name": {
+            "type": "string",
+            "readOnly": true,
+            "title": "Next Name",
+            "example": "Copy of Nginx"
+          }
+        }
+      },
+      "Setting": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Setting Name",
+            "example": "default_workflow"
+          },
+          "value": {
+            "type": "string",
+            "title": "Setting Value",
+            "example": 2
+          }
+        }
+      },
+      "PortfolioItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "favorite": {
+            "type": "boolean",
+            "title": "Favorite",
+            "example": "Definition of a favorite portfolio item"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "example": "Name of the portfolio item",
+            "minLength": 1,
+            "maxLength": 512
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "example": "Description of a portfolio item",
+            "nullable": true
+          },
+          "orphan": {
+            "type": "boolean",
+            "readOnly": true,
+            "title": "Orphan",
+            "example": "Boolean if an associated catalog item no longer exists"
+          },
+          "state": {
+            "type": "string",
+            "readOnly": true,
+            "title": "State",
+            "example": "The current state of a portfolio item"
+          },
+          "long_description": {
+            "type": "string",
+            "title": "Long Description",
+            "example": "The longer description of a portfolio item",
+            "nullable": true
+          },
+          "distributor": {
+            "type": "string",
+            "title": "Distributor",
+            "example": "The name of the provider for this Item",
+            "nullable": true
+          },
+          "documentation_url": {
+            "type": "string",
+            "title": "Documentation URL",
+            "example": "The URL for documentation of the portfolio item",
+            "nullable": true
+          },
+          "support_url": {
+            "type": "string",
+            "title": "Support URL",
+            "example": "The URL for finding support for the portfolio item",
+            "nullable": true
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner",
+            "example": "jdoe",
+            "readOnly": true
+          },
+          "service_offering_source_ref": {
+            "type": "string",
+            "title": "Service Offering Source Ref",
+            "description": "The source reference this product was created from",
+            "readOnly": true,
+            "example": "20"
+          },
+          "service_offering_type": {
+            "type": "string",
+            "title": "Service Offering Type",
+            "description": "The service offering type stored by the Topology Service",
+            "readOnly": true,
+            "example": "job_template"
+          },
+          "portfolio_id": {
+            "type": "string",
+            "title": "Portfolio ID",
+            "description": "ID of a parent portfolio",
+            "readOnly": true,
+            "example": "1"
+          },
+          "icon_id": {
+            "type": "string",
+            "title": "Icon ID",
+            "description": "The Portfolio Item Icon ID",
+            "readOnly": true,
+            "example": "1"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created at",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated at",
+            "readOnly": true
+          },
+          "metadata": {
+            "type": "object",
+            "title": "Metadata",
+            "description": "JSON Metadata about the portfolio item",
+            "readOnly": true
+          }
+        }
+      },
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "user_id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "Created",
+              "Approval Pending",
+              "Ordered",
+              "Failed",
+              "Completed",
+              "Canceled"
+            ],
+            "title": "State",
+            "description": "Current State of the order."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created at",
+            "readOnly": true
+          },
+          "order_request_sent_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Order request sent at",
+            "description": "The time at which the order request was sent to the Topology Service",
+            "nullable": true
+          },
+          "completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Completed at",
+            "readOnly": true
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner",
+            "example": "jdoe",
+            "readOnly": true
+          }
+        }
+      },
+      "OrderItem": {
+        "type": "object",
+        "required": [
+          "count",
+          "portfolio_item_id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "count": {
+            "type": "integer",
+            "default": 1,
+            "title": "Item Count"
+          },
+          "service_parameters": {
+            "type": "object",
+            "title": "JSON object with provisioning parameters",
+            "nullable": true
+          },
+          "provider_control_parameters": {
+            "type": "object",
+            "title": "Provider Control Parameters",
+            "description": "The provider specific parameters needed to provision this service. This might include namespaces, special keys.",
+            "nullable": true
+          },
+          "portfolio_item_id": {
+            "type": "string",
+            "title": "Portfolio Item ID",
+            "description": "Stores the Portfolio Item ID."
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "Created",
+              "Approval Pending",
+              "Ordered",
+              "Failed",
+              "Completed",
+              "Approved",
+              "Denied",
+              "Canceled"
+            ],
+            "title": "State",
+            "description": "Current state of this order item.",
+            "readOnly": true
+          },
+          "order_id": {
+            "type": "string",
+            "title": "Order ID",
+            "description": "The Order that the OrderItem belongs to.",
+            "readOnly": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created at",
+            "readOnly": true
+          },
+          "order_request_sent_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Order request sent at",
+            "description": "The time at which the order request was sent to the Topology Service",
+            "readOnly": true
+          },
+          "completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Completed at",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Completed at",
+            "readOnly": true
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner",
+            "example": "jdoe",
+            "readOnly": true
+          },
+          "external_url": {
+            "type": "string",
+            "title": "External url",
+            "description": "The external url of the service instance used with relation to this order item",
+            "readOnly": true
+          },
+          "insights_request_id": {
+            "type": "string",
+            "title": "Insights Request ID ",
+            "example": "364498f142194beba576833d7303abe5",
+            "description": "The insights request id can be used to collect log data for this order item as its processed by the system",
+            "readOnly": true
+          },
+          "process_sequence": {
+            "type": "integer",
+            "title": "Sequence of when the order item is ran",
+            "example": 1,
+            "description": "The sequence that this order item is ran relative to the other order items within the order.",
+            "readOnly": true
+          },
+          "process_scope": {
+            "type": "string",
+            "title": "Scope of when the order item is ran",
+            "example": "before",
+            "description": "Denotes the scope in which the order item will run for the order it belongs to. It can be 'before', 'after', or 'applicable'",
+            "readOnly": true
+          },
+          "artifacts": {
+            "type": "object",
+            "title": "Return values from a product provision",
+            "description": "Contains a prefix-stripped key/value object that contains all of the information exposed from product provisioning. Must be exposed from Tower with prefix 'expose_to_cloud_redhat_com_'",
+            "readOnly": true,
+            "example": {
+              "important_id": 10,
+              "ip_address": "127.0.0.1"
+            }
+          }
+        }
+      },
+      "ApprovalRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "ID",
+            "description": "The unique identifier for this approval request.",
+            "readOnly": true
+          },
+          "approval_request_ref": {
+            "type": "string",
+            "title": "Approval Request Ref",
+            "description": "The id of the approval submitted to approval-api",
+            "readOnly": true
+          },
+          "order_item_id": {
+            "type": "string",
+            "title": "Order Item ID",
+            "description": "The Order Item which the approval request belongs to",
+            "readOnly": true
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason",
+            "description": "The reason for the current state.",
+            "readOnly": true
+          },
+          "request_completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Approval Request Completed At",
+            "readOnly": true
+          },
+          "state": {
+            "type": "string",
+            "title": "State",
+            "enum": [
+              "undecided",
+              "approved",
+              "denied",
+              "canceled",
+              "error"
+            ],
+            "description": "The state of the approval request (approved, denied, undecided, canceled, error)",
+            "readOnly": true
+          }
+        }
+      },
+      "Icon": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "ID",
+            "description": "The unique identifier for this Service Offering Icon",
+            "readOnly": true
+          },
+          "image_id": {
+            "type": "string",
+            "title": "Image ID",
+            "description": "The Image reference containing the binary image data for this icon",
+            "readOnly": false
+          },
+          "source_ref": {
+            "type": "string",
+            "title": "Source Ref",
+            "description": "Stores the Source Ref for this icon",
+            "readOnly": true
+          },
+          "source_id": {
+            "type": "string",
+            "title": "Source ID",
+            "description": "The source ID for this icon",
+            "readOnly": true
+          },
+          "portfolio_id": {
+            "type": "string",
+            "title": "Portfolio ID",
+            "description": "The portfolio this icon belongs to.",
+            "readOnly": true
+          },
+          "portfolio_item_id": {
+            "type": "string",
+            "title": "Portfolio Item ID",
+            "description": "The portfolio_item this icon belongs to.",
+            "readOnly": true
+          }
+        }
+      },
+      "ProgressMessage": {
+        "type": "object",
+        "properties": {
+          "received_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Message Received At",
+            "readOnly": true
+          },
+          "level": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "info",
+              "error",
+              "warning",
+              "debug"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "example": "This is a sample message",
+            "title": "Message",
+            "readOnly": true
+          },
+          "order_item_id": {
+            "type": "string",
+            "title": "Order Item ID",
+            "readOnly": true
+          }
+        }
+      },
+      "ServicePlan": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the service plan.",
+            "readOnly": true
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "The service plan description.",
+            "readOnly": true
+          },
+          "create_json_schema": {
+            "type": "object",
+            "title": "JSON Schema",
+            "description": "JSON schema for the object.",
+            "readOnly": true
+          },
+          "portfolio_item_id": {
+            "type": "string",
+            "title": "Portfolio Item ID",
+            "description": "The reference ID of the Portfolio Item",
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "title": "ID",
+            "description": "The unique identifier for this service plan.",
+            "readOnly": true
+          },
+          "imported": {
+            "type": "boolean",
+            "title": "Imported",
+            "description": "Whether or not the ServicePlan has been imported for editing",
+            "readOnly": true
+          },
+          "modified": {
+            "type": "boolean",
+            "title": "Modified",
+            "description": "Whether or not the ServicePlan has a modified schema",
+            "readOnly": true
+          }
+        }
+      },
+      "PortfoliosCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Portfolio"
+            }
+          }
+        }
+      },
+      "PortfolioItemsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortfolioItem"
+            }
+          }
+        }
+      },
+      "OrdersCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Order"
+            }
+          }
+        }
+      },
+      "OrderItemsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderItem"
+            }
+          }
+        }
+      },
+      "ApprovalRequestsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApprovalRequest"
+            }
+          }
+        }
+      },
+      "ProgressMessagesCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProgressMessage"
+            }
+          }
+        }
+      },
+      "TenantsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tenant"
+            }
+          }
+        }
+      },
+      "CollectionLinks": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "string",
+            "title": "First Link",
+            "description": "The link to fetch the first group of items in the result set"
+          },
+          "last": {
+            "type": "string",
+            "title": "Last Link",
+            "description": "The link to fetch the last group of items in the result set"
+          },
+          "prev": {
+            "type": "string",
+            "title": "Previous Link",
+            "description": "The link to fetch the previous group of items in the result set"
+          },
+          "next": {
+            "type": "string",
+            "title": "Next Link",
+            "description": "The link to fetch the next group of items in the result set"
+          }
+        }
+      },
+      "CollectionMetadata": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer",
+            "title": "Total number of items in the result set",
+            "description": "Total number of items in the result set, of which only a subset is returned, defined by the QueryLimit parameter."
+          }
+        }
+      },
+      "ProviderControlParameters": {
+        "type": "object",
+        "title": "Provider Control Parameters",
+        "description": "JSON Schema for Provider control parameters."
+      },
+      "TenantSettings": {
+        "type": "object",
+        "title": "Tenant Settings",
+        "description": "The tenant settings and schema",
+        "properties": {
+          "current": {
+            "type": "object",
+            "title": "Current Settings",
+            "description": "The current settings for this tenant"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/TenantSettingsSchema"
+          }
+        }
+      },
+      "TenantSettingsSchema": {
+        "type": "object",
+        "title": "Tenant Settings Schema",
+        "description": "JSON Schema for the Tenant Settings"
+      },
+      "SharePolicy": {
+        "type": "object",
+        "required": [
+          "permissions",
+          "group_uuids"
+        ],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "title": "Name",
+            "description": "The permissions to apply for this share. The valid values are read, update, delete and order",
+            "items": {
+              "type": "string",
+              "enum": [
+                "read",
+                "update",
+                "delete",
+                "order"
+              ]
+            },
+            "minItems": 1,
+            "example": [
+              "read",
+              "update",
+              "delete",
+              "order"
+            ]
+          },
+          "group_uuids": {
+            "type": "array",
+            "title": "The Group UUIDs",
+            "description": "An array of group UUID's retrieved from the RBAC Service with whom the resource has to be shared.",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "minItems": 1
+          }
+        }
+      },
+      "UnsharePolicy": {
+        "type": "object",
+        "required": [
+          "permissions"
+        ],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "title": "Name",
+            "description": "The permissions to remove for this resource.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "read",
+                "update",
+                "delete",
+                "order"
+              ]
+            },
+            "minItems": 1
+          },
+          "group_uuids": {
+            "type": "array",
+            "title": "The Group UUIDs",
+            "description": "An array of group UUID's retrieved from the RBAC Service from which the permissions have to be removed. If group uuids are not specified we will unshare it from all groups.",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "Tenant": {
+        "type": "object",
+        "properties": {
+          "external_tenant": {
+            "type": "string",
+            "title": "Request account number",
+            "description": "The Request account number"
+          },
+          "id": {
+            "type": "string",
+            "title": "Internal tenant id",
+            "description": "The internal tenant id"
+          }
+        }
+      },
+      "OrderProcess": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the order process."
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "The order process description.",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created at",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated at",
+            "readOnly": true
+          },
+          "before_portfolio_item_id": {
+            "type": "string",
+            "description": "The ID of the portfolio item associated to the 'before' step",
+            "readOnly": true
+          },
+          "after_portfolio_item_id": {
+            "type": "string",
+            "description": "The ID of the portfolio item associated to the 'after' step",
+            "readOnly": true
+          },
+          "metadata": {
+            "type": "object",
+            "title": "Metadata",
+            "description": "JSON Metadata about the order process",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OrderProcessCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderProcess"
+            }
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "tag": {
+            "example": "/namespace/architecture=x86_64",
+            "type": "string",
+            "pattern": "^/.*/.+(=.+|[^=]$)"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TagsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          }
+        }
+      },
+      "ShareInfo": {
+        "type": "object",
+        "properties": {
+          "group_uuid": {
+            "type": "string",
+            "title": "The Group UUID",
+            "description": "The Group UUID"
+          },
+          "group_name": {
+            "type": "string",
+            "title": "The Group Name",
+            "description": "The Group Name"
+          },
+          "permissions": {
+            "type": "array",
+            "title": "Permissions",
+            "description": "One or more permissions currently applied to this group.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "read",
+                "update",
+                "delete",
+                "order"
+              ]
+            }
+          }
+        }
+      },
+      "GraphQLRequest": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "The GraphQL query",
+            "default": "{}"
+          },
+          "operationName": {
+            "type": "string",
+            "description": "If the Query contains several named operations, the operationName controls which one should be executed",
+            "default": ""
+          },
+          "variables": {
+            "type": "object",
+            "description": "Optional Query variables",
+            "nullable": true
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "GraphQLResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "description": "Results from the GraphQL query"
+          },
+          "errors": {
+            "type": "array",
+            "description": "Errors resulting from the GraphQL query",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "ApiError": {
+        "type": "object",
+        "description": "API Error",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "HTTP status code",
+            "example": "400"
+          },
+          "details": {
+            "type": "string",
+            "description": "Error details",
+            "example": "Bad Request"
+          }
+        }
+      },
+      "ApiErrorCollection": {
+        "type": "object",
+        "description": "API Error collection",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "description": "Error list from the API query",
+            "items": {
+              "$ref": "#/components/schemas/ApiError"
+            }
+          }
+        }
+      },
+      "ResourceObject": {
+         "type": "object",
+         "description": "Resource object definition",
+         "required": [
+          "object_type",
+          "app_name",
+          "object_id"
+         ],
+         "properties": {
+          "object_type": {
+            "type": "string",
+            "title": "Object type",
+            "description": "Object type",
+            "example": "PortfolioItem"
+          },
+          "app_name": {
+            "type": "string",
+            "title": "App name",
+            "description": "Name of the application that the object belongs to",
+            "example": "catalog"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object ID",
+            "description": "ID of the object",
+            "example": "123"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/lib/topological_inventory/event_listener_spec.rb
+++ b/spec/lib/topological_inventory/event_listener_spec.rb
@@ -31,7 +31,8 @@ describe TopologicalInventory::EventListener do
       progress_message = ProgressMessage.last
       expect(progress_message.level).to eq("info")
       expect(progress_message.message).to eq("Order Item Is Running")
-      expect(progress_message.order_item_id).to eq(order_item.id.to_s)
+      expect(progress_message.messageable_id).to eq(order_item.id)
+      expect(progress_message.messageable_type).to eq(order_item.class.name)
       order_item.reload
       expect(order_item.external_url).to eq("external_url")
     end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -7,7 +7,8 @@ describe OrderItem do
       order_item.reload
       last_message = order_item.progress_messages.last
       expect(order_item.updated_at).to be_a(Time)
-      expect(last_message.order_item_id.to_i).to eq order_item.id
+      expect(last_message.messageable_id.to_i).to eq(order_item.id)
+      expect(last_message.messageable_type).to eq(order_item.class.name)
       expect(last_message.tenant_id).to eq(order_item.tenant.id)
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -52,7 +52,9 @@ describe Order do
       order1.reload
       last_message = order1.progress_messages.last
       expect(order1.updated_at).to be_a(Time)
-      expect(last_message.order_id.to_i).to eq order1.id
+      expect(last_message.message).to eq("test message")
+      expect(last_message.messageable_type).to eq(order1.class.name)
+      expect(last_message.messageable_id.to_i).to eq(order1.id)
       expect(last_message.tenant_id).to eq(order1.tenant.id)
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -45,4 +45,15 @@ describe Order do
       end
     end
   end
+
+  context "updating order progress messages" do
+    it "syncs the time between order and progress message" do
+      order1.update_message("test_level", "test message")
+      order1.reload
+      last_message = order1.progress_messages.last
+      expect(order1.updated_at).to be_a(Time)
+      expect(last_message.order_id.to_i).to eq order1.id
+      expect(last_message.tenant_id).to eq(order1.tenant.id)
+    end
+  end
 end

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -84,7 +84,7 @@ describe "OpenAPI stuff" do
     end
   end
 
-  %w[1.0 1.1 1.2].each do |version|
+  %w[1.0 1.1 1.2 1.3].each do |version|
     describe "Openapi schema attributes" do
       context "correctly configured" do
         ActiveRecord::Base.connection.tables.each do |table|

--- a/spec/requests/api/v1.0/progress_message_spec.rb
+++ b/spec/requests/api/v1.0/progress_message_spec.rb
@@ -2,7 +2,10 @@ describe "v1.0 - ProgressMessageRequests", :type => [:request, :v1] do
   let(:order) { create(:order) }
   let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
-  let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id.to_s) }
+
+  before do
+    order_item.update_message("info", "test message")
+  end
 
   context "v1.0" do
     describe "GET /order_items/:order_item_id/progress_messages" do
@@ -11,7 +14,7 @@ describe "v1.0 - ProgressMessageRequests", :type => [:request, :v1] do
 
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['data'].first['message']).to eq(progress_message.message)
+        expect(JSON.parse(response.body)['data'].first['message']).to eq("test message")
       end
 
       context "when the order item does not exist" do

--- a/spec/requests/api/v1.3/progress_messages_controller_spec.rb
+++ b/spec/requests/api/v1.3/progress_messages_controller_spec.rb
@@ -1,0 +1,56 @@
+describe "v1.3 - ProgressMessageRequests", :type => [:request, :v1x3] do
+  let(:order) { create(:order) }
+  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
+  let!(:progress_message) { create(:progress_message, :message => "order item message", :order_item_id => order_item.id.to_s) }
+  let!(:order_progress_message) { create(:progress_message, :message => "order message", :order_id => order.id.to_s) }
+
+  describe "v1.3" do
+    context "GET /orders/:order_id/progress_messages" do
+      let(:params) { {:source_type => "Order"} }
+
+      it "lists progress messages" do
+        get "#{api_version}/orders/#{order.id}/progress_messages", :headers => default_headers, :params => params
+
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['data'].first['message']).to eq(order_progress_message.message)
+      end
+
+      context "when params are invalid" do
+        let(:params) { {:source_type => "OrderItem"} }
+
+        it "returns a 404" do
+          get "#{api_version}/orders/#{order.id}/progress_messages", :headers => default_headers, :params => params
+
+          expect(response.status).to eq(400)
+          expect(first_error_detail).to match(/Catalog::InvalidParameter/)
+        end
+      end
+    end
+
+    context "GET /order_items/:order_item_id/progress_messages" do
+      let(:params) { {:source_type => "OrderItem"} }
+
+      it "lists progress messages" do
+        get "#{api_version}/order_items/#{order_item.id}/progress_messages", :headers => default_headers
+
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['data'].first['message']).to eq(progress_message.message)
+      end
+
+      context "when the order item does not exist" do
+        let(:order_item_id) { 0 }
+
+        it "returns a 404" do
+          get "#{api_version}/order_items/#{order_item_id}/progress_messages", :headers => default_headers, :params => params
+
+          expect(response.content_type).to eq("application/json")
+          expect(response).to have_http_status(:not_found)
+          expect(first_error_detail).to match(/Couldn't find OrderItem/)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1.3/progress_messages_controller_spec.rb
+++ b/spec/requests/api/v1.3/progress_messages_controller_spec.rb
@@ -2,49 +2,37 @@ describe "v1.3 - ProgressMessageRequests", :type => [:request, :v1x3] do
   let(:order) { create(:order) }
   let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
-  let!(:progress_message) { create(:progress_message, :message => "order item message", :order_item_id => order_item.id.to_s) }
-  let!(:order_progress_message) { create(:progress_message, :message => "order message", :order_id => order.id.to_s) }
+
+  before do
+    order.update_message("info", "test order progress_messages")
+    order_item.update_message("info", "test order item progress_messages")
+  end
 
   describe "v1.3" do
     context "GET /orders/:order_id/progress_messages" do
-      let(:params) { {:source_type => "Order"} }
-
       it "lists progress messages" do
-        get "#{api_version}/orders/#{order.id}/progress_messages", :headers => default_headers, :params => params
+        get "#{api_version}/orders/#{order.id}/progress_messages", :headers => default_headers
 
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['data'].first['message']).to eq(order_progress_message.message)
-      end
-
-      context "when params are invalid" do
-        let(:params) { {:source_type => "OrderItem"} }
-
-        it "returns a 404" do
-          get "#{api_version}/orders/#{order.id}/progress_messages", :headers => default_headers, :params => params
-
-          expect(response.status).to eq(400)
-          expect(first_error_detail).to match(/Catalog::InvalidParameter/)
-        end
+        expect(JSON.parse(response.body)['data'].first['message']).to eq("test order progress_messages")
       end
     end
 
     context "GET /order_items/:order_item_id/progress_messages" do
-      let(:params) { {:source_type => "OrderItem"} }
-
       it "lists progress messages" do
         get "#{api_version}/order_items/#{order_item.id}/progress_messages", :headers => default_headers
 
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['data'].first['message']).to eq(progress_message.message)
+        expect(JSON.parse(response.body)['data'].first['message']).to eq("test order item progress_messages")
       end
 
       context "when the order item does not exist" do
         let(:order_item_id) { 0 }
 
         it "returns a 404" do
-          get "#{api_version}/order_items/#{order_item_id}/progress_messages", :headers => default_headers, :params => params
+          get "#{api_version}/order_items/#{order_item_id}/progress_messages", :headers => default_headers
 
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:not_found)

--- a/spec/requests/api/v1.3/root_spec.rb
+++ b/spec/requests/api/v1.3/root_spec.rb
@@ -1,0 +1,8 @@
+describe "v1.3 - root", :type => [:request, :v1x3] do
+  it "#openapi.json" do
+    get("#{api_version}/openapi.json")
+
+    expect(response.content_type).to eq("application/json")
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/api/v1/application_controller_spec.rb
+++ b/spec/requests/api/v1/application_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApplicationController, :type => [:request, :v1x2] do
+RSpec.describe ApplicationController, :type => [:request, :v1x3] do
   let(:portfolio) { create(:portfolio, :name => 'tenant_portfolio', :description => 'tenant desc', :owner => 'wilma') }
   let(:portfolio_id) { portfolio.id }
   let(:catalog_access) { instance_double(Insights::API::Common::RBAC::Access, :scopes => %w[admin]) }

--- a/spec/requests/api/v1/root_spec.rb
+++ b/spec/requests/api/v1/root_spec.rb
@@ -1,4 +1,4 @@
-describe "v1 - root", :type => [:request, :v1x2] do
+describe "v1 - root", :type => [:request, :v1x3] do
   it "#openapi.json" do
     get("#{api_version}/openapi.json")
 

--- a/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
@@ -49,7 +49,8 @@ describe Api::V1x0::Catalog::CreateRequestForAppliedInventories, :type => :servi
         progress_message = ProgressMessage.last
         expect(progress_message.level).to eq("info")
         expect(progress_message.message).to eq("Waiting for inventories")
-        expect(progress_message.order_item_id).to eq(order_item.id.to_s)
+        expect(progress_message.messageable_id).to eq(order_item.id)
+        expect(progress_message.messageable_type).to eq(order_item.class.name)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,7 @@ RSpec.configure do |config|
   config.include V1Helper, :type => :v1
   config.include V1x1Helper, :type => :v1x1
   config.include V1x2Helper, :type => :v1x2
+  config.include V1x3Helper, :type => :v1x3
   # ------------------------ #
 
   config.include ServiceSpecHelper

--- a/spec/support/v1x3_helper.rb
+++ b/spec/support/v1x3_helper.rb
@@ -1,0 +1,5 @@
+module V1x3Helper
+  def api_version
+    File.join('/', ENV['PATH_PREFIX'], ENV['APP_NAME'], 'v1.3')
+  end
+end


### PR DESCRIPTION
This PR contains following changes:
1. Add an endpoint `/orders/:order_id/progress_messages`; 
2. Change `ProgressMessage` schema to add `messageable_id` and `messageable_type` field, so it can have relations with both `Order` and `OrderItem`;
3. bump api version to 1.3 to support above changes;