### PR TITLE
Keep before, after and applicable order items all have the same insights-request-ids

### DIFF
--- a/lib/catalog/evaluate_order_process.rb
+++ b/lib/catalog/evaluate_order_process.rb
@@ -20,19 +20,21 @@ module Catalog
       before_sequence_number = 1
       after_sequence_number = determine_starting_after_sequence_number(relevant_order_processes)
 
-      relevant_order_processes.each do |order_process|
-        if order_process.before_portfolio_item.present?
-          before_item = Api::V1x2::Catalog::AddToOrderViaOrderProcess.new(order_item_params(order_process, before_sequence_number, "before")).process.order_item
-          before_item.send(:service_parameters_raw=, service_parameters(before_item))
-          before_item.save
-          before_sequence_number += 1
-        end
+      Insights::API::Common::Request.with_request(@applicable_order_item.context.transform_keys(&:to_sym)) do
+        relevant_order_processes.each do |order_process|
+          if order_process.before_portfolio_item.present?
+            before_item = Api::V1x2::Catalog::AddToOrderViaOrderProcess.new(order_item_params(order_process, before_sequence_number, "before")).process.order_item
+            before_item.send(:service_parameters_raw=, service_parameters(before_item))
+            before_item.save
+            before_sequence_number += 1
+          end
 
-        if order_process.after_portfolio_item.present?
-          after_item = Api::V1x2::Catalog::AddToOrderViaOrderProcess.new(order_item_params(order_process, after_sequence_number, "after")).process.order_item
-          after_item.send(:service_parameters_raw=, service_parameters(after_item))
-          after_item.save
-          after_sequence_number -= 1
+          if order_process.after_portfolio_item.present?
+            after_item = Api::V1x2::Catalog::AddToOrderViaOrderProcess.new(order_item_params(order_process, after_sequence_number, "after")).process.order_item
+            after_item.send(:service_parameters_raw=, service_parameters(after_item))
+            after_item.save
+            after_sequence_number -= 1
+          end
         end
       end
 


### PR DESCRIPTION
The `insights-request-id` of created `before` and `after` order items somehow are different from the original `applicable` one. So only part of logs are displayed in Kibana. The PR will fix the issue by keeping the same request id.