### PR TITLE
Add :: to Insights::API::Common::RBAC::Access

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -3,7 +3,7 @@ module Api
     module Mixins
       module IndexMixin
         def scoped(relation, pre_authorized)
-          relation = rbac_scope(relation, :pre_authorized => pre_authorized) if Insights::API::Common::RBAC::Access.enabled?
+          relation = rbac_scope(relation, :pre_authorized => pre_authorized) if ::Insights::API::Common::RBAC::Access.enabled?
           if relation.model.respond_to?(:taggable?) && relation.model.taggable?
             ref_schema = {relation.model.tagging_relation_name => :tag}
 


### PR DESCRIPTION
Some constant loading error happened when pod is started:

/usr/share/gems/gems/activesupport-5.2.4.4/lib/active_support/dependencies.rb:456: warning: already initialized constant Insights::API::Common::RBAC
/usr/share/gems/gems/activesupport-5.2.4.4/lib/active_support/dependencies.rb:456: warning: previous definition of RBAC was here
{"@timestamp":"2021-01-27T20:49:58.895936 ","hostname":"catalog-api-378-pm68k","pid":38,"tid":"2aba4a462e48","level":"info","message":"Completed 500 Internal Server Error in 297ms (ActiveRecord: 82.0ms)"}
{"@timestamp":"2021-01-27T20:49:58.896606 ","hostname":"catalog-api-378-pm68k","pid":38,"tid":"2aba4a462e48","level":"crit","message":"  "}
{"@timestamp":"2021-01-27T20:49:58.896792 ","hostname":"catalog-api-378-pm68k","pid":38,"tid":"2aba4a462e48","level":"crit","message":"LoadError (Unable to autoload constant Insights::API::Common::RBAC::Access, expected /usr/share/gems/gems/insights-api-common-5.0.1/lib/insights/api/common/rbac/access.rb to define it):"}
{"@timestamp":"2021-01-27T20:49:58.896852 ","hostname":"catalog-api-378-pm68k","pid":38,"tid":"2aba4a462e48","level":"crit","message":"  "}
{"@timestamp":"2021-01-27T20:49:58.896890 ","hostname":"catalog-api-378-pm68k","pid":38,"tid":"2aba4a462e48","level":"crit","message":"app/controllers/api/v1x0/mixins/index_mixin.rb:6:in `scoped'