### PR TITLE
Do not leak uncaught error when submit an order item

### DIFF
--- a/lib/catalog/approval_transition.rb
+++ b/lib/catalog/approval_transition.rb
@@ -34,8 +34,8 @@ module Catalog
 
     def submit_order
       @order_item.update(:state => "Approved")
-      @order_item.order.mark_ordered("Submitting Order for provisioning")
       update_order
+      @order_item.order.mark_ordered("Submitting Order for provisioning")
       Catalog::SubmitNextOrderItem.new(@order_item.order_id).process
     end
 

--- a/lib/catalog/submit_order_item.rb
+++ b/lib/catalog/submit_order_item.rb
@@ -21,7 +21,7 @@ module Catalog
     rescue => e
       @order_item.mark_failed("Error Submitting Order Item: #{e.message}")
     ensure
-      order_item.update(:service_parameters => runtime_parameters)
+      order_item.update(:service_parameters => @runtime_parameters) if @runtime_parameters
     end
 
     private

--- a/spec/lib/catalog/submit_order_item_spec.rb
+++ b/spec/lib/catalog/submit_order_item_spec.rb
@@ -107,6 +107,15 @@ describe Catalog::SubmitOrderItem, :type => [:service, :inventory, :current_forw
         expect(order_item.service_parameters).to eq(service_parameters)
       end
     end
+
+    context "when runtime service_parameters have errors" do
+      before { allow(Catalog::OrderItemRuntimeParameters).to receive(:new).and_raise("bad happened") }
+
+      it "updates the state to fail" do
+        submit_order.process
+        expect(order_item.state).to eq("Failed")
+      end
+    end
   end
 
   context "when the base service_plan has changed from inventory" do


### PR DESCRIPTION
This is not a direct fix to https://issues.redhat.com/browse/SSP-2139 but address a few issues exposed by the report.

When an order item completes it will start the next order item. In the ensure block of `SubmitOrderItem#process` the `runtime_parapters` method raises an uncaught error. This causes the logic to turn the completed order item to failed. This fix now catches such error.

We also adjust the progressive message sequence in `ApprovalTransition#submit_order` so that message "Submitting Order for provisioning" comes after "Approval Request Completed"