### PR TITLE
Disallow unorderable portfolio item copying

### DIFF
--- a/app/services/api/v1x0/catalog/copy_portfolio.rb
+++ b/app/services/api/v1x0/catalog/copy_portfolio.rb
@@ -36,7 +36,11 @@ module Api
 
         def copy_portfolio_items(portfolio_id)
           @portfolio.portfolio_items.each do |item|
-            Api::V1x0::Catalog::CopyPortfolioItem.new(:portfolio_item_id => item.id, :portfolio_id => portfolio_id).process
+            begin
+              Api::V1x0::Catalog::CopyPortfolioItem.new(:portfolio_item_id => item.id, :portfolio_id => portfolio_id).process
+            rescue ::Catalog::OrderNotOrderable => e
+              Rails.logger.error("Failed to copy Portfolio Item #{item.id}: #{e.message}")
+            end
           end
         end
       end

--- a/app/services/api/v1x0/catalog/copy_portfolio.rb
+++ b/app/services/api/v1x0/catalog/copy_portfolio.rb
@@ -36,11 +36,9 @@ module Api
 
         def copy_portfolio_items(portfolio_id)
           @portfolio.portfolio_items.each do |item|
-            begin
-              Api::V1x0::Catalog::CopyPortfolioItem.new(:portfolio_item_id => item.id, :portfolio_id => portfolio_id).process
-            rescue ::Catalog::OrderNotOrderable => e
-              Rails.logger.error("Failed to copy Portfolio Item #{item.id}: #{e.message}")
-            end
+            Api::V1x0::Catalog::CopyPortfolioItem.new(:portfolio_item_id => item.id, :portfolio_id => portfolio_id).process
+          rescue ::Catalog::OrderNotOrderable => e
+            Rails.logger.error("Failed to copy Portfolio Item #{item.id}: #{e.message}")
           end
         end
       end

--- a/app/services/api/v1x0/catalog/copy_portfolio_item.rb
+++ b/app/services/api/v1x0/catalog/copy_portfolio_item.rb
@@ -18,6 +18,7 @@ module Api
 
         def process
           PortfolioItem.transaction do
+            determine_orderable
             @new_portfolio_item = make_copy
           rescue => e
             Rails.logger.error("Failed to copy Portfolio Item #{@portfolio_item.id}: #{e.message}")
@@ -28,6 +29,11 @@ module Api
         end
 
         private
+
+        def determine_orderable
+          return if Api::V1x1::Catalog::PortfolioItemOrderable.new(@portfolio_item).process.result
+          raise ::Catalog::OrderNotOrderable, "#{@portfolio_item.name} is not orderable, and cannot be copied"
+        end
 
         def make_copy
           @portfolio_item.dup.tap do |new_portfolio_item|

--- a/app/services/api/v1x0/catalog/copy_portfolio_item.rb
+++ b/app/services/api/v1x0/catalog/copy_portfolio_item.rb
@@ -32,6 +32,7 @@ module Api
 
         def determine_orderable
           return if Api::V1x1::Catalog::PortfolioItemOrderable.new(@portfolio_item).process.result
+
           raise ::Catalog::OrderNotOrderable, "#{@portfolio_item.name} is not orderable, and cannot be copied"
         end
 

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -4,6 +4,7 @@ module Catalog
   class InvalidParameter < StandardError; end
   class InvalidSurvey < StandardError; end
   class NotAuthorized < StandardError; end
+  class OrderNotOrderable < StandardError; end
   class OrderUncancelable < StandardError; end
   class RBACError < StandardError; end
   class ServiceOfferingArchived < StandardError; end

--- a/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_rbac_spec.rb
@@ -59,10 +59,13 @@ describe "v1.0 - Portfolio Items RBAC API", :type => [:request, :v1] do
   end
 
   context "when user has RBAC update portfolios access" do
+    let(:portfolio_item_orderable) { instance_double(Api::V1x1::Catalog::PortfolioItemOrderable, :result => true) }
     let(:portfolio_access_obj) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true) }
     let(:rbac_access) { instance_double(Catalog::RBAC::Access) }
 
     before do
+      allow(Api::V1x1::Catalog::PortfolioItemOrderable).to receive(:new).and_return(portfolio_item_orderable)
+      allow(portfolio_item_orderable).to receive(:process).and_return(portfolio_item_orderable)
       allow(Catalog::RBAC::Access).to receive(:new).and_return(rbac_access)
       allow(rbac_access).to receive(:resource_check).with('read', portfolio.id, Portfolio).and_return(true)
       allow(rbac_access).to receive(:resource_check).with('update', portfolio.id, Portfolio).and_return(true)

