### PR TITLE
Clear service_parameters_raw after order

### DIFF
--- a/lib/catalog/evaluate_order_process.rb
+++ b/lib/catalog/evaluate_order_process.rb
@@ -22,16 +22,12 @@ module Catalog
 
       relevant_order_processes.each do |order_process|
         if order_process.before_portfolio_item.present?
-          before_item = Api::V1x2::Catalog::AddToOrderViaOrderProcess.new(order_item_params(order_process, before_sequence_number, "before")).process.order_item
-          before_item.send(:service_parameters_raw=, service_parameters(before_item))
-          before_item.save
+          create_itsm_item(order_process, before_sequence_number, 'before')
           before_sequence_number += 1
         end
 
         if order_process.after_portfolio_item.present?
-          after_item = Api::V1x2::Catalog::AddToOrderViaOrderProcess.new(order_item_params(order_process, after_sequence_number, "after")).process.order_item
-          after_item.send(:service_parameters_raw=, service_parameters(after_item))
-          after_item.save
+          create_itsm_item(order_process, after_sequence_number, 'after')
           after_sequence_number -= 1
         end
       end
@@ -42,6 +38,12 @@ module Catalog
     end
 
     private
+
+    def create_itsm_item(order_process, sequence_number, scope)
+      Api::V1x2::Catalog::AddToOrderViaOrderProcess.new(order_item_params(order_process, sequence_number, scope)).process.order_item.tap do |item|
+        item.update(:service_parameters => service_parameters(item))
+      end
+    end
 
     def find_relevant_order_processes
       tag_link_query = TagLink.where(:tag_name => all_tags)

--- a/lib/catalog/order_item_runtime_parameters.rb
+++ b/lib/catalog/order_item_runtime_parameters.rb
@@ -1,0 +1,86 @@
+module Catalog
+  class OrderItemRuntimeParameters
+    attr_reader :runtime_parameters
+
+    ORDER_ITEM_REGEX = /(?<=\{\{after\.|before\.)(.+?)(?=\.artifacts|\.extra_vars|\.status.*\}\})/.freeze
+
+    def initialize(order_item)
+      @order_item = order_item
+    end
+
+    def process
+      @runtime_parameters = compute_runtime_parameters
+      self
+    rescue => e
+      Rails.logger.error("OrderItemRuntimeParameters #{e.message}")
+      raise
+    end
+
+    private
+
+    def compute_runtime_parameters
+      return {} unless @order_item.service_plan_ref
+
+      params = service_parameters_raw.slice(*fields.collect { |field| field[:name] })
+      params.collect { |key, value| [key, compute_value(key, value)] }.to_h
+    end
+
+    def fields
+      @fields ||= ServicePlanFields.new(@order_item).process.fields
+    end
+
+    def service_parameters_raw
+      @order_item.service_parameters_raw || {}
+    end
+
+    def compute_value(key, value)
+      field = fields.find { |f| f[:name] == key }
+      return value unless field[:isSubstitution]
+
+      str_val = substitute(value)
+      if str_val.blank?
+        Rails.logger.warn("Substitution result for expression #{value} is blank")
+        @order_item.update_message("warn", "Parameter #{key} results an empty value after substitution")
+      end
+
+      begin
+        convert_type(str_val, field[:type])
+      rescue
+        Rails.logger.error("Failed to convert #{str_val} to #{field[:type]}. Substitution expression #{value}, worksplace #{workspace}")
+        raise
+      end
+    end
+
+    def substitute(template)
+      template.gsub!(ORDER_ITEM_REGEX) { |order_item_name| encode_name(order_item_name) }
+
+      template.instance_of?(String) ? Mustache.render(template, workspace) : template
+    rescue
+      Rails.logger.error("Failed to substitute #{template} with workspace #{workspace}")
+      raise
+    end
+
+    def convert_type(str, dtype)
+      case dtype
+      when 'integer'
+        Integer(str)
+      when 'float', 'number'
+        Float(str)
+      when 'boolean'
+        raise ArgumentError, "Cannot convert #{str} to boolean" unless str.downcase! == 'true' || str == 'false'
+
+        str == 'true'
+      else
+        str
+      end
+    end
+
+    def encode_name(name)
+      name.each_byte.map { |byte| byte.to_s(16) }.join
+    end
+
+    def workspace
+      @workspace ||= Catalog::WorkspaceBuilder.new(@order_item.order).process.workspace
+    end
+  end
+end

