### PR TITLE
Change deletion check on product

### DIFF
--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -31,7 +31,9 @@ class PortfolioItem < ApplicationRecord
   end
 
   def validate_deletable
-    unless deletable?
+    order_process_ids = OrderProcess.where(:before_portfolio_item_id => id).or(OrderProcess.where(:after_portfolio_item_id => id)).pluck(:id)
+
+    unless order_process_ids.empty?
       errors.add(:base, "cannot be deleted because it is used by order processes #{order_process_ids.uniq}")
       throw :abort
     end
@@ -47,14 +49,5 @@ class PortfolioItem < ApplicationRecord
     {
       'approval_processes' => tags.where(:namespace => 'approval', :name => 'workflows').count
     }
-  end
-
-  def deletable?
-    order_process_ids.empty?
-  end
-
-  def order_process_ids
-    OrderProcess.where(:before_portfolio_item_id => id).pluck(:id) +
-      OrderProcess.where(:after_portfolio_item_id => id).pluck(:id)
   end
 end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -31,10 +31,10 @@ class PortfolioItem < ApplicationRecord
   end
 
   def validate_deletable
-    order_process_ids = OrderProcess.where(:before_portfolio_item_id => id).or(OrderProcess.where(:after_portfolio_item_id => id)).pluck(:id)
+    order_process_names = OrderProcess.where(:before_portfolio_item_id => id).or(OrderProcess.where(:after_portfolio_item_id => id)).pluck(:name)
 
-    unless order_process_ids.empty?
-      errors.add(:base, "cannot be deleted because it is used by order processes #{order_process_ids.uniq}")
+    unless order_process_names.empty?
+      errors.add(:base, "cannot be deleted because it is used by order processes #{order_process_names.uniq}")
       throw :abort
     end
   end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -32,7 +32,7 @@ class PortfolioItem < ApplicationRecord
 
   def validate_deletable
     unless deletable?
-      errors.add(:base, "cannot be deleted because it is used by some order processes")
+      errors.add(:base, "cannot be deleted because it is used by order processes #{order_process_ids.uniq}")
       throw :abort
     end
   end
@@ -50,6 +50,11 @@ class PortfolioItem < ApplicationRecord
   end
 
   def deletable?
-    tags.where(:name => 'order_processes').count == 0
+    order_process_ids.empty?
+  end
+
+  def order_process_ids
+    OrderProcess.where(:before_portfolio_item_id => id).pluck(:id) +
+      OrderProcess.where(:after_portfolio_item_id => id).pluck(:id)
   end
 end

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -86,12 +86,12 @@ describe PortfolioItem do
     end
 
     context "when is the before/after portfolio item of an order process" do
-      let!(:order_process1) { create(:order_process, :before_portfolio_item_id => subject.id) }
-      let!(:order_process2) { create(:order_process, :after_portfolio_item_id => subject.id) }
+      let!(:order_process1) { create(:order_process, :name => "foo", :before_portfolio_item_id => subject.id) }
+      let!(:order_process2) { create(:order_process, :name => "bar", :after_portfolio_item_id => subject.id) }
 
       it "raises an error" do
         expect { subject.validate_deletable }.to raise_error(UncaughtThrowError, "uncaught throw :abort")
-        expect(subject.errors[:base]).to include("cannot be deleted because it is used by order processes [#{order_process1.id}, #{order_process2.id}]")
+        expect(subject.errors[:base]).to include("cannot be deleted because it is used by order processes #{OrderProcess.pluck(:name)}")
       end
     end
   end

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -85,12 +85,13 @@ describe PortfolioItem do
       expect(subject.validate_deletable).to be_nil
     end
 
-    context "when has associated order processes" do
-      before { subject.tag_add('order_processes', :namespace => 'catalog', :value => '789') }
+    context "when is the before/after portfolio item of an order process" do
+      let!(:order_process1) { create(:order_process, :before_portfolio_item_id => subject.id) }
+      let!(:order_process2) { create(:order_process, :after_portfolio_item_id => subject.id) }
 
       it "raises an error" do
         expect { subject.validate_deletable }.to raise_error(UncaughtThrowError, "uncaught throw :abort")
-        expect(subject.errors[:base]).to include("cannot be deleted because it is used by some order processes")
+        expect(subject.errors[:base]).to include("cannot be deleted because it is used by order processes [#{order_process1.id}, #{order_process2.id}]")
       end
     end
   end


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-1937

This is the fix for above issue. During the product deletion, instead of checking if it has attached order process, we check if it's the before/after portfolio item of an order process.