### PR TITLE
Use custom error messages for various policy methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 
 gem 'dhasher'
 gem 'discard', :git => 'https://github.com/jhawthorn/discard', :branch => 'master'
-gem 'insights-api-common', '~> 4.0'
+gem 'insights-api-common', '~> 5.0'
 gem 'jbuilder', '~> 2.0'
 gem 'manageiq-loggers', '~> 0.2'
 gem 'manageiq-messaging', '~> 1.0'

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -32,7 +32,7 @@ class ApplicationPolicy
 
   def user_capabilities
     capabilities = {}
-    (self.class.instance_methods(false) - [:user_capabilities, :index?]).each do |method|
+    (self.class.instance_methods(false) - [:user_capabilities, :index?, :error_message]).each do |method|
       capabilities[method.to_s.delete_suffix('?')] = self.send(method)
     end
 

--- a/app/policies/portfolio_item_policy.rb
+++ b/app/policies/portfolio_item_policy.rb
@@ -1,21 +1,27 @@
 class PortfolioItemPolicy < ApplicationPolicy
+  attr_reader :error_message
+
   def index?
     rbac_access.permission_check('read', Portfolio)
   end
 
   def create?
+    build_error_message(__method__)
     update_portfolio_check
   end
 
   def update?
+    build_error_message(__method__)
     update_portfolio_check
   end
 
   def show?
+    build_error_message(__method__)
     rbac_access.resource_check('read', @record.portfolio_id, Portfolio)
   end
 
   def destroy?
+    build_error_message(__callee__)
     update_portfolio_check
   end
 
@@ -33,6 +39,7 @@ class PortfolioItemPolicy < ApplicationPolicy
   end
 
   def edit_survey?
+    build_error_message(__method__)
     update_portfolio_check
   end
 
@@ -51,6 +58,10 @@ class PortfolioItemPolicy < ApplicationPolicy
   end
 
   private
+
+  def build_error_message(action)
+    @error_message = "You are not authorized to perform the #{action.to_s.delete_suffix('?')} action for this portfolio item"
+  end
 
   def can_read_and_update_destination?(destination_id)
     rbac_access.resource_check('read', destination_id, Portfolio) &&

--- a/app/policies/service_plan_policy.rb
+++ b/app/policies/service_plan_policy.rb
@@ -1,15 +1,23 @@
 class ServicePlanPolicy < ApplicationPolicy
+  attr_reader :error_message
+
   def create?
+    build_error_message(__method__)
     rbac_access.resource_check("update", @record.id, Portfolio)
   end
 
   def update_modified?
+    build_error_message(__callee__)
     update_portfolio_check
   end
 
   alias reset? update_modified?
 
   private
+
+  def build_error_message(action)
+    @error_message = "You are not authorized to perform the #{action.to_s.delete_suffix('?')} action for this service plan"
+  end
 
   def portfolio_id
     @record.portfolio_item.portfolio_id

--- a/spec/policies/portfolio_item_policy_spec.rb
+++ b/spec/policies/portfolio_item_policy_spec.rb
@@ -19,6 +19,10 @@ describe PortfolioItemPolicy do
   end
 
   describe "#create?" do
