### PR TITLE
Enhance order and items state transitions caused by approval decision

### DIFF
--- a/app/controllers/api/v1x0/mixins/service_offering_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/service_offering_mixin.rb
@@ -14,7 +14,7 @@ module Api
             raise ::Catalog::ServiceOfferingArchived, archived_error_message
           end
         rescue
-          @order.update(:state => "Failed")
+          @order.mark_failed("Failed due to unexpected error in service_offering_check")
           raise
         end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,6 +2,9 @@ class Order < ApplicationRecord
   include OwnerField
   include Discard::Model
   include Api::V1x0::Catalog::DiscardRestore
+
+  FINISHED_STATES = ["Completed", "Failed", "Canceled"].freeze
+
   destroy_dependencies :order_items
   destroy_dependencies :progress_messages
   acts_as_tenant(:tenant)
@@ -21,8 +24,50 @@ class Order < ApplicationRecord
     self.state = "Created"
   end
 
+  def finished?
+    FINISHED_STATES.include?(state)
+  end
+
   def update_message(level, message)
     progress_messages << ProgressMessage.new(:level => level, :message => message, :tenant_id => tenant_id)
     touch
+  end
+
+  def mark_approval_pending(msg = nil)
+    return if state == "Approval Pending"
+
+    mark_item(msg, :state => "Approval Pending")
+  end
+
+  def mark_ordered(msg = nil)
+    return if state == "Ordered"
+
+    mark_item(msg, :order_request_sent_at => Time.now.utc, :state => "Ordered")
+  end
+
+  def mark_failed(msg = nil)
+    return if state == "Failed"
+
+    mark_item(msg, :completed_at => Time.now.utc, :state => "Failed", :level => "error")
+  end
+
+  def mark_completed(msg = nil)
+    return if state == "Completed"
+
+    mark_item(msg, :completed_at => Time.now.utc, :state => "Completed")
+  end
+
+  def mark_canceled(msg = nil)
+    return if state == "Canceled"
+
+    mark_item(msg, :completed_at => Time.now.utc, :state => "Canceled")
+  end
+
+  private
+
+  def mark_item(msg, level: "info", **opts)
+    update!(**opts)
+    update_message(level, msg) if msg
+    Rails.logger.send(level, "Updated Order: #{id} with '#{opts[:state]}' state".tap { |log| log << " message: #{msg}" }) if msg
   end
 end

--- a/app/services/api/v1x0/catalog/create_request_for_applied_inventories.rb
+++ b/app/services/api/v1x0/catalog/create_request_for_applied_inventories.rb
@@ -19,8 +19,7 @@ module Api
           end
           self
         rescue => e
-          @order.update(:state => "Failed")
-          @order.update_message(:error, "Error computing inventories: #{e.message}")
+          @order.mark_failed("Error computing inventories: #{e.message}")
           raise
         end
 

--- a/lib/catalog/submit_next_order_item.rb
+++ b/lib/catalog/submit_next_order_item.rb
@@ -15,13 +15,9 @@ module Catalog
 
       Catalog::SubmitOrderItem.new(order_item).process
 
-      @order.update(:state => 'Ordered', :order_request_sent_at => Time.now.utc) unless @order.state == 'Ordered'
-
+      @order.mark_ordered
       @order.reload
       self
-    rescue => e
-      Rails.logger.error("Error Submitting Order #{@order_id}: #{e.message}")
-      raise
     end
   end
 end

--- a/lib/catalog/submit_order_item.rb
+++ b/lib/catalog/submit_order_item.rb
@@ -19,7 +19,6 @@ module Catalog
       end
       self
     rescue => e
-      Rails.logger.error("Error Submitting Order Item: #{@order_item.id}: #{e.message}")
       @order_item.mark_failed("Error Submitting Order Item: #{e.message}")
     ensure
       order_item.update(:service_parameters => runtime_parameters)

--- a/spec/lib/catalog/create_approval_request_spec.rb
+++ b/spec/lib/catalog/create_approval_request_spec.rb
@@ -66,18 +66,18 @@ describe Catalog::CreateApprovalRequest, :type => :service do
 
       it "raises an error and does not create an approval request" do
         expect(ApprovalRequest.count).to eq(0)
-        expect { subject.process }.to raise_exception(Catalog::ApprovalError)
+        subject.process
         expect(ApprovalRequest.count).to eq(0)
       end
 
       it "creates a progress message" do
-        expect { subject.process }.to raise_exception(Catalog::ApprovalError)
-        expect(ProgressMessage.first.message).to eq("Error while creating approval request")
+        subject.process
+        expect(ProgressMessage.first.message).to match(/Error while creating approval request/)
         expect(ProgressMessage.last.message).to eq("Order Failed")
       end
 
       it "fails the order" do
-        expect { subject.process }.to raise_exception(Catalog::ApprovalError)
+        subject.process
         order.reload
         expect(order.state).to eq("Failed")
       end

--- a/spec/lib/catalog/determine_task_relevancy_spec.rb
+++ b/spec/lib/catalog/determine_task_relevancy_spec.rb
@@ -85,6 +85,7 @@ describe Catalog::DetermineTaskRelevancy, :type => :service do
             it "fails the order, log errors, and adds a progress message" do
               expect(Rails.logger).to receive(:error).with("Incoming task 123 is completed but errored: #{payload_context}")
               expect(Rails.logger).to receive(:error).with(/Updated OrderItem: \d+ with 'Failed'/)
+              expect(Rails.logger).to receive(:error).with(/Order Failed/)
               subject.process
               order_item.reload
               expect(order_item.progress_messages.size).to eq(2)

