### PR TITLE
rename the service to catalog-api

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -77,7 +77,7 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: catalog-api-transitional
+    name: catalog-api
     labels:
       app: catalog-api
       pod: catalog-api-v2


### PR DESCRIPTION
 so that 3scale can route to it