+    before do
+      allow(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
+    end
+
     context "when the record passed into the policy is a portfolio" do
       subject { described_class.new(user_context, portfolio) }
 
@@ -30,6 +34,11 @@ describe PortfolioItemPolicy do
         expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
         expect(subject.create?).to eq(true)
       end
+
+      it "sets the error message to denote the record is a portfolio item" do
+        subject.create?
+        expect(subject.error_message).to eq("You are not authorized to perform the create action for this portfolio item")
+      end
     end
 
     context "when the record passed into the policy is a portfolio item" do
@@ -37,20 +46,43 @@ describe PortfolioItemPolicy do
         expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
         expect(subject.create?).to eq(true)
       end
+
+      it "sets the error message to denote the record is a portfolio item" do
+        subject.create?
+        expect(subject.error_message).to eq("You are not authorized to perform the create action for this portfolio item")
+      end
     end
   end
 
   describe "#update?" do
+    before do
+      allow(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
+    end
+
     it "delegates to the check for update permissions on the portfolio" do
       expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
       expect(subject.update?).to eq(true)
     end
+
+    it "sets the error message to denote the record is a portfolio item" do
+      subject.update?
+      expect(subject.error_message).to eq("You are not authorized to perform the update action for this portfolio item")
+    end
   end
 
   describe "#edit_survey?" do
+    before do
+      allow(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
+    end
+
     it "delegates to the check for update permissions on the portfolio" do
       expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
       expect(subject.edit_survey?).to eq(true)
+    end
+
+    it "sets the error message to denote the record is a portfolio item" do
+      subject.edit_survey?
+      expect(subject.error_message).to eq("You are not authorized to perform the edit_survey action for this portfolio item")
     end
   end
 
@@ -90,17 +122,35 @@ describe PortfolioItemPolicy do
 
   %i[destroy? restore?].each do |method|
     describe "##{method}" do
+      before do
+        allow(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
+      end
+
       it "delegates to the check for update permissions on the portfolio" do
         expect(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)
         expect(subject.send(method)).to eq(true)
+      end
+
+      it "sets the error message to denote the record is a portfolio item" do
+        subject.send(method)
+        expect(subject.error_message).to eq("You are not authorized to perform the #{method.to_s.delete_suffix('?')} action for this portfolio item")
       end
     end
   end
 
   describe "#show?" do
+    before do
+      allow(rbac_access).to receive(:resource_check).with('read', portfolio.id, Portfolio).and_return(true)
+    end
+
     it "delegates to the check for read permissions on the portfolio" do
       expect(rbac_access).to receive(:resource_check).with('read', portfolio.id, Portfolio).and_return(true)
       expect(subject.show?).to eq(true)
+    end
+
+    it "sets the error message to denote the record is a portfolio item" do
+      subject.show?
+      expect(subject.error_message).to eq("You are not authorized to perform the show action for this portfolio item")
     end
   end
 

--- a/spec/policies/service_plan_policy_spec.rb
+++ b/spec/policies/service_plan_policy_spec.rb
@@ -10,6 +10,7 @@ describe ServicePlanPolicy do
 
   before do
     allow(Catalog::RBAC::Access).to receive(:new).with(user_context, service_plan).and_return(rbac_access)
+    allow(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(true)
   end
 
   describe "#create?" do
@@ -23,6 +24,11 @@ describe ServicePlanPolicy do
       expect(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(true)
       expect(subject.create?).to eq(true)
     end
+
+    it "sets the error message to denote the record is a service plan" do
+      subject.create?
+      expect(subject.error_message).to eq("You are not authorized to perform the create action for this service plan")
+    end
   end
 
   describe "#update_modified?" do
@@ -30,12 +36,22 @@ describe ServicePlanPolicy do
       expect(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(true)
       expect(subject.update_modified?).to eq(true)
     end
+
+    it "sets the error message to denote the record is a service plan" do
+      subject.update_modified?
+      expect(subject.error_message).to eq("You are not authorized to perform the update_modified action for this service plan")
+    end
   end
 
   describe "#reset?" do
     it "delegates to the rbac_access resource check" do
       expect(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(true)
       expect(subject.reset?).to eq(true)
+    end
+
+    it "sets the error message to denote the record is a service plan" do
+      subject.reset?
+      expect(subject.error_message).to eq("You are not authorized to perform the reset action for this service plan")
     end
   end
 end

--- a/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
@@ -54,7 +54,7 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
 
     it "uses a custom message" do
       post "#{api_version}/portfolio_items/#{portfolio_item1.id}/copy", :headers => default_headers
-      expect(first_error_detail).to eq("You are not authorized to copy this portfolio item")
+      expect(first_error_detail).to eq("You are not authorized to perform the copy action for this portfolio item")
     end
   end
 

--- a/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
@@ -51,6 +51,11 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
       post "#{api_version}/portfolio_items/#{portfolio_item1.id}/copy", :headers => default_headers
       expect(response).to have_http_status(403)
     end
+
+    it "uses a custom message" do
+      post "#{api_version}/portfolio_items/#{portfolio_item1.id}/copy", :headers => default_headers
+      expect(first_error_detail).to eq("You are not authorized to copy this portfolio item")
+    end
   end
 
   context "when user has RBAC update portfolios access" do
@@ -67,6 +72,27 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
       post "#{api_version}/portfolio_items/#{portfolio_item1.id}/copy", :headers => default_headers
 
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "when the user does not have create access" do
+    subject do
+      post "#{api_version}/portfolio_items", :params => {:portfolio_id => portfolio.id.to_s}, :headers => default_headers
+    end
+
+    before do
+      allow(rbac_access).to receive(:resource_check).with("update", portfolio.id, Portfolio).and_return(false)
+    end
+
+    it 'returns status code 403' do
+      subject
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "uses a custom message" do
+      subject
+      expect(first_error_detail).to eq("You are not authorized to perform the create action for this portfolio item")
     end
   end
 end

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -138,7 +138,7 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
 
       it "uses a custom message" do
         post "#{api_version}/portfolios", :headers => default_headers, :params => valid_attributes
-        expect(first_error_detail).to eq("You are not authorized to create this portfolio")
+        expect(first_error_detail).to eq("You are not authorized to perform the create action for this portfolio")
       end
     end
   end
@@ -166,7 +166,7 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
 
       it "uses a custom message" do
         patch "#{api_version}/portfolios/#{portfolio1.id}", :headers => default_headers, :params => updated_attributes
-        expect(first_error_detail).to eq("You are not authorized to update this portfolio")
+        expect(first_error_detail).to eq("You are not authorized to perform the update action for this portfolio")
       end
     end
   end


### PR DESCRIPTION
When a policy that checks permissions against a portfolio fails, Pundit sets the `exception.record` to be that of a `Portfolio`, which ends up generating odd error messages because the user is trying to create/read/update/whatever a "portfolio_item" or a "service_plan", but the error message says "you can't do X on this Portfolio".

This change allows us to set custom error messages based on the action, with a very small change from the insights-api-common side.

insights-api-common PR: https://github.com/RedHatInsights/insights-api-common-rails/pull/214
JIRA Story: https://issues.redhat.com/browse/SSP-1977

Do note, there is one spec that I purposely changed to ensure we're using the newer api-common, but until it gets merged/updated, specs will be broken on this. We could in theory merge this first without affecting anything, since all this does is set some instance variables, so if for some reason we want to do that, I can change the broken spec, but then we will need to update the spec once the api-common repo gets updated anyway.

@lindgrenj6 Tagging you since this is heavily related to the api-common PR.
@hsong-rh Please Review
