### PR TITLE
Update codeclimate to use the insights common rubocop file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,9 +2,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+ignore: |
+
+extends: relaxed
+
+rules:
+  line-length:
+    max: 120


### PR DESCRIPTION
@hsong-rh @bzwei This should fix our codeclimate issues, the manageiq-style repository got changed to reference a `code/styles/base.yml` instead of explicitly setting the rules. Of course, this PR will fail because codeclimate will still be looking for it, but our other ones should work after this.

It makes more sense to use this one anyway, since we have more control over when it changes.

/cc @lindgrenj6