### PR TITLE
Move part of progress messages to its order

### DIFF
--- a/app/models/approval_request.rb
+++ b/app/models/approval_request.rb
@@ -5,7 +5,7 @@ class ApprovalRequest < ApplicationRecord
   belongs_to :order_item
 
   after_create do
-    order_item.update_message("info", "Created Approval Request ref: #{approval_request_ref}.  catalog approval request id: #{id}")
+    order_item.order.update_message("info", "Created Approval Request ref: #{approval_request_ref}.  catalog approval request id: #{id}")
   end
 
   scope :by_owner, lambda {

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -80,6 +80,7 @@ class OrderItem < ApplicationRecord
     update_message(level, msg) if msg
     Rails.logger.send(level, "Updated OrderItem: #{id} with '#{opts[:state]}' state".tap { |log| log << " message: #{msg}" }) if msg
 
+    order.reload
     Catalog::OrderStateTransition.new(order).process
   end
 end

--- a/app/services/api/v1x0/catalog/create_request_for_applied_inventories.rb
+++ b/app/services/api/v1x0/catalog/create_request_for_applied_inventories.rb
@@ -15,11 +15,12 @@ module Api
             validate_surveys
             send_request_to_compute_applied_inventories
 
-            @item.update_message(:info, "Waiting for inventories")
+            @order.update_message(:info, "Computing inventories")
           end
           self
-        rescue
+        rescue => e
           @order.update(:state => "Failed")
+          @order.update_message(:error, "Error computing inventories: #{e.message}")
           raise
         end
 

--- a/lib/catalog/approval_transition.rb
+++ b/lib/catalog/approval_transition.rb
@@ -1,8 +1,6 @@
 module Catalog
   class ApprovalTransition
-    attr_reader :order_item_id
-    attr_reader :order_item
-    attr_reader :state
+    attr_reader :order_item_id, :order_item, :state
 
     def initialize(order_item_id)
       @order_item = OrderItem.find(order_item_id)
@@ -37,28 +35,29 @@ module Catalog
 
     def submit_order
       finalize_order
-      @order_item.update_message("info", "Submitting Order #{@order_item.order_id} for provisioning ")
+      @order_item.order.update_message("info", "Submitting Order for provisioning")
       Catalog::SubmitNextOrderItem.new(@order_item.order_id).process
     rescue ::Catalog::TopologyError => e
       Rails.logger.error("Error Submitting Order #{@order_item.order_id}, #{e.message}")
-      @order_item.update_message("error", "Error Submitting Order #{@order_item.order_id}, #{e.message}")
+      @order_item.order.update_message("error", "Error Submitting Order: #{e.message}")
+      @order_item.mark_failed("Error Submitting Order: #{e.message}")
     end
 
     def mark_canceled
       finalize_order
-      @order_item.update_message("info", "Order #{@order_item.order_id} has been canceled")
+      @order_item.order.update_message("info", "Order has been canceled")
       Rails.logger.info("Order #{@order_item.order_id} has been canceled")
     end
 
     def mark_denied
       finalize_order
-      @order_item.update_message("info", "Order #{@order_item.order_id} has been denied")
+      @order_item.order.update_message("info", "Order has been denied")
       Rails.logger.info("Order #{@order_item.order_id} has been denied")
     end
 
     def mark_errored
       finalize_order
-      @order_item.update_message("error", "Order #{@order_item.order_id} has approval errors. #{reasons}")
+      @order_item.order.update_message("error", "Order has approval errors. #{reasons}")
       Rails.logger.error("Order #{@order_item.order_id} has failed. #{reasons}")
     end
 

--- a/lib/catalog/approval_transition.rb
+++ b/lib/catalog/approval_transition.rb
@@ -39,8 +39,7 @@ module Catalog
       Catalog::SubmitNextOrderItem.new(@order_item.order_id).process
     rescue ::Catalog::TopologyError => e
       Rails.logger.error("Error Submitting Order #{@order_item.order_id}, #{e.message}")
-      @order_item.order.update_message("error", "Error Submitting Order: #{e.message}")
-      @order_item.mark_failed("Error Submitting Order: #{e.message}")
+      @order_item.order.update_message("error", "Error when submitting order item #{@order_item.id}: #{e.message}")
     end
 
     def mark_canceled

--- a/lib/catalog/order_state_transition.rb
+++ b/lib/catalog/order_state_transition.rb
@@ -22,6 +22,7 @@ module Catalog
       if item_states.include?('Failed') || item_states.include?('Denied')
         'Failed'
       elsif item_states.all? { |state| state == "Completed" }
+        @order.update_message("info", "Order Completed")
         'Completed'
       elsif item_states.include?('Canceled')
         'Canceled'

--- a/lib/catalog/order_state_transition.rb
+++ b/lib/catalog/order_state_transition.rb
@@ -20,11 +20,13 @@ module Catalog
 
       # TO DO: How to determine order state with pre and post order_processes?
       if item_states.include?('Failed') || item_states.include?('Denied')
+        @order.update_message("error", "Order Failed")
         'Failed'
       elsif item_states.all? { |state| state == "Completed" }
         @order.update_message("info", "Order Completed")
         'Completed'
       elsif item_states.include?('Canceled')
+        # Message of 'Order Canceled' has been recorded
         'Canceled'
       else
         'Ordered'

--- a/lib/catalog/submit_order_item.rb
+++ b/lib/catalog/submit_order_item.rb
@@ -9,10 +9,12 @@ module Catalog
     end
 
     def process
+      @order_item.update_message("info", "Submitting Order Item for provisioning")
       validate_before_submit
+
       TopologicalInventory::Service.call do |api_instance|
         result = api_instance.order_service_offering(order_item.portfolio_item.service_offering_ref, parameters)
-        order_item.mark_ordered("Ordered", :topology_task_ref => result.task_id)
+        order_item.mark_ordered(:topology_task_ref => result.task_id)
         Rails.logger.info("OrderItem #{order_item.id} ordered with topology task ref #{result.task_id}")
       end
       self

--- a/lib/catalog/submit_order_item.rb
+++ b/lib/catalog/submit_order_item.rb
@@ -18,6 +18,9 @@ module Catalog
         Rails.logger.info("OrderItem #{order_item.id} ordered with topology task ref #{result.task_id}")
       end
       self
+    rescue => e
+      Rails.logger.error("Error Submitting Order Item: #{@order_item.id}: #{e.message}")
+      @order_item.mark_failed("Error Submitting Order Item: #{e.message}")
     end
 
     private
@@ -41,8 +44,7 @@ module Catalog
 
       unless changed_surveys.empty?
         invalid_survey_messages = changed_surveys.collect(&:invalid_survey_message)
-        order_item.mark_failed("Order Item Failed: #{invalid_survey_messages.join('; ')}")
-        raise ::Catalog::InvalidSurvey, invalid_survey_messages
+        raise ::Catalog::InvalidSurvey, invalid_survey_messages.join('; ')
       end
     end
 

--- a/spec/lib/catalog/approval_transition_spec.rb
+++ b/spec/lib/catalog/approval_transition_spec.rb
@@ -118,19 +118,15 @@ describe Catalog::ApprovalTransition do
 
     context "when the call to submit order fails" do
       before do
-        count = 0
         approval.update(:state => "approved")
-        allow(submit_order).to receive(:process) do
-          count += 1
-          count < 2 ? raise(topo_ex) : submit_order
-        end
+        allow(submit_order).to receive(:process).and_raise(topo_ex)
       end
 
       it "blows up" do
         order_item_transition.process
         msg = order.progress_messages.last
         expect(msg.level).to eq "error"
-        expect(msg.message).to eq "Error Submitting Order: #{topo_ex.message}"
+        expect(msg.message).to eq "Error when submitting order item #{order_item.id}: #{topo_ex.message}"
       end
     end
 

--- a/spec/lib/catalog/create_approval_request_spec.rb
+++ b/spec/lib/catalog/create_approval_request_spec.rb
@@ -72,7 +72,8 @@ describe Catalog::CreateApprovalRequest, :type => :service do
 
       it "creates a progress message" do
         expect { subject.process }.to raise_exception(Catalog::ApprovalError)
-        expect(ProgressMessage.last.message).to eq("Error while creating approval request")
+        expect(ProgressMessage.first.message).to eq("Error while creating approval request")
+        expect(ProgressMessage.last.message).to eq("Order Failed")
       end
 
       it "fails the order" do

--- a/spec/lib/catalog/submit_order_item_spec.rb
+++ b/spec/lib/catalog/submit_order_item_spec.rb
@@ -85,7 +85,10 @@ describe Catalog::SubmitOrderItem, :type => [:service, :topology, :current_forwa
 
       it "throws an unauthorized exception" do
         Insights::API::Common::Request.with_request(default_request) do
-          expect { submit_order.process }.to raise_error(Catalog::NotAuthorized)
+          submit_order.process
+          msg = order_item.progress_messages.last
+          expect(msg.level).to eq "error"
+          expect(msg.message).to eq "Error Submitting Order Item: Catalog::NotAuthorized"
         end
       end
     end
@@ -99,11 +102,10 @@ describe Catalog::SubmitOrderItem, :type => [:service, :topology, :current_forwa
     end
 
     it "fails to order" do
-      expect(order_item).to receive(:mark_failed).with(/Order Item Failed:/)
-      expect { submit_order.process }.to raise_exception do |error|
-        expect(error).to be_a(Catalog::InvalidSurvey)
-        expect(error.message).to match(/The underlying survey.*has been changed/)
-      end
+      submit_order.process
+      msg = order_item.progress_messages.last
+      expect(msg.level).to eq "error"
+      expect(msg.message).to match(/Error Submitting Order Item: The underlying survey/)
     end
   end
 end

--- a/spec/models/approval_request_spec.rb
+++ b/spec/models/approval_request_spec.rb
@@ -28,7 +28,7 @@ describe ApprovalRequest, :type => :model do
 
   describe ".create" do
     it "generates a progress_message on the associated order_item" do
-      progress_message = approval_request1.order_item.progress_messages.first
+      progress_message = approval_request1.order_item.order.progress_messages.first
       expect(progress_message.message).to match(/Created Approval Request ref: \d*\.  catalog approval request id: #{approval_request1.id}/)
     end
   end

--- a/spec/requests/api/v1.0/orders_spec.rb
+++ b/spec/requests/api/v1.0/orders_spec.rb
@@ -66,7 +66,8 @@ describe "v1.0 - OrderRequests", :type => [:request, :v1] do
       end
 
       it "creates progress messages for the order items" do
-        expect(ProgressMessage.last.message).to match(/has been archived/)
+        expect(ProgressMessage.first.message).to match(/has been archived/)
+        expect(ProgressMessage.last.message).to match(/Order Failed/)
       end
 
       it "marks the order as failed" do

--- a/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
@@ -53,7 +53,7 @@ describe Api::V1x0::Catalog::CreateRequestForAppliedInventories, :type => :servi
         subject.process
         progress_message = ProgressMessage.last
         expect(progress_message.level).to eq("info")
-        expect(progress_message.message).to eq("Waiting for inventories")
+        expect(progress_message.message).to eq("Computing inventories")
         expect(progress_message.messageable_id).to eq(order_item.order.id)
         expect(progress_message.messageable_type).to eq(order_item.order.class.name)
       end

--- a/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
@@ -54,8 +54,8 @@ describe Api::V1x0::Catalog::CreateRequestForAppliedInventories, :type => :servi
         progress_message = ProgressMessage.last
         expect(progress_message.level).to eq("info")
         expect(progress_message.message).to eq("Waiting for inventories")
-        expect(progress_message.messageable_id).to eq(order_item.id)
-        expect(progress_message.messageable_type).to eq(order_item.class.name)
+        expect(progress_message.messageable_id).to eq(order_item.order.id)
+        expect(progress_message.messageable_type).to eq(order_item.order.class.name)
       end
     end
 


### PR DESCRIPTION
Changed the orders' progress messages to `Order`, instead of `OrderItem`

https://issues.redhat.com/browse/SSP-1955