--- a/lib/catalog/order_item_sanitized_parameters.rb
+++ b/lib/catalog/order_item_sanitized_parameters.rb
@@ -1,22 +1,16 @@
-require 'mustache'
-
 module Catalog
   class OrderItemSanitizedParameters
     attr_reader :sanitized_parameters
 
     MASKED_VALUE = "$protected$".freeze
     FILTERED_PARAMS = %w[password token secret].freeze
-    ORDER_ITEM_REGEX = /(?<=\{\{after\.|before\.)(.+?)(?=\.artifacts|\.extra_vars|\.status.*\}\})/.freeze
 
-    def initialize(params)
-      @params = params
-      @order_item = params[:order_item]
+    def initialize(order_item)
+      @order_item = order_item
     end
 
     def process
       @sanitized_parameters = compute_sanitized_parameters
-      update_service_parameters if @params[:do_not_mask_values]
-
       self
     rescue => e
       Rails.logger.error("OrderItemSanitizedParameters #{e.message}")
@@ -25,32 +19,10 @@ module Catalog
 
     private
 
-    def order_item
-      @order_item ||= OrderItem.find(@params[:order_item_id])
-    end
-
-    def service_plan_ref
-      order_item.service_plan_ref
-    end
-
-    def service_parameters_raw
-      order_item.service_parameters_raw || {}
-    end
-
-    def filtered_parameters
-      params = service_parameters_raw.slice(*fields.collect { |field| field[:name] })
-      params.collect { |key, value| [key, sanitize_value(key, value)] }.to_h
-    end
-
     def compute_sanitized_parameters
-      return {} if service_plan_does_not_exist?
-      return filtered_parameters if @params[:do_not_mask_values]
+      return {} unless @order_item.service_plan_ref
 
-      mask_values
-    end
-
-    def mask_values
-      svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters_raw)
+      svc_params = ActiveSupport::HashWithIndifferentAccess.new(Hash(@order_item.service_parameters))
       fields.each_with_object({}) do |field, result|
         value = mask_value?(field) ? MASKED_VALUE : svc_params[field[:name]]
         result[field[:name]] = value
@@ -64,67 +36,7 @@ module Catalog
     end
 
     def fields
-      @fields ||= ServicePlanFields.new(order_item).process.fields
-    end
-
-    def service_plan_does_not_exist?
-      service_plan_ref.nil?
-    end
-
-    def sanitize_value(key, value)
-      field = fields.find { |f| f[:name] == key }
-      return value unless field[:isSubstitution]
-
-      str_val = substitute(value)
-      if str_val.blank?
-        Rails.logger.warn("Substitution result for expression #{value} is blank")
-        order_item.update_message("warn", "Parameter #{key} results an empty value after substitution")
-      end
-
-      begin
-        convert_type(str_val, field[:type]).tap do |new_val|
-          order_item.service_parameters_raw[key] = new_val
-        end
-      rescue
-        Rails.logger.error("Failed to convert #{str_val} to #{field[:type]}. Substitution expression #{value}, worksplace #{workspace}")
-        raise
-      end
-    end
-
-    def substitute(template)
-      template.gsub!(ORDER_ITEM_REGEX) { |order_item_name| encode_name(order_item_name) }
-
-      template.instance_of?(String) ? Mustache.render(template, workspace) : template
-    rescue
-      Rails.logger.error("Failed to substitute #{template} with workspace #{workspace}")
-      raise
-    end
-
-    def convert_type(str, dtype)
-      case dtype
-      when 'integer'
-        Integer(str)
-      when 'float', 'number'
-        Float(str)
-      when 'boolean'
-        raise ArgumentError, "Cannot convert #{str} to boolean" unless str.downcase! == 'true' || str == 'false'
-
-        str == 'true'
-      else
-        str
-      end
-    end
-
-    def encode_name(name)
-      name.each_byte.map { |byte| byte.to_s(16) }.join
-    end
-
-    def workspace
-      @workspace ||= Catalog::WorkspaceBuilder.new(order_item.order).process.workspace
-    end
-
-    def update_service_parameters
-      order_item.update(:service_parameters => mask_values)
+      @fields ||= ServicePlanFields.new(@order_item).process.fields
     end
   end
 end

