### PR TITLE
replace before_destory callback with before_discard

### DIFF
--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -17,7 +17,7 @@ class PortfolioItem < ApplicationRecord
   after_discard   :update_portfolio_stats
   after_undiscard :update_portfolio_stats
   after_destroy   :update_portfolio_stats
-  before_destroy  :validate_deletable, :prepend => true
+  before_discard  :validate_deletable, :prepend => true
 
   belongs_to :icon, :optional => true
   has_many :service_plans, :dependent => :destroy

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -73,7 +73,7 @@ describe PortfolioItem do
     it "runs validate_deletable callback" do
       expect(subject).to receive(:validate_deletable)
 
-      subject.run_callbacks 'destroy'
+      subject.run_callbacks 'discard'
     end
   end
 


### PR DESCRIPTION
Correct to use `before_discard` callback to protect `product` from deletion.

https://issues.redhat.com/browse/SSP-2052