### PR TITLE
Wrap Kafka event processing in a database connection session

### DIFF
--- a/spec/lib/kafka_listener_spec.rb
+++ b/spec/lib/kafka_listener_spec.rb
@@ -61,6 +61,11 @@ describe KafkaListener do
         expect(subject).to receive(:process_event).with(event)
         subject.subscribe
       end
+
+      it 'runs in a new db connection checkout from the pool' do
+        expect(ActiveRecord::Base.connection_pool).to receive(:with_connection)
+        subject.subscribe
+      end
     end
   end
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2013

The database connection in a thread is kept in a rails managed pool. Since the Kafka listener thread is a long living thread the connection sometimes can become ill. We now force to checkout a connection when we process an event and check it in after.