--- a/lib/catalog/order_state_transition.rb
+++ b/lib/catalog/order_state_transition.rb
@@ -18,6 +18,10 @@ module Catalog
     def determine_order_state
       item_states = @order.order_items.collect(&:state)
 
+      return 'Ordered' unless order_finished?(item_states)
+
+      clear_sensitive_parameters
+
       # TO DO: How to determine order state with pre and post order_processes?
       if item_states.include?('Failed') || item_states.include?('Denied')
         @order.update_message("error", "Order Failed")
@@ -28,9 +32,15 @@ module Catalog
       elsif item_states.include?('Canceled')
         # Message of 'Order Canceled' has been recorded
         'Canceled'
-      else
-        'Ordered'
       end
+    end
+
+    def order_finished?(item_states)
+      item_states.all? { |state| OrderItem::FINISHED_STATES.include?(state) }
+    end
+
+    def clear_sensitive_parameters
+      @order.order_items.each(&:clear_sensitive_service_parameters)
     end
   end
 end

--- a/spec/lib/catalog/evaluate_order_process_spec.rb
+++ b/spec/lib/catalog/evaluate_order_process_spec.rb
@@ -114,14 +114,14 @@ describe Catalog::EvaluateOrderProcess, :type => :service do
           expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(before_params).and_return(add_to_order_via_order_process_before)
 
           subject
-          expect(before_order_item.service_parameters_raw).to eq('param1' => 'val1')
+          expect(before_order_item.service_parameters).to eq('param1' => 'val1')
         end
 
         it "delegates creation of an 'after' order_item with a process sequence of 3" do
           expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(after_params).and_return(add_to_order_via_order_process_after)
 
           subject
-          expect(after_order_item.service_parameters_raw).to eq('param1' => 'val1')
+          expect(after_order_item.service_parameters).to eq('param1' => 'val1')
         end
 
         context "when there is no before portfolio item" do
@@ -153,7 +153,7 @@ describe Catalog::EvaluateOrderProcess, :type => :service do
             expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(after_params).and_return(add_to_order_via_order_process_after)
 
             subject
-            expect(after_order_item.service_parameters_raw).to eq('param1' => 'val1')
+            expect(after_order_item.service_parameters).to eq('param1' => 'val1')
           end
         end
 
@@ -176,7 +176,7 @@ describe Catalog::EvaluateOrderProcess, :type => :service do
             expect(Api::V1x2::Catalog::AddToOrderViaOrderProcess).to receive(:new).with(before_params).and_return(add_to_order_via_order_process_before)
 
             subject
-            expect(before_order_item.service_parameters_raw).to eq('param1' => 'val1')
+            expect(before_order_item.service_parameters).to eq('param1' => 'val1')
           end
         end
       end

