### PR TITLE
Use insights-api-common-rails rubocop instead of manageiq-style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
 - .rubocop_local.yml


### PR DESCRIPTION
Not sure why we never changed catalog-api to use the rubocop from insights-api-common-rails like we did with approval-api, but we can now 😄 