### PR TITLE
Adjust references of 'master' to 'main'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,6 @@ gem 'sources-api-client', '~> 1.0'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'catalog_inventory-api-client-ruby', :git => 'https://github.com/RedHatInsights/catalog_inventory-api-client-ruby.git', :branch => 'master'
+gem 'catalog_inventory-api-client-ruby', :git => 'https://github.com/RedHatInsights/catalog_inventory-api-client-ruby.git', :branch => 'main'
 
 gem 'insights-approval-api-client', '~> 1.2'

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Build Status](https://api.travis-ci.org/RedHatInsights/catalog-api.svg)](https://travis-ci.org/RedHatInsights/catalog-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a9e6e5c7feb376381c5f/maintainability)](https://codeclimate.com/github/RedHatInsights/catalog-api/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/a9e6e5c7feb376381c5f/test_coverage)](https://codeclimate.com/github/RedHatInsights/catalog-api/test_coverage)
-[![Security](https://hakiri.io/github/RedHatInsights/catalog-api/master.svg)](https://hakiri.io/github/RedHatInsights/catalog-api/master)
+[![Security](https://hakiri.io/github/RedHatInsights/catalog-api/main.svg)](https://hakiri.io/github/RedHatInsights/catalog-api/main)
 
-[![Build history for master branch](https://buildstats.info/travisci/chart/RedHatInsights/catalog-api?branch=master&includeBuildsFromPullRequest=false&buildCount=50)](https://travis-ci.org/RedHatInsights/catalog-api/branches)
+[![Build history for main branch](https://buildstats.info/travisci/chart/RedHatInsights/catalog-api?branch=main&includeBuildsFromPullRequest=false&buildCount=50)](https://travis-ci.org/RedHatInsights/catalog-api/branches)
 
 ## OpenAPI for Rails 5
 


### PR DESCRIPTION
Only places I could find were in the README and then referencing the catalog inventory api ruby client gem that we control that I've also changed the default branch on.