--- a/spec/lib/catalog/order_item_runtime_parameters_spec.rb
+++ b/spec/lib/catalog/order_item_runtime_parameters_spec.rb
@@ -1,0 +1,159 @@
+describe Catalog::OrderItemRuntimeParameters, :type => [:service, :topology, :current_forwardable] do
+  let(:subject) { described_class.new(order_item) }
+
+  describe "#process" do
+    let(:service_plan) { create(:service_plan, :base => {:schema => {:fields => fields}}, :modified => nil) }
+    let(:item_name) { "s.t $ ./ \b } 中文{ |" }
+    let(:portfolio_item) { create(:portfolio_item, :name => item_name, :service_plans => [service_plan]) }
+    let(:order_item) do
+      create(
+        :order_item,
+        :name               => item_name,
+        :portfolio_item     => portfolio_item,
+        :service_plan_ref   => service_plan_ref,
+        :artifacts          => artifacts,
+        :service_parameters => {"name" => "{{after.#{item_name}.artifacts.testk}}", "Totally not a pass" => "s3cret"},
+        :process_scope      => 'after'
+      )
+    end
+    let(:artifacts) { {'testk' => 'testv'} }
+    let(:data_type) { 'string' }
+
+    context "when there is a valid service_plan_ref" do
+      around do |example|
+        Insights::API::Common::Request.with_request(default_request) { example.call }
+      end
+
+      let(:service_plan_ref) { "777" }
+      let(:result) { subject.process.runtime_parameters.values }
+      let(:fields) do
+        [{
+          :name         => "Totally not a pass",
+          :type         => "password",
+          :label        => "Totally not a pass",
+          :component    => "text-field",
+          :helperText   => "",
+          :isRequired   => true,
+          :initialValue => ""
+        }, {
+          :name         => "most_important_var1",
+          :label        => "secret field 1",
+          :component    => "textarea-field",
+          :helperText   => "Has no effect on anything, ever.",
+          :initialValue => ""
+        }, {
+          :name         => "token idea",
+          :label        => "field 1",
+          :component    => "textarea-field",
+          :helperText   => "Don't look.",
+          :initialValue => ""
+        }, {
+          :name           => "name",
+          :type           => data_type,
+          :label          => "field 1",
+          :component      => "textarea-field",
+          :helperText     => "That's not my name.",
+          :initialValue   => "{{product.artifacts.testk}}",
+          :isSubstitution => true
+        }]
+      end
+
+      context 'when substitution data type is string' do
+        it 'includes a string in the parameters' do
+          expect(result).to match_array %w[testv s3cret]
+        end
+      end
+
+      context 'when substitution data type is integer' do
+        let(:data_type) { 'integer' }
+
+        context 'when substituted string is a valid integer' do
+          let(:artifacts) { {'testk' => 500} }
+
+          it 'includes an integer in the parameters' do
+            expect(result).to match_array [500, 's3cret']
+          end
+        end
+
+        context 'when substituted string is not a valid integer' do
+          let(:artifacts) { {'testk' => true} }
+
+          it 'raise an error' do
+            expect { result }.to raise_error(ArgumentError)
+          end
+        end
+      end
+
+      context 'when substitution data type is float' do
+        let(:data_type) { 'float' }
+
+        context 'when substituted string is a valid float' do
+          let(:artifacts) { {'testk' => '50.20'} }
+
+          it 'includes a floating number in the parameters' do
+            expect(result).to match_array [50.20, 's3cret']
+          end
+        end
+
+        context 'when substituted string is not a valid float' do
+          let(:artifacts) { {'testk' => 'any'} }
+
+          it 'raise an error' do
+            expect { result }.to raise_error(ArgumentError)
+          end
+        end
+      end
+
+      context 'when substitution data type is boolean' do
+        let(:data_type) { 'boolean' }
+
+        context 'when substituted string is a valid boolean' do
+          let(:artifacts) { {'testk' => 'false'} }
+
+          it 'includes a boolean in the parameters' do
+            expect(result).to match_array [false, 's3cret']
+          end
+        end
+
+        context 'when substituted string is not a valid boolean' do
+          let(:artifacts) { {'testk' => 'any'} }
+
+          it 'raise an error' do
+            expect { result }.to raise_error(ArgumentError)
+          end
+        end
+      end
+
+      context 'when substitution key does not exist' do
+        let(:artifacts) { {} }
+
+        it 'includes an empty string in the parameters' do
+          expect(Rails.logger).to receive(:warn)
+          expect(result).to match_array ['', 's3cret']
+        end
+      end
+
+      context "when service_parameters is nil" do
+        let(:order_item) { create(:order_item, :service_parameters => nil, :portfolio_item => portfolio_item, :service_plan_ref => service_plan_ref) }
+
+        it "returns empty filtered parameters" do
+          expect(subject.process.runtime_parameters).to be_empty
+        end
+      end
+    end
+
+    context "when the service plan ref is 'null'" do
+      let(:service_plan_ref) { nil }
+      let(:fields) { [] }
+
+      it "does not call the api" do
+        subject.process
+        expect(a_request(:any, /topology/)).not_to have_been_made
+      end
+
+      it "returns an empty hash" do
+        expect(subject.process.runtime_parameters).to eq({})
+      end
+    end
+  end
+end