--- a/spec/requests/api/v1.0/portfolio_items_spec.rb
+++ b/spec/requests/api/v1.0/portfolio_items_spec.rb
@@ -348,11 +348,15 @@ describe "v1.0 - PortfolioItemRequests", :type => [:request, :inventory, :v1] do
   end
 
   describe "copying portfolio items" do
+    let(:portfolio_item_orderable) { instance_double(Api::V1x1::Catalog::PortfolioItemOrderable, :result => true) }
+
     subject do
       post "#{api_version}/portfolio_items/#{portfolio_item.id}/copy", :params => params, :headers => default_headers
     end
 
     before do |example|
+      allow(Api::V1x1::Catalog::PortfolioItemOrderable).to receive(:new).and_return(portfolio_item_orderable)
+      allow(portfolio_item_orderable).to receive(:process).and_return(portfolio_item_orderable)
       subject unless example.metadata[:subject_inside]
     end
 

--- a/spec/requests/api/v1.0/portfolios_spec.rb
+++ b/spec/requests/api/v1.0/portfolios_spec.rb
@@ -352,7 +352,11 @@ describe "v1.0 - Portfolios API", :type => [:request, :v1] do
     end
 
     context "copy without specifying name" do
+      let(:portfolio_item_orderable) { instance_double(Api::V1x1::Catalog::PortfolioItemOrderable, :result => true) }
+
       before do
+        allow(Api::V1x1::Catalog::PortfolioItemOrderable).to receive(:new).and_return(portfolio_item_orderable)
+        allow(portfolio_item_orderable).to receive(:process).and_return(portfolio_item_orderable)
         post "#{api_version}/portfolios/#{portfolio.id}/copy", :headers => default_headers
       end
 

--- a/spec/requests/api/v1.1/portfolios_controller_spec.rb
+++ b/spec/requests/api/v1.1/portfolios_controller_spec.rb
@@ -179,7 +179,11 @@ describe "v1.1 - PortfoliosRequests", :type => [:request, :v1x1] do
   end
 
   describe "POST /portfolios/:portfolio_id/copy #copy" do
+    let(:portfolio_item_orderable) { instance_double(Api::V1x1::Catalog::PortfolioItemOrderable, :result => true) }
+
     before do
+      allow(Api::V1x1::Catalog::PortfolioItemOrderable).to receive(:new).and_return(portfolio_item_orderable)
+      allow(portfolio_item_orderable).to receive(:process).and_return(portfolio_item_orderable)
       post "#{api_version}/portfolios/#{portfolio.id}/copy", :headers => default_headers
     end
 

--- a/spec/services/api/v1.0/catalog/copy_portfolio_spec.rb
+++ b/spec/services/api/v1.0/catalog/copy_portfolio_spec.rb
@@ -2,11 +2,17 @@ describe Api::V1x0::Catalog::CopyPortfolio, :type => :service do
   let(:portfolio) { create(:portfolio, :icon => create(:icon)) }
   let!(:portfolio_item1) { create(:portfolio_item, :portfolio => portfolio) }
   let!(:portfolio_item2) { create(:portfolio_item, :portfolio => portfolio) }
+  let(:portfolio_item_orderable) { instance_double(Api::V1x1::Catalog::PortfolioItemOrderable, :result => true) }
 
   let(:copy_portfolio) { described_class.new(:portfolio_id => portfolio.id).process }
 
   describe "#process" do
     let(:new_portfolio) { copy_portfolio.new_portfolio }
+
+    before do
+      allow(Api::V1x1::Catalog::PortfolioItemOrderable).to receive(:new).and_return(portfolio_item_orderable)
+      allow(portfolio_item_orderable).to receive(:process).and_return(portfolio_item_orderable)
+    end
 
     context "when there isn't a conflicting name" do
       it "copies the portfolio over" do


### PR DESCRIPTION
The 'orderable' metadata is calculated at the time the `#show` API call is requested, and we were not checking if a portfolio item was orderable or not before attempting to copy it.

However, when copying a portfolio, since we then iterate over the portfolio items to copy them, it might not make sense to completely cancel the copy simply if any portfolio item fails to copy, so that is the logic I've used for copying a portfolio.

https://issues.redhat.com/browse/SSP-2056