### PR TITLE
Switch request context when call topology to apply inventory

### DIFF
--- a/app/services/api/v1x0/catalog/create_request_for_applied_inventories.rb
+++ b/app/services/api/v1x0/catalog/create_request_for_applied_inventories.rb
@@ -10,10 +10,13 @@ module Api
         end
 
         def process
-          validate_surveys
-          send_request_to_compute_applied_inventories
+          # The request was made in submit_order API. Switch to the context of the item which contains the tracking ID.
+          Insights::API::Common::Request.with_request(@item.context.transform_keys(&:to_sym)) do
+            validate_surveys
+            send_request_to_compute_applied_inventories
 
-          @item.update_message(:info, "Waiting for inventories")
+            @item.update_message(:info, "Waiting for inventories")
+          end
           self
         rescue
           @order.update(:state => "Failed")

--- a/lib/catalog/approval_transition.rb
+++ b/lib/catalog/approval_transition.rb
@@ -10,9 +10,7 @@ module Catalog
     end
 
     def process
-      Insights::API::Common::Request.with_request(@order_item.context.transform_keys(&:to_sym)) do
-        state_transitions
-      end
+      state_transitions
       self
     end
 

--- a/spec/requests/api/v1.0/orders_spec.rb
+++ b/spec/requests/api/v1.0/orders_spec.rb
@@ -81,8 +81,12 @@ describe "v1.0 - OrderRequests", :type => [:request, :v1] do
 
     context "when the survey has changed" do
       let(:archived) { false }
-
-      let!(:order_item) { create(:order_item, :order => order) }
+      let(:req) { {:headers => default_headers, :original_url => "localhost/nope"} }
+      let!(:order_item) do
+        Insights::API::Common::Request.with_request(req) do
+          create(:order_item, :order => order)
+        end
+      end
       let!(:service_plan) { create(:service_plan, :portfolio_item => order.order_items.first.portfolio_item) }
 
       before do |example|

--- a/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
+++ b/spec/services/api/v1.0/catalog/create_request_for_applied_inventories_spec.rb
@@ -1,7 +1,12 @@
 describe Api::V1x0::Catalog::CreateRequestForAppliedInventories, :type => :service do
   let(:subject) { described_class.new(order_item.order) }
   let(:service_plan_ref) { "991" }
-  let!(:order_item) { create(:order_item, :portfolio_item => portfolio_item, :service_parameters => "service_parameters", :service_plan_ref => service_plan_ref) }
+  let(:req) { {:headers => default_headers, :original_url => "localhost/nope"} }
+  let!(:order_item) do
+    Insights::API::Common::Request.with_request(req) do
+      create(:order_item, :portfolio_item => portfolio_item, :service_parameters => "service_parameters", :service_plan_ref => service_plan_ref)
+    end
+  end
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => 123) }
 
   around do |example|


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-1958

When the order_item is created the insight-request-id is saved as the tracking id. However apply_inventory is done per submit_order api call under another insight-request-id. Under the same ID before/after oder_item and approval request are created. The original insight-request-id is restored at approval_transition. As a result we see two tracking IDs in the same order.

The fix is to switch the context to use the order_item's insight_request_id at apply_inventory. From this point on every external-api call and kafka listener will perform under correct context. No need to restore ID at approval_transition.