--- a/spec/lib/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/lib/catalog/order_item_sanitized_parameters_spec.rb
@@ -1,27 +1,18 @@
 describe Catalog::OrderItemSanitizedParameters, :type => [:service, :topology, :current_forwardable] do
-  let(:subject) { described_class.new(params) }
-  let(:params) { ActionController::Parameters.new('order_item_id' => order_item.id) }
+  let(:subject) { described_class.new(order_item) }
 
   describe "#process" do
     let(:service_plan) { create(:service_plan, :base => {:schema => {:fields => fields}}, :modified => nil) }
-    let(:item_name) { "s.t $ ./ \b } 中文{ |" }
-    let(:portfolio_item) { create(:portfolio_item, :name => item_name, :service_plans => [service_plan]) }
+    let(:portfolio_item) { create(:portfolio_item, :service_plans => [service_plan]) }
     let(:order_item) do
       create(
         :order_item,
-        :name               => item_name,
         :portfolio_item     => portfolio_item,
         :service_plan_ref   => service_plan_ref,
-        :artifacts          => artifacts,
-        :service_parameters => nil,
+        :service_parameters => {"name" => "joe", "Totally not a pass" => "s3cret"},
         :process_scope      => 'after'
-      ).tap do |item|
-        item.send(:service_parameters_raw=, "name" => "{{after.#{item_name}.artifacts.testk}}", "Totally not a pass" => "s3cret")
-        item.save
-      end
+      )
     end
-    let(:artifacts) { {'testk' => 'testv'} }
-    let(:data_type) { 'string' }
 
     context "when there is a valid service_plan_ref" do
       let(:service_plan_ref) { "777" }
