### PR TITLE
Add tracking ID to order's progress_messages

### DIFF
--- a/app/services/api/v1x0/catalog/add_to_order.rb
+++ b/app/services/api/v1x0/catalog/add_to_order.rb
@@ -13,6 +13,13 @@ module Api
           @order_item = order.order_items.create!(order_item_params.merge!(:service_plan_ref => service_plan_ref))
           @order_item.update_message("info", "Order item tracking ID (x-rh-insights-request-id): #{@order_item.insights_request_id}")
 
+          # In the earlier design tracking (insights-request-id) is only available in order item since an order can have multiple
+          # order_items. In reality an order has only one product order_item that is created upon user's request. Other itsm order_items
+          # are auto-created. It makes sense to use the product's tracking ID for the order.
+          if order.order_items.size == 1 # the first order_item added is the product
+            order.update_message("info", "Order tracking ID (x-rh-insights-request-id): #{@order_item.insights_request_id}")
+          end
+
           self
         end
 

--- a/spec/services/api/v1.0/catalog/add_to_order_spec.rb
+++ b/spec/services/api/v1.0/catalog/add_to_order_spec.rb
@@ -60,8 +60,11 @@ describe Api::V1x0::Catalog::AddToOrder, :type => :service do
     end
 
     it "should create a process message with the x-rh-insights-request-id" do
-      progress_message = Insights::API::Common::Request.with_request(request) { subject.order_item.progress_messages.first }
-      expect(progress_message.message).to match('Order item tracking ID (x-rh-insights-request-id): gobbledygook')
+      Insights::API::Common::Request.with_request(request) do
+        item = subject.order_item
+        expect(item.progress_messages.first.message).to match('Order item tracking ID (x-rh-insights-request-id): gobbledygook')
+        expect(item.order.progress_messages.first.message).to match('Order tracking ID (x-rh-insights-request-id): gobbledygook')
+      end
     end
   end
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2103

As explained in the code comment, the order itself does not have a tracking id attribute. We can write down the product's tracking number in the order's progress message.

My concern is order returning. It should have a separated tracking ID because it is triggered by a user request at a much later time. This ID is no longer equal to to the order's.