### PR TITLE
Seed for org admin per tenant

### DIFF
--- a/app/controllers/api/v1x3.rb
+++ b/app/controllers/api/v1x3.rb
@@ -20,7 +20,6 @@ module Api
     class ServicePlansController              < Api::V1x2::ServicePlansController; end
     class SettingsController                  < Api::V1x2::SettingsController; end
     class TagsController                      < Api::V1x2::TagsController; end
-    class TenantsController                   < Api::V1x2::TenantsController; end
 
     extend_each_subclass Mixins::IndexMixin
   end

--- a/app/controllers/api/v1x3/tenants_controller.rb
+++ b/app/controllers/api/v1x3/tenants_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1x3
+    class TenantsController < Api::V1x2::TenantsController
+      include Mixins::IndexMixin
+      DEFAULT_GROUP_DESC = "System created Catalog & Approval administrator".freeze
+      DEFAULT_ROLES = ["Catalog Administrator", "Approval Administrator"].freeze
+      DEFAULT_GROUP_NAME = "Default Catalog & Approval Administrator".freeze
+
+      def seed
+        tenant = Tenant.scoped_tenants.find(params.require(:tenant_id))
+        account_number = Insights::API::Common::Request.current.identity['identity']['account_number']
+        raise ::Catalog::NotAuthorized if account_number != tenant.external_tenant
+        raise ::Catalog::NotAuthorized unless Insights::API::Common::Request.current.user.org_admin?
+
+        username = Insights::API::Common::Request.current.user.username
+        if RbacSeed.where(:external_tenant => tenant.external_tenant).any?
+          head :no_content
+        else
+          Api::V1x3::Catalog::AddToGroup.new(DEFAULT_GROUP_NAME, DEFAULT_GROUP_DESC, DEFAULT_ROLES, username).process
+          Api::V1x3::Catalog::SeedPortfolios.new.process
+          RbacSeed.create(:external_tenant => tenant.external_tenant)
+          head :created
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v1x3/catalog/add_to_group.rb
+++ b/app/services/api/v1x3/catalog/add_to_group.rb
@@ -1,0 +1,101 @@
+module Api
+  module V1x3
+    module Catalog
+      class AddToGroup
+        attr_reader :result
+
+        def initialize(group_name, group_description, role_names, user_name)
+          @group_name = group_name
+          @group_description = group_description
+          @role_names  = role_names
+          @user_name  = user_name
+          @result = false
+        end
+
+        def process
+          Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+            group_uuid = get_group_uuid(api)
+            if group_uuid.nil?
+              group_uuid = add_group(api)
+            end
+            add_roles_to_group(api, group_uuid)
+            add_principal_to_group(api, group_uuid)
+            @result = true
+            self
+          end
+        end
+
+        private
+
+        def add_group(api)
+          group = RBACApiClient::Group.new(name: @group_name, description: @group_description)
+          result = api.create_group(group)
+          result.uuid
+        rescue RBACApiClient::ApiError => e
+          Rails.logger.error("Exception when calling GroupApi->create_group: #{e.message}")
+          raise "Error adding group #{@group_name}"
+        end
+
+        def add_roles_to_group(api, group_uuid)
+          @role_names.each do |role_name|
+            if !role_exists_in_group?(api, role_name, group_uuid)
+              add_role_to_group(api, role_name, group_uuid)
+            end
+          end
+        end
+
+        def get_role_uuid(role_name)
+          Insights::API::Common::RBAC::Service.call(RBACApiClient::RoleApi) do |api|
+            opts = { name: role_name }
+            result = api.list_roles(opts)
+            result.meta.count == 1 ? result.data.first.uuid : nil
+          end
+        rescue RBACApiClient::ApiError => e
+          Rails.logger.error("Exception when calling RoleApi->list_roles: #{e}")
+          raise "Error getting role uuid for #{role_name}"
+        end
+
+        def get_group_uuid(api)
+          opts = { name: @group_name }
+          result = api.list_groups(opts)
+          result.meta.count == 1 ? result.data.first.uuid : nil 
+        rescue RBACApiClient::ApiError => e
+          Rails.logger.error("Exception when calling GroupApi->list_groups: #{e}")
+          raise "Error getting group uuid for #{@group_name}"
+        end
+
+        def role_exists_in_group?(api, role_name, group_uuid)
+          opts = { role_name: role_name }
+          result = api.list_roles_for_group(group_uuid, opts)
+          return result.meta.count == 1
+        rescue RBACApiClient::ApiError => e
+          Rails.logger.error("Exception when calling GroupApi->list_roles_for_group: #{e}")
+          raise "Error checking if role #{role_name} exists in group #{@group_name}"
+        end
+
+        def add_role_to_group(api, role_name, group_uuid)
+          role_uuid = get_role_uuid(role_name)
+          if role_uuid.nil?
+            raise "Role #{role_name} does not exist"
+          end
+          group_role_in = RBACApiClient::GroupRoleIn.new 
+          group_role_in.roles = [role_uuid]
+          api.add_role_to_group(group_uuid, group_role_in)
+        rescue RBACApiClient::ApiError => e
+          Rails.logger.error("Exception when calling GroupApi->add_role_to_group: #{e}")
+          raise "Error adding role #{role_name} to group #{@group_name}"
+        end
+
+        def add_principal_to_group(api, group_uuid)
+          group_principal_in = RBACApiClient::GroupPrincipalIn.new
+          principal = RBACApiClient::PrincipalIn.new(username: @user_name)
+          group_principal_in.principals = [principal]
+          api.add_principal_to_group(group_uuid, group_principal_in)
+        rescue RBACApiClient::ApiError => e
+          Rails.logger.error("Exception when calling GroupApi->add_principal_to_group: #{e}")
+          raise "Error adding user #{@user_name} to group #{@group_name}"
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v1x3/catalog/seed_portfolios.rb
+++ b/app/services/api/v1x3/catalog/seed_portfolios.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1x3
+    module Catalog
+      class SeedPortfolios
+        DEFAULT_PORTFOLIOS = [
+              {:name => "ITSM", :description => "Default ITSM Portfolio"}
+        ]
+
+        def process
+          DEFAULT_PORTFOLIOS.each do |p|
+            if Portfolio.where(:name => p[:name]).empty?
+              Portfolio.create!(:name => p[:name], :description => p[:description], :owner => Insights::API::Common::Request.current.user.username)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/public/doc/openapi-3-v1.3.json
+++ b/public/doc/openapi-3-v1.3.json
@@ -821,11 +821,11 @@
           }
         ],
         "responses": {
-          "200": {
+          "201": {
             "description": "The tenant was seeded"
           },
           "204": {
-            "description": "No content"
+            "description": "No content, seeding skipped"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"

--- a/spec/requests/api/v1.3/tenant_spec.rb
+++ b/spec/requests/api/v1.3/tenant_spec.rb
@@ -1,0 +1,50 @@
+describe "v1.3 - Seed API", :type => [:request, :v1x3] do
+  let!(:tenant) { create(:tenant) }
+  let!(:tenant_id) { tenant.id }
+  let(:org_admin) do
+    false_hash = default_user_hash
+    false_hash["identity"]["user"]["is_org_admin"] = true
+    false_hash
+  end
+  let(:response_headers) { {"Content-Type" => 'application/json'} }
+  let(:add_to_group) { instance_double(Api::V1x3::Catalog::AddToGroup) } 
+  let(:seed_portfolio) { instance_double(Api::V1x3::Catalog::SeedPortfolios) }
+
+  describe 'POST /tenants/:id/seed' do
+    context "when the group was previously not seeded" do
+
+      before do
+        allow(Api::V1x3::Catalog::SeedPortfolios).to receive(:new).and_return(seed_portfolio)
+        allow(Api::V1x3::Catalog::AddToGroup).to receive(:new).and_return(add_to_group)
+        allow(seed_portfolio).to receive(:process).and_return(seed_portfolio)
+        allow(add_to_group).to receive(:process).and_return(add_to_group)
+      end
+
+      before { post "#{api_version}/tenants/#{tenant_id}/seed", :headers => modified_headers(org_admin) }
+
+      it 'returns status code 201' do
+        expect(response).to have_http_status(201)
+        expect(RbacSeed.where(:external_tenant => tenant.external_tenant).any?).to be_truthy
+      end
+    end
+
+    context "when the group already has been seeded" do
+      before do
+        RbacSeed.create!(:external_tenant => org_admin['identity']['account_number'])
+      end
+      before { post "#{api_version}/tenants/#{tenant_id}/seed", :headers => modified_headers(org_admin) }
+
+      it 'returns status code 204' do
+        expect(response).to have_http_status(204)
+      end
+    end
+
+    context 'when the user is not an org admin' do
+      before { post "#{api_version}/tenants/#{tenant_id}/seed", :headers => default_headers }
+
+      it 'returns status code 403' do
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+end

--- a/spec/services/api/v1.3/catalog/add_to_group_spec.rb
+++ b/spec/services/api/v1.3/catalog/add_to_group_spec.rb
@@ -1,0 +1,89 @@
+describe Api::V1x3::Catalog::AddToGroup, :type => [:service] do
+  include_context "seed_objects"
+  around do |example|
+    Insights::API::Common::Request.with_request(default_request) { example.call }
+  end
+
+  let(:subject) { described_class.new(group_name, group_description, [role_name], user_name) }
+
+  context "group exists" do
+    before do
+      allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::GroupApi).and_yield(group_api)
+      allow(group_api).to receive(:list_groups).with(group_opts).and_return(group_result)
+      allow(group_api).to receive(:list_roles_for_group).with(group_uuid, group_role_opts).and_return(group_role_result)
+      allow(group_api).to receive(:add_principal_to_group).with(group_uuid, group_principal_in).and_return(group_with_principal_roles)
+    end
+
+    it '#process' do
+      expect(subject.process.result).to be_truthy
+    end
+
+    it '#process list_groups error' do
+      allow(group_api).to receive(:list_groups).with(group_opts).and_raise(rbac_error)
+      expect { subject.process }.to raise_exception(RuntimeError, /Error getting group uuid for #{Regexp.quote(group_name)}/)
+    end
+
+    it '#process list_roles_for_group error' do
+      allow(group_api).to receive(:list_roles_for_group).with(group_uuid, group_role_opts).and_raise(rbac_error)
+
+      expect { subject.process }.to raise_exception(RuntimeError, /Error checking if role #{Regexp.quote(role_name)} exists in group #{Regexp.quote(group_name)}/)
+    end
+
+    it '#process add_principal_to_group error' do
+      allow(group_api).to receive(:add_principal_to_group).with(group_uuid, group_principal_in).and_raise(rbac_error)
+
+      expect { subject.process }.to raise_exception(RuntimeError, /Error adding user #{Regexp.quote(user_name)} to group #{Regexp.quote(group_name)}/)
+    end
+  end
+
+  context "group missing" do
+    let(:group_pagination_meta) { RBACApiClient::PaginationMeta.new(count: 0) }
+    let(:group_result) { RBACApiClient::GroupPagination.new(meta: group_pagination_meta, links: nil, data: []) }
+    let(:group) {  RBACApiClient::Group.new(name: group_name, description: group_description) }
+    let(:group_out) { RBACApiClient::GroupOut.new(name: group_name, uuid: group_uuid) }
+    let(:group_role_pagination_meta) { RBACApiClient::PaginationMeta.new(count: 0) }
+    let(:group_role_result) { RBACApiClient::GroupRolesPagination.new(meta: group_role_pagination_meta, links: nil, data: []) }
+    let(:zero_role_pagination_meta) { RBACApiClient::PaginationMeta.new(count: 0) }
+    let(:empty_role_result) { RBACApiClient::RolePaginationDynamic.new(meta: zero_role_pagination_meta, links: nil, data: []) }
+    let(:group_role_in) {  RBACApiClient::GroupRoleIn.new(roles: [role_uuid]) }
+
+    before do
+      allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::GroupApi).and_yield(group_api)
+      allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::RoleApi).and_yield(role_api)
+      allow(group_api).to receive(:list_groups).with(group_opts).and_return(group_result)
+      allow(group_api).to receive(:create_group).with(group).and_return(group_out)
+      allow(group_api).to receive(:list_roles_for_group).with(group_uuid, group_role_opts).and_return(group_role_result)
+      allow(role_api).to receive(:list_roles).with(role_opts).and_return(role_result)
+      allow(group_api).to receive(:add_role_to_group).with(group_uuid, group_role_in).and_return(RBACApiClient::InlineResponse200.new(data: nil))
+      allow(group_api).to receive(:add_principal_to_group).with(group_uuid, group_principal_in).and_return(group_with_principal_roles)
+    end
+
+    it '#process' do
+      expect(subject.process.result).to be_truthy
+    end
+
+    it '#process create_group error' do
+      allow(group_api).to receive(:create_group).with(group).and_raise(rbac_error)
+
+      expect { subject.process }.to raise_exception(RuntimeError, /Error adding group #{Regexp.quote(group_name)}/)
+    end
+
+    it '#process list_roles error' do
+      allow(role_api).to receive(:list_roles).with(role_opts).and_raise(rbac_error)
+
+      expect { subject.process }.to raise_exception(RuntimeError, /Error getting role uuid for #{Regexp.quote(role_name)}/)
+    end
+
+    it '#process list_roles missing' do
+      allow(role_api).to receive(:list_roles).with(role_opts).and_return(empty_role_result)
+
+      expect { subject.process }.to raise_exception(RuntimeError, /Role #{Regexp.quote(role_name)} does not exist/)
+    end
+
+    it '#process add_role_to_group error' do
+      allow(group_api).to receive(:add_role_to_group).with(group_uuid, group_role_in).and_raise(rbac_error)
+
+      expect { subject.process }.to raise_exception(RuntimeError, /Error adding role #{Regexp.quote(role_name)} to group #{Regexp.quote(group_name)}/)
+    end
+  end
+end

--- a/spec/services/api/v1.3/catalog/seed_portfolios_spec.rb
+++ b/spec/services/api/v1.3/catalog/seed_portfolios_spec.rb
@@ -1,0 +1,15 @@
+describe Api::V1x3::Catalog::SeedPortfolios, :type => [:service] do
+  around do |example|
+    Insights::API::Common::Request.with_request(default_request) { example.call }
+  end
+
+  let(:subject) { described_class.new }
+
+  context "process" do
+    it 'with create access' do
+      subject.process
+
+      expect(Portfolio.where(:name => "ITSM").any?).to be_truthy
+    end
+  end
+end

--- a/spec/support/seed_object_shared_context.rb
+++ b/spec/support/seed_object_shared_context.rb
@@ -1,0 +1,28 @@
+RSpec.shared_context "seed_objects" do
+  let(:group_name) { "Crane Operators" }
+  let(:group_description) { "Brontosaurus Experts" }
+  let(:role_name) { "Geological Engineer" }
+  let(:user_name) { "Fred Flintstone" }
+  let(:group_uuid) { "123456-889" }
+  let(:role_uuid) { "5678-900" }
+  let(:number_of_groups) { 1 }
+  let(:number_of_group_roles) { 1 }
+  let(:number_of_roles) { 1 }
+  let(:group_api) { instance_double(RBACApiClient::GroupApi) }
+  let(:role_api) { instance_double(RBACApiClient::RoleApi) }
+  let(:group_list) { [RBACApiClient::GroupOut.new(:name => group_name, :uuid => group_uuid)] }
+  let(:role_list) { [RBACApiClient::RoleOut.new(:name => role_name, :uuid => role_uuid)] }
+  let(:group_opts) { { name: group_name } }
+  let(:group_role_opts) { { role_name: role_name } }
+  let(:role_opts) { { name: role_name } }
+  let(:principal) { RBACApiClient::PrincipalIn.new(username: user_name) }
+  let(:group_principal_in) { RBACApiClient::GroupPrincipalIn.new(principals: [principal]) }
+  let(:group_with_principal_roles) {  RBACApiClient::GroupWithPrincipalsAndRoles.new() }
+  let(:group_pagination_meta) { RBACApiClient::PaginationMeta.new(count: number_of_groups) }
+  let(:group_role_pagination_meta) { RBACApiClient::PaginationMeta.new(count: number_of_group_roles) }
+  let(:role_pagination_meta) { RBACApiClient::PaginationMeta.new(count: number_of_roles) }
+  let(:group_result) { RBACApiClient::GroupPagination.new(meta: group_pagination_meta, links: nil, data: group_list) }
+  let(:group_role_result) { RBACApiClient::GroupRolesPagination.new(meta: group_role_pagination_meta, links: nil, data: role_list) }
+  let(:role_result) { RBACApiClient::RolePaginationDynamic.new(meta: role_pagination_meta, links: nil, data: role_list) }
+  let(:rbac_error) { RBACApiClient::ApiError.new(:message => 'Kaboom') }
+end


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2213

(1) Create an ITSM Portfolio
(2) Create/Update a group called **Default Catalog & Approval Administrator**
(3) If the following 2 roles are missing add them to the group
    * **Catalog Administrator**
    * **Approval Administrator**
(4) Add the current user to the Group
(5) If the seeding was done send back HTTP Status Code 201 (Created) and
create a record in the RbacSeed table for the tenant.
(6) If the seeding was skipped send back HTTP Status Code 204 (No
content)

The seeding is a 3 step process for the UI
 * GET https://<CATALOG_URL>/api/catalog/v1.3/tenants
 * Parse the Tenant ID from the response
 * POST https://<CATALOG_URL>/api/catalog/v1.3/tenants/<<TENANT_ID>>/seed

If the seeding was done you will get back a 201, the caller should
reload RBAC permissions

If the seeding was skipped you will get back a 204, no need to reload
RBAC permissions

If the user is not an org admin you will get back a 403.

<img width="1203" alt="Screen Shot 2021-05-17 at 3 16 32 PM" src="https://user-images.githubusercontent.com/6452699/118546885-94526480-b726-11eb-8a92-fcf85b22d3e6.png">