@@ -50,7 +41,6 @@ describe Catalog::OrderItemSanitizedParameters, :type => [:service, :topology, :
             :initialValue => ""
           }, {
             :name           => "name",
-            :type           => data_type,
             :label          => "field 1",
             :component      => "textarea-field",
             :helperText     => "That's not my name.",
@@ -68,7 +58,7 @@ describe Catalog::OrderItemSanitizedParameters, :type => [:service, :topology, :
         end
 
         context "when portfilio_item has no service plans" do
-          let(:portfolio_item) { create(:portfolio_item, :name => item_name) }
+          let(:portfolio_item) { create(:portfolio_item) }
           let(:service_plan_response) do
             TopologicalInventoryApiClient::ServicePlan.new(
               :name               => "Plan A",
@@ -86,102 +76,6 @@ describe Catalog::OrderItemSanitizedParameters, :type => [:service, :topology, :
           it "returns 3 masked values and 1 unmasked" do
             expect(result.count { |v| v == described_class::MASKED_VALUE }).to eq(3)
             expect(result.count { |v| v != described_class::MASKED_VALUE }).to eq(1)
-          end
-        end
-
-        context "when the do_not_mask_values parameter is set" do
-          around do |example|
-            Insights::API::Common::Request.with_request(default_request) { example.call }
-          end
-
-          let(:params) { ActionController::Parameters.new(:order_item => order_item, :do_not_mask_values => true) }
-
-          context 'when substitution data type is string' do
-            it 'includes a string in the parameters' do
-              expect(result).to match_array %w[testv s3cret]
-              order_item.reload
-              expect(order_item.service_parameters).to include('name' => 'testv')
-            end
-          end
-
-          context 'when substitution data type is integer' do
-            let(:data_type) { 'integer' }
-
-            context 'when substituted string is a valid integer' do
-              let(:artifacts) { {'testk' => 500} }
-
-              it 'includes an integer in the parameters' do
-                expect(result).to match_array [500, 's3cret']
-              end
-            end
-
-            context 'when substituted string is not a valid integer' do
-              let(:artifacts) { {'testk' => true} }
-
-              it 'raise an error' do
-                expect { result }.to raise_error(ArgumentError)
-              end
-            end
-          end
-
-          context 'when substitution data type is float' do
-            let(:data_type) { 'float' }
-
-            context 'when substituted string is a valid float' do
-              let(:artifacts) { {'testk' => '50.20'} }
-
-              it 'includes an integer in the parameters' do
-                expect(result).to match_array [50.20, 's3cret']
-              end
-            end
-
-            context 'when substituted string is not a valid float' do
-              let(:artifacts) { {'testk' => 'any'} }
-
-              it 'raise an error' do
-                expect { result }.to raise_error(ArgumentError)
-              end
-            end
-          end
-
-          context 'when substitution data type is boolean' do
-            let(:data_type) { 'boolean' }
-
-            context 'when substituted string is a valid boolean' do
-              let(:artifacts) { {'testk' => 'false'} }
-
-              it 'includes an integer in the parameters' do
-                expect(result).to match_array [false, 's3cret']
-              end
-            end
-
-            context 'when substituted string is not a valid boolean' do
-              let(:artifacts) { {'testk' => 'any'} }
-
-              it 'raise an error' do
-                expect { result }.to raise_error(ArgumentError)
-              end
-            end
-          end
-
-          context 'when substitution key does not exist' do
-            context 'when substituted string is a valid float' do
-              let(:artifacts) { {} }
-
-              it 'includes an integer in the parameters' do
-                expect(Rails.logger).to receive(:warn)
-                expect(result).to match_array ['', 's3cret']
-              end
-            end
-          end
-        end
-
-        context "when raw service parameters is nil" do
-          let(:order_item) { create(:order_item, :portfolio_item => portfolio_item, :service_plan_ref => service_plan_ref) }
-          let(:params) { ActionController::Parameters.new(:order_item => order_item, :do_not_mask_values => true) }
-
-          it "returns empty filtered parameters" do
-            expect(subject.process.sanitized_parameters).to be_empty
           end
         end
       end

--- a/spec/lib/catalog/submit_order_item_spec.rb
+++ b/spec/lib/catalog/submit_order_item_spec.rb
@@ -92,6 +92,21 @@ describe Catalog::SubmitOrderItem, :type => [:service, :topology, :current_forwa
         end
       end
     end
+
+    context "when runtime service_parameters changes due to substitution" do
+      let(:original_parameters) { {'username' => 'oldname'} }
+      let(:order_item_runtime_parameters) { instance_double(Catalog::OrderItemRuntimeParameters, :process => double(:runtime_parameters => service_parameters)) }
+      before do
+        order_item.update(:service_parameters => original_parameters)
+        allow(Catalog::OrderItemRuntimeParameters).to receive(:new).and_return(order_item_runtime_parameters)
+      end
+
+      it "updates service_parameters with the runtime parameters" do
+        expect(order_item.service_parameters).to eq(original_parameters)
+        submit_order.process
+        expect(order_item.service_parameters).to eq(service_parameters)
+      end
+    end
   end
 
   context "when the base service_plan has changed from topology" do


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-1922

A few refactors
* set `OrderItem#service_parameters_raw` only if the service_parameters have protected data
* `OrderItemSanitizedParameters` only detects and protects sensitive data
* new `OrderItemRuntimeParameters` is extracted from `OrderItemSanitizedParameters` and does substitution
* `SubmitOrderItem` saves substituted parameters
* `OrderStateTransition` clears `service_parameters_raw` of all order_items after the order is finished