### PR TITLE
Change extra_vars to parameters in regex

### DIFF
--- a/lib/catalog/order_item_runtime_parameters.rb
+++ b/lib/catalog/order_item_runtime_parameters.rb
@@ -2,7 +2,7 @@ module Catalog
   class OrderItemRuntimeParameters
     attr_reader :runtime_parameters
 
-    ORDER_ITEM_REGEX = /(?<=\{\{after\.|before\.)(.+?)(?=\.artifacts|\.extra_vars|\.status.*\}\})/.freeze
+    ORDER_ITEM_REGEX = /(?<=\{\{after\.|before\.)(.+?)(?=\.artifacts|\.parameters|\.status.*\}\})/.freeze
 
     def initialize(order_item)
       @order_item = order_item
@@ -51,8 +51,8 @@ module Catalog
       end
     end
 
-    def substitute(template)
-      template.gsub!(ORDER_ITEM_REGEX) { |order_item_name| encode_name(order_item_name) }
+    def substitute(template_raw)
+      template = template_raw.gsub(ORDER_ITEM_REGEX) { |order_item_name| encode_name(order_item_name) }
 
       template.instance_of?(String) ? Mustache.render(template, workspace) : template
     rescue


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2033

We missed a spot in previous work that changed the substitution key from `extra_vars` to `parameters`

Also fixed an issue that encoded name was written back to `service_parameters` because of the in place replacement.