--- a/spec/lib/catalog/order_state_transition_spec.rb
+++ b/spec/lib/catalog/order_state_transition_spec.rb
@@ -6,6 +6,7 @@ describe Catalog::OrderStateTransition do
 
   describe "#process" do
     before do
+      order.update(:state => "Ordered")
       order_item.update(:state => expected_state)
     end
 
@@ -26,21 +27,15 @@ describe Catalog::OrderStateTransition do
     context "when the order item gets updated to denied" do
       let(:expected_state) { "Denied" }
 
-      it "sets the state to Failed" do
+      it "sets the state to Failed if this is the only order item" do
         transition
         expect(order.state).to eq 'Failed'
       end
 
-      it "sets the state to Failed even if only one is denied" do
+      it "sets the state to Failed even if others are completed" do
         order_item2.update(:state => "Completed")
         transition
         expect(order.state).to eq 'Failed'
-      end
-
-      it "sets the state to Ordered if another item is not finished" do
-        order_item2.update(:state => 'Pending')
-        transition
-        expect(order.state).to eq('Ordered')
       end
     end
 
@@ -49,7 +44,19 @@ describe Catalog::OrderStateTransition do
 
       it "sets the state to Failed" do
         transition
-        expect(order.state).to eq 'Failed'
+        expect(order.state).to eq('Failed')
+      end
+
+      it "sets the state to Failed even if other items are completed" do
+        order_item2.update(:state => "Completed")
+        transition
+        expect(order.state).to eq('Failed')
+      end
+
+      it "changes not the order state even if other items are not completed" do
+        order_item2.update(:state => "Ordered")
+        transition
+        expect(order.state).to eq('Ordered')
       end
     end
 
@@ -59,22 +66,29 @@ describe Catalog::OrderStateTransition do
       it "does not transition to completed until all items are completed" do
         order_item2.update(:state => "Created")
         transition
-        expect(order.state).to eq 'Ordered'
+        expect(order.state).to eq('Ordered')
       end
 
-      it "sets the state to Completed" do
+      it "sets the state to Completed if all items are completed" do
         order_item2.update(:state => "Completed")
         transition
-        expect(order.state).to eq 'Completed'
+        expect(order.state).to eq('Completed')
       end
     end
 
     context "when the order item gets updated to canceled" do
       let(:expected_state) { "Canceled" }
 
-      it "sets the state to Canceled" do
+      it "sets the state to Canceled if all items are finished" do
+        order_item2.update(:state => "Completed")
         transition
-        expect(order.state).to eq 'Canceled'
+        expect(order.state).to eq('Canceled')
+      end
+
+      it "does not transition the state if other items are not finished" do
+        order_item2.update(:state => "Created")
+        transition
+        expect(order.state).to eq("Ordered")
       end
     end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -58,4 +58,48 @@ describe Order do
       expect(last_message.tenant_id).to eq(order1.tenant.id)
     end
   end
+
+  describe "#mark_completed" do
+    it "marks the order as completed" do
+      order1.mark_completed("Cool")
+      expect(order1.state).to eq("Completed")
+      expect(order1.completed_at).to be_truthy
+      expect(order1.progress_messages.last.message).to match(/Cool/)
+    end
+  end
+
+  describe "#mark_failed" do
+    it "marks the order as failed" do
+      order1.mark_failed("Too bad")
+      expect(order1.state).to eq("Failed")
+      expect(order1.completed_at).to be_truthy
+      expect(order1.progress_messages.last.message).to match(/Too bad/)
+    end
+  end
+
+  describe "#mark_canceled" do
+    it "marks the order as failed" do
+      order1.mark_canceled
+      expect(order1.state).to eq("Canceled")
+      expect(order1.completed_at).to be_truthy
+      expect(order1.progress_messages).to be_empty
+    end
+  end
+
+  describe "#mark_ordered" do
+    it "marks the order as failed" do
+      order1.mark_ordered
+      expect(order1.state).to eq("Ordered")
+      expect(order1.order_request_sent_at).to be_truthy
+      expect(order1.progress_messages).to be_empty
+    end
+  end
+
+  describe "#mark_approval_pending" do
+    it "marks the order as failed" do
+      order1.mark_approval_pending
+      expect(order1.state).to eq("Approval Pending")
+      expect(order1.progress_messages).to be_empty
+    end
+  end
 end

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -167,12 +167,11 @@ describe Portfolio do
       end
 
       context 'ancillary_metadata instance was destroyed' do
-        before { subject.destroy }
-
         it 'returns without updating ancillary_metadata' do
           expect(subject.ancillary_metadata).not_to receive(:save!)
 
-          portfolio.update_metadata
+          subject.ancillary_metadata.destroy
+          subject.update_metadata
         end
       end
     end

--- a/spec/requests/api/v1.0/orders_spec.rb
+++ b/spec/requests/api/v1.0/orders_spec.rb
@@ -60,7 +60,7 @@ describe "v1.0 - OrderRequests", :type => [:request, :v1] do
       it_behaves_like "action that tests authorization", :submit_order?, Order
 
       it "logs the error", :subject_inside do
-        expect(Rails.logger).to receive(:error).with(/Service offering for order #{order.id} has been archived/).twice
+        expect(Rails.logger).to receive(:error).with(/Service offering for order #{order.id} has been archived/)
 
         subject
       end


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2045

Refactor how to do state transition when the approval request finishes.
Upon approval: order item is Approved, pre/post remain Created. order state is Ordered
Upon denied: order item is Denied, pre/post are Canceled. order state is Failed
Upon cancel: all items are Canceled. order is Canceled
Upon error: order item is Failed, pre/post are Canceled. order is Failed.