### PR TITLE
Move sources-api back under dependencies

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -73,7 +73,6 @@ objects:
     - approval
     - catalog-inventory
     - rbac
-    optionalDependencies:
     - sources
 
 parameters:


### PR DESCRIPTION
The original problem is that the name should be `sources-api` rather than `sources`